### PR TITLE
docs: doc PR convention + CLAUDE.md regeneration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ pipeline/src/pipeline/__pycache__/
 pipeline/tests/__pycache__/
 __pycache__/
 *.pyc
+docs/.dry-run/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,10 @@ commcare-ios/
 
 | Wave | Group | Files | Status |
 |------|-------|-------|--------|
-| 0 | Build setup | — | Done (PR #2) |
-| 1 | javarosa-utilities | 115 | Done (PR #3) |
-| 2 | javarosa-model | 82 | Done (PR #4) |
-| 3 | xpath-engine | 134 | Open (Issue #5) |
+| 0 | Build setup | — | Done (commcare-core PR #2) |
+| 1 | javarosa-utilities | 115 | Done (commcare-core PR #3) |
+| 2 | javarosa-model | 82 | Done (commcare-core PR #4) |
+| 3 | xpath-engine | 134 | Done (Issue #5 closed, commcare-ios PR #13 open) |
 | 4 | xform-parser | 27 | Open (Issue #6) |
 | 5 | case-management | 66 | Open (Issue #7) |
 | 6 | suite-and-session | 93 | Open (Issue #8) |
@@ -50,9 +50,19 @@ After Phase 1: KMP multiplatform targets (Issue #11), then final verification (I
 
 ## Key Docs
 
+**Plans:**
 - **Design**: `docs/plans/2026-03-07-commcare-ios-design.md` — full architecture, phasing, verification strategy
 - **Phase 1 plan**: `docs/plans/2026-03-07-phase1-core-port-plan.md` — wave details, PR strategy, issue closure template
-- **Conversion pitfalls**: `docs/learnings/2026-03-08-kotlin-conversion-pitfalls.md` — 6 recurring issues with fixes
+- **Phase 0 plan**: `docs/plans/2026-03-07-phase0-scaffold-plan.md` — completed infrastructure setup (pipeline, CI, task generator). **Skip unless debugging pipeline issues.**
+- **Degenerify design**: `docs/plans/2026-03-08-abstract-tree-element-degenerify-design.md` — removing AbstractTreeElement type parameter (completed in Wave 2)
+
+**Learnings:**
+- **Conversion pitfalls**: `docs/learnings/2026-03-08-kotlin-conversion-pitfalls.md` — 6 recurring issues with fixes (source for Kotlin Conversion Checklist below)
+- **PR discipline**: `docs/learnings/2026-03-08-pr-discipline.md` — why every deliverable step must be explicit in the plan (source for PR Rules below)
+- **Issue closure discipline**: `docs/learnings/2026-03-08-issue-closure-discipline.md` — why evidence is as important as code (source for Issue Closure Rules below)
+- **CLAUDE.md importance**: `docs/learnings/2026-03-08-claude-md-importance.md` — why CLAUDE.md must exist early and integrate learnings
+- **Degenerify**: `docs/learnings/2026-03-08-abstract-tree-element-degenerify.md` — removing type parameter from AbstractTreeElement, with rationale
+- **Monorepo for agents**: `docs/learnings/2026-03-09-monorepo-for-agentic-development.md` — why all context must be in one directory tree for AI agents
 
 ## Kotlin Conversion Checklist
 
@@ -74,6 +84,13 @@ When converting Java files to Kotlin in commcare-core, check for these **before 
 - **Squash fix commits**: All compilation/interop fixes squashed into one commit per wave
 - **Size**: ~100-150 files max per PR
 - **CI gate**: PR must pass before next wave starts
+
+## Doc PR Rules
+
+- **Doc changes get their own PRs** — changes to CLAUDE.md, `docs/plans/`, and `docs/learnings/` must not be mixed into code PRs
+- **Branch naming**: `docs/<short-description>`
+- **Self-merge after CI**: Doc PRs can be merged by the agent without human review, unless they change architectural decisions
+- **During a wave**: Note learnings in the code PR description, then create a separate doc PR after the code PR merges
 
 ## Issue Closure Rules
 
@@ -124,3 +141,4 @@ git subtree split --prefix=commcare-core -b upstream-ready
 - Follow the Kotlin Conversion Checklist above for every file
 - Follow PR Rules and Issue Closure Rules exactly — AI agents must not skip deliverable steps
 - When in doubt about a technical decision, document it in the PR description
+- Never mix documentation changes into code branches — use separate doc PRs (see Doc PR Rules)

--- a/docs/plans/2026-03-07-phase1-core-port-plan.md
+++ b/docs/plans/2026-03-07-phase1-core-port-plan.md
@@ -189,6 +189,15 @@ git commit -m "port: convert <group-name> to Kotlin (<N> files)"
 
 Create a branch named `kotlin-port/wave-N-<group-name>`, push, and open a PR targeting the previous wave's branch. See **PR Strategy** above for naming, targets, and description template.
 
+**Step 7: Create doc PR for learnings**
+
+After the code PR is merged, create a separate PR for any documentation updates:
+- New learnings discovered during the wave → `docs/learnings/`
+- CLAUDE.md status table updates
+- Phase plan corrections or clarifications
+
+Branch: `docs/wave-N-learnings`, target: `main`. See CLAUDE.md "Doc PR Rules".
+
 ### PR Strategy
 
 Each wave must produce a reviewable PR before the next wave begins.

--- a/docs/plans/2026-03-09-doc-pr-discipline-and-regen-skill.md
+++ b/docs/plans/2026-03-09-doc-pr-discipline-and-regen-skill.md
@@ -1,0 +1,269 @@
+# Doc PR Discipline + Doc Regeneration Skill — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Separate documentation from code PRs, create a lean doc-regeneration skill, and validate it with a dry-run against commcare-ios.
+
+**Architecture:** Three independent-then-sequential tasks: (1) add doc PR convention to CLAUDE.md, (2) create a lean doc-regeneration skill in canopy-skills, (3) run the skill in dry-run mode and review output. Tasks 1 and 2 are independent. Task 3 depends on Task 2.
+
+**Tech Stack:** Markdown, canopy-skills SKILL.md format, `gh` CLI for GitHub data.
+
+---
+
+## Task 1: Add Doc PR Convention to CLAUDE.md and Phase 1 Plan
+
+**Files:**
+- Modify: `CLAUDE.md:68-77` (after PR Rules section)
+- Modify: `CLAUDE.md:120-127` (AI Agent Guidelines section)
+- Modify: `docs/plans/2026-03-07-phase1-core-port-plan.md:126-189` (porting process)
+
+**Step 1: Add "Doc PR Rules" section to CLAUDE.md after "PR Rules"**
+
+Insert after line 77 (after the PR Rules section, before Issue Closure Rules):
+
+```markdown
+## Doc PR Rules
+
+- **Doc changes get their own PRs** — changes to CLAUDE.md, `docs/plans/`, and `docs/learnings/` must not be mixed into code PRs
+- **Branch naming**: `docs/<short-description>`
+- **Self-merge after CI**: Doc PRs can be merged by the agent without human review, unless they change architectural decisions
+- **During a wave**: Note learnings in the code PR description, then create a separate doc PR after the code PR merges
+```
+
+**Step 2: Add guideline to AI Agent Guidelines in CLAUDE.md**
+
+Add a new bullet to the AI Agent Guidelines section (after line 126):
+
+```markdown
+- Never mix documentation changes into code branches — use separate doc PRs (see Doc PR Rules)
+```
+
+**Step 3: Add Step 7 to Porting Process in Phase 1 plan**
+
+In `docs/plans/2026-03-07-phase1-core-port-plan.md`, after "Step 6: Commit and Create PR" (line 183-189), add:
+
+```markdown
+**Step 7: Create doc PR for learnings**
+
+After the code PR is merged, create a separate PR for any documentation updates:
+- New learnings discovered during the wave → `docs/learnings/`
+- CLAUDE.md status table updates
+- Phase plan corrections or clarifications
+
+Branch: `docs/wave-N-learnings`, target: `main`. See CLAUDE.md "Doc PR Rules".
+```
+
+**Step 4: Add `docs/.dry-run/` to .gitignore**
+
+Append to `.gitignore`:
+
+```
+docs/.dry-run/
+```
+
+**Step 5: Verify changes read correctly**
+
+Read CLAUDE.md and confirm:
+- "Doc PR Rules" section appears between "PR Rules" and "Issue Closure Rules"
+- AI Agent Guidelines has the new bullet
+- .gitignore has the dry-run exclusion
+
+**Step 6: Commit**
+
+```bash
+git add CLAUDE.md docs/plans/2026-03-07-phase1-core-port-plan.md .gitignore
+git commit -m "docs: add doc PR convention and dry-run gitignore"
+```
+
+---
+
+## Task 2: Create Lean Doc Regeneration Skill
+
+**Files:**
+- Create: `~/.claude/plugins/marketplaces/canopy-skills/plugins/canopy/skills/doc-regeneration/SKILL.md`
+
+**Step 1: Create the skill directory**
+
+```bash
+mkdir -p ~/.claude/plugins/marketplaces/canopy-skills/plugins/canopy/skills/doc-regeneration
+```
+
+**Step 2: Write SKILL.md**
+
+Create `~/.claude/plugins/marketplaces/canopy-skills/plugins/canopy/skills/doc-regeneration/SKILL.md` with the following content:
+
+```markdown
+---
+name: doc-regeneration
+description: Audit project documentation for staleness and coverage gaps, then regenerate CLAUDE.md and learnings. Use when docs may be out of sync with actual project state.
+version: 0.1.0
+---
+
+# Doc Regeneration — Lean v1
+
+## Purpose
+
+Audit CLAUDE.md and docs/ against the actual project state (GitHub issues, PRs, learnings), then produce a corrected version. The goal is ensuring an AI agent starting a new wave has accurate, complete context — no stale status, no missing learnings, no confusing contradictions.
+
+## Modes
+
+**Dry-run (default):** Generate all output into `docs/.dry-run/`. Nothing is committed or branched. Review the output and decide what to apply.
+
+**Apply:** Create a `docs/regen-YYYY-MM-DD` branch, write the regenerated files, and create a PR.
+
+To select mode, the invoker specifies `--dry-run` or `--apply` when calling the skill. Default is `--dry-run`.
+
+## Process
+
+### Phase 1: Read Everything (no output yet)
+
+Read these inputs. Do NOT produce any output until all inputs are gathered:
+
+1. **CLAUDE.md** — read the full file
+2. **docs/learnings/** — read every file, note each learning's key takeaway
+3. **docs/plans/** — read headers and status sections only (skip large plan bodies like Phase 0's 2000+ lines — just read the first 50 lines for context)
+4. **GitHub issues** — run `gh issue list --state all --limit 50` to get current state
+5. **GitHub PRs** — run `gh pr list --state all --limit 50` to get merged/open PRs
+
+### Phase 2: Analyze (two checks)
+
+**Check 1 — Staleness:**
+Compare CLAUDE.md's status table against GitHub issue states. For each wave:
+- Is the status in CLAUDE.md correct? (Open vs Done, issue number, file count)
+- Does the PR link match?
+- Are any completed waves still marked as Open?
+
+**Check 2 — Coverage:**
+For each learning in `docs/learnings/`:
+- Is the learning's key takeaway reflected somewhere in CLAUDE.md? (Checklist item, guideline, key doc reference, etc.)
+- If not, what section of CLAUDE.md should it be added to?
+
+Also check:
+- Are there patterns from merged PRs or closed issues that should be learnings but aren't?
+- Are any docs/plans referenced in CLAUDE.md that don't exist or are obsolete?
+
+### Phase 3: Produce Output
+
+Generate these files:
+
+**`review-report.md`** — The core deliverable. Contains:
+1. **Staleness findings** — table of what's wrong in the status table, with corrections
+2. **Coverage findings** — table of each learning and whether it's reflected in CLAUDE.md
+3. **Opinionated assessment** — "If I were an agent starting Wave N today, here's what would confuse me and what I'd need." Be specific and direct.
+4. **Recommended changes** — bullet list of what the regenerated CLAUDE.md changes
+
+**`CLAUDE.md`** — The regenerated version. Rules:
+- Preserve the existing structure and section order exactly
+- Update the status table to match GitHub reality
+- Add missing learning references to Key Docs or relevant sections
+- Do NOT add new sections unless a learning explicitly calls for one
+- Do NOT remove or rewrite content that is already correct
+- Mark completed/obsolete plans appropriately in Key Docs
+
+**`learnings/<name>.md`** (only if gaps found) — New learning docs for patterns discovered in PRs/issues that aren't captured yet. Use the existing learning format:
+```
+# Learning: <Title>
+
+**Date**: YYYY-MM-DD
+**Context**: <where this came from>
+**Status**: <Resolved/Active>
+
+## Problem
+<what went wrong or was discovered>
+
+## Root Cause
+<why>
+
+## Fix / Key Takeaway
+<what to do differently>
+```
+
+### Phase 4: Deliver
+
+**If dry-run (default):**
+1. Create `docs/.dry-run/` directory
+2. Write `docs/.dry-run/review-report.md`
+3. Write `docs/.dry-run/CLAUDE.md`
+4. Write any new learnings to `docs/.dry-run/learnings/`
+5. Present the review report to the user
+6. Suggest: "Review `docs/.dry-run/` and compare against current docs. When ready, re-run with `--apply` to create a PR."
+
+**If apply:**
+1. Create branch `docs/regen-YYYY-MM-DD`
+2. Write regenerated CLAUDE.md to repo root
+3. Write any new learnings to `docs/learnings/`
+4. Commit with message `docs: regenerate documentation (staleness + coverage fixes)`
+5. Create PR targeting `main`
+
+## Key Principles
+
+- **Read before write.** Gather ALL inputs before producing ANY output.
+- **Preserve structure.** CLAUDE.md's section order is intentional. Don't reorganize.
+- **Be opinionated.** The assessment should say what would confuse a new agent, not just list facts.
+- **Minimal changes.** Only change what's wrong or missing. Don't rewrite correct content.
+- **Evidence-based.** Every finding must cite the source (issue number, learning filename, PR number).
+```
+
+**Step 3: Verify skill loads**
+
+```bash
+ls -la ~/.claude/plugins/marketplaces/canopy-skills/plugins/canopy/skills/doc-regeneration/SKILL.md
+```
+
+Confirm the file exists and has content.
+
+**Step 4: Commit the skill to canopy-skills**
+
+```bash
+cd ~/.claude/plugins/marketplaces/canopy-skills
+git add plugins/canopy/skills/doc-regeneration/SKILL.md
+git commit -m "feat: add doc-regeneration skill (lean v1)"
+```
+
+---
+
+## Task 3: Run Dry-Run and Review
+
+**Depends on:** Task 2
+
+**Step 1: Invoke the doc-regeneration skill in dry-run mode**
+
+From the commcare-ios repo, invoke the doc-regeneration skill. It will:
+1. Read CLAUDE.md, all learnings, plan headers, GitHub issues, GitHub PRs
+2. Run staleness and coverage checks
+3. Generate output to `docs/.dry-run/`
+
+**Step 2: Review the dry-run output**
+
+Read `docs/.dry-run/review-report.md` and evaluate:
+- Are the staleness findings accurate?
+- Are the coverage findings accurate?
+- Is the opinionated assessment useful — would it actually help a Wave 4 agent?
+
+Read `docs/.dry-run/CLAUDE.md` and compare key sections against current CLAUDE.md:
+- Status table corrections
+- Key Docs additions
+- Any new guidelines
+
+**Step 3: Discuss with user**
+
+Present findings and get feedback before applying.
+
+---
+
+## Execution Order
+
+Tasks 1 and 2 are independent — run in parallel.
+Task 3 depends on Task 2.
+
+```
+┌──────┬─────────────────────────────┬───────────────┬────────────┐
+│ Step │         What                │     Where     │ Depends On │
+├──────┼─────────────────────────────┼───────────────┼────────────┤
+│ 1    │ Doc PR convention           │ commcare-ios  │ —          │
+├──────┼─────────────────────────────┼───────────────┼────────────┤
+│ 2    │ Doc-regen skill (lean v1)   │ canopy-skills │ —          │
+├──────┼─────────────────────────────┼───────────────┼────────────┤
+│ 3    │ Dry-run + review            │ commcare-ios  │ Step 2     │
+└──────┴─────────────────────────────┴───────────────┴────────────┘
+```


### PR DESCRIPTION
## Summary

- Add **Doc PR Rules** section to CLAUDE.md — doc changes must get separate PRs from code, with `docs/<description>` branch naming and self-merge after CI
- Add **Step 7** (create doc PR for learnings) to Phase 1 porting process
- **Fix stale status table**: Wave 3 updated from "Open" to "Done" (Issue #5 is closed, PR #13 open). Clarify Waves 0-2 PRs are on commcare-core repo (pre-monorepo)
- **Expand Key Docs** from 3 entries to 10: all 4 plans and all 6 learnings now referenced, with Phase 0 plan marked "skip unless debugging pipeline"
- Add AI Agent Guideline: "Never mix documentation changes into code branches"
- Add implementation plan for doc-regeneration skill
- Gitignore `docs/.dry-run/` for skill dry-run output

## Context

This PR was produced by a first dry-run of a new doc-regeneration skill that audits CLAUDE.md against GitHub reality (issue states, PR locations) and learning coverage. Key findings:

- Wave 3 status was stale (Issue #5 closed but CLAUDE.md said "Open")
- Only 1 of 6 learnings was referenced in Key Docs
- PRs #2-4 are on jjackson/commcare-core, not commcare-ios (pre-monorepo)
- Wave 2 file count (82) confirmed correct via commcare-core PR #4 title
- 67K Phase 0 plan was unreferenced, risking agent time waste

## Test plan

- [x] CLAUDE.md Doc PR Rules section exists between PR Rules and Issue Closure Rules
- [x] Phase 1 plan has Step 7 for doc PR creation
- [x] Status table matches GitHub issue states
- [x] All 6 learnings referenced in Key Docs
- [x] .gitignore includes docs/.dry-run/

🤖 Generated with [Claude Code](https://claude.com/claude-code)