### PR TITLE
docs: Wave 3 learnings and conversion checklist updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ commcare-ios/
 | 0 | Build setup | — | Done (commcare-core PR #2) |
 | 1 | javarosa-utilities | 115 | Done (commcare-core PR #3) |
 | 2 | javarosa-model | 82 | Done (commcare-core PR #4) |
-| 3 | xpath-engine | 134 | Done (Issue #5 closed, commcare-ios PR #13 open) |
+| 3 | xpath-engine | 134 | Done (PR #13 merged) |
 | 4 | xform-parser | 27 | Open (Issue #6) |
 | 5 | case-management | 66 | Open (Issue #7) |
 | 6 | suite-and-session | 93 | Open (Issue #8) |
@@ -63,6 +63,7 @@ After Phase 1: KMP multiplatform targets (Issue #11), then final verification (I
 - **CLAUDE.md importance**: `docs/learnings/2026-03-08-claude-md-importance.md` — why CLAUDE.md must exist early and integrate learnings
 - **Degenerify**: `docs/learnings/2026-03-08-abstract-tree-element-degenerify.md` — removing type parameter from AbstractTreeElement, with rationale
 - **Monorepo for agents**: `docs/learnings/2026-03-09-monorepo-for-agentic-development.md` — why all context must be in one directory tree for AI agents
+- **Wave 3 XPath learnings**: `docs/learnings/2026-03-09-wave3-xpath-conversion-learnings.md` — KDoc `*/` hazard, abstract preservation, nullable threading, protected→internal
 
 ## Kotlin Conversion Checklist
 
@@ -74,6 +75,10 @@ When converting Java files to Kotlin in commcare-core, check for these **before 
 4. **`open` keyword**: Kotlin classes are `final` by default. Check if the class is subclassed anywhere (including commcare-android, FormPlayer) and mark `open`.
 5. **`@JvmField` / `@JvmStatic`**: Java subclasses accessing `super.field` need `@JvmField`. Java callers of companion methods need `@JvmStatic`.
 6. **Local build first**: Run `./gradlew compileKotlin compileJava` locally before pushing. Run `./gradlew test` for final verification.
+7. **KDoc `*/` hazard**: Grep for `*/` inside `/** ... */` block comments — XPath wildcards like `/data/*/to` prematurely close the comment. Escape as `` `*` ``.
+8. **Preserve `abstract`**: If the Java class is `abstract`, the Kotlin class must be `abstract` too (not `open`). Reflection-based tests depend on this.
+9. **Nullable parameter threading**: Don't add `!!` on nullable params just to call a child method — make the child accept nullable too. Java silently passes null through call chains.
+10. **`protected` → `internal`**: Java `protected` = package + subclass access. Kotlin `protected` = subclass only. Use `internal` for same-package non-subclass callers.
 
 ## PR Rules
 

--- a/docs/learnings/2026-03-09-wave3-xpath-conversion-learnings.md
+++ b/docs/learnings/2026-03-09-wave3-xpath-conversion-learnings.md
@@ -1,0 +1,64 @@
+# Learning: Wave 3 XPath Engine Conversion (134 files)
+
+**Date**: 2026-03-09
+**Context**: Converting `org.javarosa.xpath` (134 files) from Java to Kotlin — Wave 3 of Phase 1
+**Status**: Active — these patterns apply to remaining waves
+
+## New Pitfalls Discovered
+
+### 1. KDoc block comments containing `*/` in XPath patterns
+
+**Problem:** XPath documentation naturally contains patterns like `/data/*/to`. When this appears inside a `/** ... */` KDoc comment, the `*/` in the wildcard path prematurely closes the block comment. Everything after that line becomes unparseable, causing dozens of cascade "unresolved reference" errors in completely unrelated files.
+
+**Root cause in Wave 3:** Line 283 of `XPathPathExpr.kt` had ` * /data/*/to` in a KDoc comment. The `*/` closed the comment, making the rest of the file invalid Kotlin. This produced 22 cascade errors.
+
+**Fix:** Escape wildcards in KDoc: `` /data/`*`/to `` (backtick-escaped). Always grep converted files for `*/` inside block comments before committing.
+
+**Key insight for debugging:** When you see many "unresolved reference" errors for symbols that are clearly defined (e.g., companion object constants), the problem is usually the TARGET class failing to compile, not the calling class. Trace the cascade to find the root compilation error.
+
+### 2. Abstract classes must stay abstract
+
+**Problem:** When converting `abstract class` from Java to Kotlin, if the converter produces `open class` instead, tests that use reflection (e.g., `Modifier.isAbstract()`) or classpath scanning will fail. The class itself works fine at runtime, but test infrastructure that distinguishes abstract from concrete breaks.
+
+**Example:** `XPathFuncExpr` was `abstract` in Java. The converter made it `open class`, and a test that finds "all non-abstract subclasses of XPathFuncExpr" started finding `XPathFuncExpr` itself, failing the test.
+
+**Fix:** Always preserve `abstract` when converting. Check the original Java source if unsure. A class with methods that throw `UnsupportedOperationException("not implemented")` is almost certainly abstract in the original.
+
+### 3. Nullable `model` parameter threading
+
+**Problem:** In Java, `null` passes silently through method chains without crashing until the null is actually dereferenced. In Kotlin, a `model!!` non-null assertion at any point in the chain causes an immediate NPE, even if no method in that particular call path ever uses `model`.
+
+**Example:** `XPathFuncExpr.evalRaw()` receives `model: DataInstance<*>?` from the abstract `XPathExpression.evalRaw()`. It then calls `evalBody(model!!, ...)`, but many XPath functions (like `true()`, `false()`, `random()`, `now()`) never use `model`. In Java, `null` flowed through harmlessly. In Kotlin, `model!!` crashed 64 tests.
+
+**Fix:** When a parameter is nullable in a parent method, keep it nullable through the entire call chain. Don't add `!!` just to satisfy a child method's non-null signature — instead make the child method also accept nullable. Applied across 74 `evalBody` implementations.
+
+### 4. Java `protected` means package-private + subclass access
+
+**Problem:** Java's `protected` allows access from any class in the same package AND from subclasses. Kotlin's `protected` only allows subclass access. When a `protected` Java method is called from another class in the same package (not a subclass), the Kotlin version becomes inaccessible.
+
+**Example:** `XPathStep.matches()` was `protected` in Java. `XPathPathExpr` (same package, not a subclass) called it. After conversion, Kotlin's `protected` blocked the call.
+
+**Fix:** Use `internal` for Java `protected` methods that are called from same-package non-subclass code. This preserves the package-level access semantic.
+
+### 5. Kotlin `Class<*>` maps to Java `Class<?>`, not raw `Class`
+
+**Problem:** When a Kotlin method returns `HashMap<String, Class<*>>`, Java sees it as `HashMap<String, Class<?>>`. Java code using raw `Class` (no type parameter) gets a compilation error.
+
+**Fix:** Update Java test code to use `Class<?>` when calling Kotlin methods that return `Class<*>`.
+
+## Compilation Fix Cycle Efficiency
+
+Wave 3 required 6 CI iterations (262 → 79 → 24 → 22 → 2 → 64 tests → 0 errors). Key efficiency insights:
+
+1. **Cascade errors are misleading**: 22 errors from one KDoc `*/` bug. Always find the root compilation error first.
+2. **Bulk fixes via sed**: When a signature change affects 74 files, use `sed` or `find -exec` instead of editing one-by-one.
+3. **Test failures after compilation passes**: Compilation success doesn't mean tests pass. Kotlin's stricter null checking surfaces runtime NPEs that Java silently ignored.
+
+## Checklist for Future Waves
+
+Before committing converted files:
+- [ ] Grep for `*/` inside `/** ... */` block comments
+- [ ] Verify `abstract` classes remain `abstract`
+- [ ] Check nullable parameter threading (no `!!` on params that could be null)
+- [ ] Check `protected` methods called from same-package non-subclasses → use `internal`
+- [ ] Verify Java test files compile against new Kotlin signatures (Class<?> vs Class)


### PR DESCRIPTION
## Summary

- New learning doc capturing 5 new Kotlin conversion pitfalls discovered during Wave 3 (134 XPath files)
- Updated CLAUDE.md with 4 new checklist items and Wave 3 status

## New checklist items (from Wave 3)
- **#7**: KDoc `*/` hazard — wildcards in comments close the block
- **#8**: Preserve `abstract` — reflection-based tests depend on it
- **#9**: Nullable parameter threading — don't add `!!` on nullable params
- **#10**: `protected` → `internal` — Java package-private semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)