### PR TITLE
docs: J2K vs AI conversion learning + JAVA_HOME fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ After Phase 1: KMP multiplatform targets (Issue #11), then final verification (I
 - **Degenerify**: `docs/learnings/2026-03-08-abstract-tree-element-degenerify.md` — removing type parameter from AbstractTreeElement, with rationale
 - **Monorepo for agents**: `docs/learnings/2026-03-09-monorepo-for-agentic-development.md` — why all context must be in one directory tree for AI agents
 - **Wave 3 XPath learnings**: `docs/learnings/2026-03-09-wave3-xpath-conversion-learnings.md` — KDoc `*/` hazard, abstract preservation, nullable threading, protected→internal
+- **J2K vs AI conversion**: `docs/learnings/2026-03-09-j2k-converter-vs-ai-conversion.md` — why we chose AI-driven conversion over IntelliJ's J2K converter
 
 ## Kotlin Conversion Checklist
 
@@ -111,6 +112,9 @@ Terse closures like "Completed. PR: link" are not acceptable. Evidence is as imp
 ## Build Commands
 
 ```bash
+# JDK is bundled with Android Studio — set JAVA_HOME before Gradle commands:
+export JAVA_HOME="/c/Program Files/Android/Android Studio/jbr"
+
 # From repo root — commcare-core is a subdirectory:
 cd commcare-core
 ./gradlew compileKotlin compileJava    # Quick compilation check

--- a/docs/learnings/2026-03-09-j2k-converter-vs-ai-conversion.md
+++ b/docs/learnings/2026-03-09-j2k-converter-vs-ai-conversion.md
@@ -1,0 +1,73 @@
+# Learning: J2K Converter vs AI-Driven Conversion
+
+**Date**: 2026-03-09
+**Context**: Reviewing Wave 3 conversion approach — agent confirmed all 134 files were converted by AI from scratch, not using IntelliJ's J2K converter. Investigated whether we should switch approaches for remaining waves (4-8, ~285 files).
+**Status**: Resolved (staying with AI conversion, documenting tradeoffs)
+
+## Problem
+
+After Wave 3 completed, we questioned whether hand-converting every Java file via AI was the right approach vs. using IntelliJ's official Java-to-Kotlin (J2K) converter. The concern: are we doing unnecessary work that a tool could automate?
+
+## Investigation
+
+### What IntelliJ's J2K does well
+- Mechanical syntax transformation: getters→properties, `instanceof`→`is`, `switch`→`when`, string concatenation→templates
+- Handles ~80-90% of straightforward syntax changes reliably
+
+### What J2K does NOT handle
+- `@JvmField`, `@JvmStatic`, `@Throws` annotations for Java interop
+- Nullability analysis from Java call-site patterns (our checklist item #1)
+- `open` keyword based on subclass analysis across commcare-android/FormPlayer
+- Generic type fixes (raw types, variance — our checklist items #2, #3)
+- `protected`→`internal` visibility mapping (our checklist item #10)
+- KDoc comment hazards (our checklist item #7)
+
+### J2K is not headless
+The converter is tightly coupled to IntelliJ's IDE internals (PSI, type resolution, symbol indexing). There is no official CLI. It can only be run via Android Studio GUI (Ctrl+Alt+Shift+K) or by building a custom IntelliJ plugin with ApplicationStarter.
+
+### How others handle this at scale
+
+**Meta (40,000+ files, "Kotlinator"):**
+- Built custom headless J2K wrapper embedded in a server-side process
+- Added ~50 preprocessing steps and ~150 postprocessing steps
+- Added build-error-fix loop (parse compiler errors → apply corrections)
+- Collaborated directly with JetBrains to improve J2K
+- Open-sourced AST utilities: https://github.com/fbsamples/kotlin_ast_tools
+- Did NOT open-source the full Kotlinator (too coupled to Buck/internal frameworks)
+
+**Google:**
+- Has a converter tool: https://github.com/google/kotlin_convert
+
+**Pandora:**
+- Built an IntelliJ plugin for bulk conversion with git history preservation
+- https://github.com/PandoraMedia/multi-file-kotlin-converter-plugin
+
+### Our environment
+- Android Studio Narwhal 3 (2025.1.3) installed with JDK 21 (JBR)
+- `JAVA_HOME="/c/Program Files/Android/Android Studio/jbr"` — needed for Gradle
+- No standalone `kotlinc` or `java` on PATH (only via Android Studio)
+- J2K available only through Android Studio GUI
+
+## Decision
+
+**Stay with AI-driven conversion** for remaining waves. Rationale:
+
+1. **The converter alone isn't sufficient.** Meta needed 200+ custom pre/post-processing steps. Everyone doing this at scale wraps J2K in a fix loop — which is what our AI agents already do (Wave 3: 6 iterations, 262→0 errors).
+
+2. **Our hard problems are J2K's blind spots.** Nullability analysis, interop annotations, visibility mapping, and generic fixes are the bulk of our fix iterations. The converter doesn't help with any of these.
+
+3. **Switching mid-project adds risk.** Waves 0-3 are done, learnings are accumulated, checklist is growing. Changing approach for waves 4-8 means re-learning failure modes.
+
+4. **No headless option.** Running J2K requires Android Studio GUI, which doesn't integrate into our autonomous AI pipeline.
+
+### Hybrid approach (future consideration)
+If starting a similar project from scratch, the ideal workflow would be:
+1. J2K for mechanical syntax transformation (via Android Studio GUI or custom plugin)
+2. AI agent for interop annotations, nullability, generics, visibility fixes
+3. Build-error-fix loop (already what our agents do)
+
+This could reduce the number of fix iterations by giving the AI a closer starting point.
+
+## Key Takeaway
+
+J2K handles syntax; AI handles semantics. At our scale (~285 remaining files), the semantic fixes dominate the work. The converter would save some mechanical effort but wouldn't eliminate the fix-iterate loop that accounts for most of the conversion time. For autonomous AI pipelines without IDE access, pure AI conversion is a viable approach — Meta's experience shows that even with J2K, extensive post-processing is required.


### PR DESCRIPTION
## Summary

- New learning doc: investigated IntelliJ J2K converter vs AI-driven conversion for the Kotlin port
- Added `JAVA_HOME` export to Build Commands section — Android Studio's bundled JBR was undocumented
- Added learning reference to Key Docs

## Context

Questioned whether our AI-driven conversion approach was correct vs using IntelliJ's official J2K converter. Research found:
- J2K has no headless CLI — tightly coupled to IntelliJ IDE internals
- Meta converted 40K+ files but needed 200+ custom pre/post-processing steps around J2K
- J2K handles syntax (getters→properties, instanceof→is); AI handles semantics (nullability, interop annotations, generics)
- Decision: stay with AI approach for remaining waves, document tradeoffs for future projects

Also discovered `JAVA_HOME` was missing from Build Commands — agents couldn't run Gradle locally without knowing the Android Studio JBR path.

## Test plan

- [x] Learning doc covers investigation, decision, and key takeaway
- [x] JAVA_HOME path verified working (`./gradlew compileKotlin compileJava` succeeds)
- [x] Key Docs references the new learning

🤖 Generated with [Claude Code](https://claude.com/claude-code)