### PR TITLE
docs: remove stale google/kotlin_convert reference

### DIFF
--- a/docs/learnings/2026-03-09-j2k-converter-vs-ai-conversion.md
+++ b/docs/learnings/2026-03-09-j2k-converter-vs-ai-conversion.md
@@ -35,9 +35,6 @@ The converter is tightly coupled to IntelliJ's IDE internals (PSI, type resoluti
 - Open-sourced AST utilities: https://github.com/fbsamples/kotlin_ast_tools
 - Did NOT open-source the full Kotlinator (too coupled to Buck/internal frameworks)
 
-**Google:**
-- Has a converter tool: https://github.com/google/kotlin_convert
-
 **Pandora:**
 - Built an IntelliJ plugin for bulk conversion with git history preservation
 - https://github.com/PandoraMedia/multi-file-kotlin-converter-plugin


### PR DESCRIPTION
## Summary

- Remove google/kotlin_convert reference from J2K learning doc — unsupported project (22 stars, last commit Dec 2024, no maintenance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)