### PR TITLE
docs: doc-regen dry-run #2 fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ commcare-ios/
 | 7 | resources | 28 | Open (Issue #9) |
 | 8 | commcare-core-services | 71 | Open (Issue #10) |
 
+**Next wave**: Wave 4 — xform-parser (Issue #6, 27 files)
+
 After Phase 1: KMP multiplatform targets (Issue #11), then final verification (Issue #12).
 
 ## Key Docs
@@ -115,13 +117,14 @@ Terse closures like "Completed. PR: link" are not acceptable. Evidence is as imp
 # JDK is bundled with Android Studio — set JAVA_HOME before Gradle commands:
 export JAVA_HOME="/c/Program Files/Android/Android Studio/jbr"
 
-# From repo root — commcare-core is a subdirectory:
+# Build from commcare-core/ (return to repo root for git commands):
 cd commcare-core
 ./gradlew compileKotlin compileJava    # Quick compilation check
 ./gradlew test                          # Full test suite
+cd ..                                   # Back to repo root for git
 
 # Future KMP:
-./gradlew :commcare-core:jvmTest       # KMP JVM tests (once KMP targets added)
+cd commcare-core && ./gradlew :commcare-core:jvmTest  # KMP JVM tests (once KMP targets added)
 
 # CI workflows:
 # - kotlin-tests.yml: runs on PRs touching commcare-core/, gradle files

--- a/docs/plans/2026-03-07-phase1-core-port-plan.md
+++ b/docs/plans/2026-03-07-phase1-core-port-plan.md
@@ -187,7 +187,7 @@ git add -A
 git commit -m "port: convert <group-name> to Kotlin (<N> files)"
 ```
 
-Create a branch named `kotlin-port/wave-N-<group-name>`, push, and open a PR targeting the previous wave's branch. See **PR Strategy** above for naming, targets, and description template.
+Create a branch named `kotlin-port/wave-N-<group-name>`, push, and open a PR targeting `main`. See **PR Strategy** above for naming, targets, and description template.
 
 **Step 7: Create doc PR for learnings**
 


### PR DESCRIPTION
## Summary

Second doc-regeneration dry-run against current main. Found docs are substantially clean (no staleness, full learning coverage). Three minor fixes:

- Fix last stale PR target reference in Phase 1 plan Step 6 ("targeting previous wave's branch" → "targeting main")
- Add "Next wave: Wave 4" pointer to CLAUDE.md status table — saves agent orientation time
- Clarify build commands: explicit `cd ..` back to repo root after Gradle commands

## Test plan

- [x] No stale references to "previous wave branch" in Phase 1 plan
- [x] "Next wave" pointer visible in status section
- [x] Build commands show full cd-in/cd-out pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)