### PR TITLE
docs: Wave 4 learnings and checklist updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,13 +40,11 @@ commcare-ios/
 | 1 | javarosa-utilities | 115 | Done (commcare-core PR #3) |
 | 2 | javarosa-model | 82 | Done (commcare-core PR #4) |
 | 3 | xpath-engine | 134 | Done (PR #13 merged) |
-| 4 | xform-parser | 27 | Open (Issue #6) |
+| 4 | xform-parser | 27 | Done (PR #21) |
 | 5 | case-management | 66 | Open (Issue #7) |
 | 6 | suite-and-session | 93 | Open (Issue #8) |
 | 7 | resources | 28 | Open (Issue #9) |
 | 8 | commcare-core-services | 71 | Open (Issue #10) |
-
-**Next wave**: Wave 4 — xform-parser (Issue #6, 27 files)
 
 After Phase 1: KMP multiplatform targets (Issue #11), then final verification (Issue #12).
 
@@ -66,6 +64,7 @@ After Phase 1: KMP multiplatform targets (Issue #11), then final verification (I
 - **Degenerify**: `docs/learnings/2026-03-08-abstract-tree-element-degenerify.md` — removing type parameter from AbstractTreeElement, with rationale
 - **Monorepo for agents**: `docs/learnings/2026-03-09-monorepo-for-agentic-development.md` — why all context must be in one directory tree for AI agents
 - **Wave 3 XPath learnings**: `docs/learnings/2026-03-09-wave3-xpath-conversion-learnings.md` — KDoc `*/` hazard, abstract preservation, nullable threading, protected→internal
+- **Wave 4 XForm parser learnings**: `docs/learnings/2026-03-09-wave4-xform-parser-learnings.md` — companion method inheritance, `@JvmField` vs `open`, companion `protected` limitation, smart cast on `var`, `const val` auto-inline
 - **J2K vs AI conversion**: `docs/learnings/2026-03-09-j2k-converter-vs-ai-conversion.md` — why we chose AI-driven conversion over IntelliJ's J2K converter
 
 ## Kotlin Conversion Checklist
@@ -82,6 +81,11 @@ When converting Java files to Kotlin in commcare-core, check for these **before 
 8. **Preserve `abstract`**: If the Java class is `abstract`, the Kotlin class must be `abstract` too (not `open`). Reflection-based tests depend on this.
 9. **Nullable parameter threading**: Don't add `!!` on nullable params just to call a child method — make the child accept nullable too. Java silently passes null through call chains.
 10. **`protected` → `internal`**: Java `protected` = package + subclass access. Kotlin `protected` = subclass only. Use `internal` for same-package non-subclass callers.
+11. **Companion method inheritance**: Kotlin companion methods are NOT inherited by subclasses. Call them on the defining class (`DataInstance.unpackReference`), not a subclass (`FormInstance.unpackReference`).
+12. **`@JvmField` vs `open`**: `@JvmField` cannot be used on `open` properties. Drop `open` — subclasses access the inherited field directly.
+13. **Companion `protected`**: Companion object members cannot be `protected`. Use `internal const val` for constants that subclasses need within the same module.
+14. **Smart cast on `var`**: Kotlin won't smart-cast mutable properties after null checks. Capture to a local `val` first: `val el = element; if (el != null) ...`
+15. **`const val` auto-inlines**: `const val` in companion objects compiles to `public static final` in Java bytecode automatically. No `@JvmField` needed for String/Int/Long/Boolean constants.
 
 ## PR Rules
 

--- a/docs/learnings/2026-03-09-wave4-xform-parser-learnings.md
+++ b/docs/learnings/2026-03-09-wave4-xform-parser-learnings.md
@@ -1,0 +1,76 @@
+# Learning: Wave 4 XForm Parser Conversion (27 files)
+
+**Date**: 2026-03-09
+**Context**: Converting `org.javarosa.xform.parse`, `org.javarosa.xform.util`, `org.javarosa.model.xform`, `org.javarosa.form.api` (27 files) from Java to Kotlin — Wave 4 of Phase 1
+**Status**: Active — these patterns apply to remaining waves
+
+## New Pitfalls Discovered
+
+### 1. Kotlin companion object methods don't inherit to subclasses
+
+**Problem:** In Java, `FormInstance.unpackReference(ref)` works even though `unpackReference` is a static method on `DataInstance` (the superclass). Java treats static methods as "inherited" — callers can reference them through any subclass name. In Kotlin, companion object methods belong to the specific class and are NOT accessible through subclass names.
+
+**Example:** `XFormSerializingVisitor` called `FormInstance.unpackReference(ref)`. After `DataInstance` was converted to Kotlin with `unpackReference` in its companion object, calling it via `FormInstance.unpackReference()` stopped compiling.
+
+**Fix:** Always call companion object methods on the class that defines them, not a subclass. Change `FormInstance.unpackReference(ref)` → `DataInstance.unpackReference(ref)`.
+
+**How to detect:** Grep for static method calls on subclass names. If the method is defined in a superclass's companion object, the call will fail.
+
+### 2. `@JvmField` cannot be used on `open` properties
+
+**Problem:** When a protected field needs both `@JvmField` (for Java subclass field access) and `open` (for Kotlin subclass override), they conflict. Kotlin does not allow `@JvmField` on `open` properties because JVM fields can't be overridden.
+
+**Example:** `FormEntryCaption.element` needed `@JvmField` because `DummyFormEntryPrompt` (Java test) does `this.element = q` as direct field access. But `element` also seemed like it should be `open` since `FormEntryPrompt` extends the class.
+
+**Fix:** Drop `open` from the property. `@JvmField` exposes the actual JVM field, which subclasses access directly (both Java and Kotlin). The field doesn't need to be `open` because subclasses access the inherited field, not override it.
+
+### 3. Companion object members cannot be `protected`
+
+**Problem:** Kotlin does not allow `protected` visibility on companion object members. When a Java class has `protected static final` constants accessed by subclasses, the Kotlin companion object equivalent cannot be `protected`.
+
+**Example:** `XFormParserReporter.TYPE_ERROR` was `protected static final String` in Java, accessed by `JSONReporter` (a subclass in `src/translate/`). Kotlin companion objects don't support `protected`.
+
+**Fix:** Use `internal` for constants that need to be visible to same-module subclasses. Since `const val` auto-inlines for Java callers, `internal const val` works for both Kotlin and Java access within the module.
+
+### 4. Smart cast fails on mutable (`var`) properties
+
+**Problem:** Kotlin's smart cast (automatic null check → non-null usage) does not work on `var` properties because another thread could change the value between the null check and usage.
+
+**Example:** `XFormParseException.element` is a `var`. The `message` property getter checked `if (element == null)` then used `element` in the else branch. Kotlin rejected this because `element` could change between check and use.
+
+**Fix:** Capture the mutable property to a local `val` before the null check:
+```kotlin
+val el = element
+return if (el == null) super.message else super.message + XFormParser.getVagueLocation(el)
+```
+
+### 5. `const val` auto-inlines — no `@JvmField` needed for primitives/Strings
+
+**Problem:** Early in the wave, we were adding `@JvmField` to companion object constants unnecessarily. For `String`, `Int`, `Long`, `Boolean`, and other primitive-typed constants, `const val` in a companion object compiles to a Java `public static final` field automatically.
+
+**Fix:** Use `const val` (not `@JvmField val`) for compile-time constants in companion objects. Reserve `@JvmField` for non-const properties (mutable fields, non-primitive types) that Java code accesses as fields.
+
+### 6. Large files (3,000+ lines) need dedicated handling
+
+**Problem:** XFormParser.java (3,049 lines) exceeded AI agent token limits when converting in one pass. The agent ran out of output tokens before it could write the file.
+
+**Fix for AI pipelines:** Treat files over ~1,000 lines as dedicated tasks. Instruct agents to minimize text output and use Write/Edit tools for all file content. If the agent still fails, break the conversion into structural phases (companion object first, then methods, then fix-up pass).
+
+## Pre-Existing Platform-Sensitive Tests
+
+Two test failures discovered during Wave 4 verification that are NOT caused by the conversion:
+
+1. **`DateRangeUtilsTest.testDateConversion`** — Off-by-one day due to timezone-sensitive logic in `DateRangeUtils.java`. Uses `Date.getTimezoneOffset()` which produces incorrect results in UTC-negative timezones. Passes on CI (Ubuntu/UTC), fails locally on Windows (US Central).
+
+2. **`XmlUtilTest.testPrettifyXml`** — Uses `System.lineSeparator()` which returns `\r\n` on Windows but the expected output file has Unix `\n` line endings. Passes on CI (Linux), fails on Windows.
+
+Both are in untouched Java code with no dependency on converted Kotlin files.
+
+## Checklist Additions for Future Waves
+
+Before committing converted files, also check:
+- [ ] Companion object method calls use the defining class, not a subclass
+- [ ] `@JvmField` properties are not also `open`
+- [ ] `protected static` constants become `internal const val` in companion (not `protected`)
+- [ ] Mutable properties used in null checks are captured to local `val` first
+- [ ] `const val` used for primitives/Strings (not `@JvmField val`)


### PR DESCRIPTION
## Summary

- Add Wave 4 learnings doc covering 6 new pitfalls discovered during xform-parser conversion
- Update CLAUDE.md: mark Wave 4 done (PR #21), add 5 new checklist items, link learnings

### New pitfalls documented

1. **Companion method inheritance** — companion methods aren't inherited by subclasses
2. **`@JvmField` vs `open`** — can't combine these on properties
3. **Companion `protected`** — not allowed, use `internal`
4. **Smart cast on `var`** — capture to local `val` first
5. **`const val` auto-inlines** — no `@JvmField` needed for primitives/Strings
6. **Large file handling** — 3,000+ line files need dedicated agent tasks

Also documents 2 pre-existing platform-sensitive test failures (timezone, line endings).

## Test plan

- [x] Doc-only changes, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)