### PR TITLE
docs: Wave 5 learnings and conversion checklist updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ commcare-ios/
 | 2 | javarosa-model | 82 | Done (commcare-core PR #4) |
 | 3 | xpath-engine | 134 | Done (PR #13 merged) |
 | 4 | xform-parser | 27 | Done (PR #21) |
-| 5 | case-management | 66 | Open (Issue #7) |
+| 5 | case-management | 60 | Done (PR #24) |
 | 6 | suite-and-session | 93 | Open (Issue #8) |
 | 7 | resources | 28 | Open (Issue #9) |
 | 8 | commcare-core-services | 71 | Open (Issue #10) |
@@ -66,6 +66,7 @@ After Phase 1: KMP multiplatform targets (Issue #11), then final verification (I
 - **Wave 3 XPath learnings**: `docs/learnings/2026-03-09-wave3-xpath-conversion-learnings.md` — KDoc `*/` hazard, abstract preservation, nullable threading, protected→internal
 - **Wave 4 XForm parser learnings**: `docs/learnings/2026-03-09-wave4-xform-parser-learnings.md` — companion method inheritance, `@JvmField` vs `open`, companion `protected` limitation, smart cast on `var`, `const val` auto-inline
 - **J2K vs AI conversion**: `docs/learnings/2026-03-09-j2k-converter-vs-ai-conversion.md` — why we chose AI-driven conversion over IntelliJ's J2K converter
+- **Wave 5 case-management learnings**: `docs/learnings/2026-03-09-wave5-case-management-learnings.md` — JVM signature clashes (constructor `val` vs interface method, field vs getter), Java boxed types in generics, Kotlin-to-Kotlin method calls
 
 ## Kotlin Conversion Checklist
 
@@ -86,6 +87,10 @@ When converting Java files to Kotlin in commcare-core, check for these **before 
 13. **Companion `protected`**: Companion object members cannot be `protected`. Use `internal const val` for constants that subclasses need within the same module.
 14. **Smart cast on `var`**: Kotlin won't smart-cast mutable properties after null checks. Capture to a local `val` first: `val el = element; if (el != null) ...`
 15. **`const val` auto-inlines**: `const val` in companion objects compiles to `public static final` in Java bytecode automatically. No `@JvmField` needed for String/Int/Long/Boolean constants.
+16. **JVM signature clash: `val` vs `fun`**: A constructor `val foo` generates `getFoo()`, which clashes with `override fun getFoo()` from an interface. Fix: rename the constructor param (e.g., `_foo`) and delegate from the override.
+17. **JVM signature clash: field vs getter**: A `var foo` field generates `getFoo()`, which clashes with an explicit `fun getFoo()`. Fix: rename the backing field to `_foo`.
+18. **Java boxed types in generics**: `Pair<Integer, Integer>` must be `Pair<Int, Int>` in Kotlin. Never use Java boxed types in Kotlin generic type arguments.
+19. **Kotlin-to-Kotlin `fun` calls**: When calling Kotlin code that defines `fun getFoo()`, use `getFoo()` not `foo`. Kotlin only synthesizes property access for *Java* getters, not Kotlin `fun` declarations.
 
 ## PR Rules
 

--- a/docs/learnings/2026-03-09-wave5-case-management-learnings.md
+++ b/docs/learnings/2026-03-09-wave5-case-management-learnings.md
@@ -1,0 +1,75 @@
+# Wave 5: Case-Management Conversion Learnings
+
+**Date**: 2026-03-09
+**Wave**: 5 — case-management (60 files)
+**PR**: #24
+
+## New Pitfalls
+
+### 1. JVM signature clash: constructor `val` vs interface method
+
+When a Kotlin class implements an interface that defines `fun getMult(): Int`, and the class constructor has `val mult: Int`, the Kotlin compiler generates a `getMult()` getter for the property that clashes with the override method.
+
+**Symptom**: `Inherited platform declarations clash: The following declarations have the same JVM signature (getMult()I)`
+
+**Fix**: Use a private/protected backing name for the constructor parameter:
+```kotlin
+// BAD — generates getMult() that clashes with the interface override
+abstract class StorageBackedChildElement(
+    protected val mult: Int
+) : AbstractTreeElement {
+    override fun getMult(): Int = mult  // clash!
+}
+
+// GOOD — no clash
+abstract class StorageBackedChildElement(
+    protected val _mult: Int
+) : AbstractTreeElement {
+    override fun getMult(): Int = _mult
+}
+```
+
+**Root cause**: Kotlin properties auto-generate getters with the same JVM signature as interface methods. This only happens when the interface defines a `fun` (not a `val`), typically because the interface was converted from Java where it was a method.
+
+### 2. JVM signature clash: field getter vs explicit method
+
+Similarly, a `var` field generates a getter that clashes with an explicit method of the same name.
+
+**Symptom**: `Platform declaration clash: The following declarations have the same JVM signature (getQueryPlanner())`
+
+**Fix**: Rename the backing field:
+```kotlin
+// BAD
+protected var queryPlanner: QueryPlanner? = null
+protected open fun getQueryPlanner(): QueryPlanner { ... }
+
+// GOOD
+private var _queryPlanner: QueryPlanner? = null
+protected open fun getQueryPlanner(): QueryPlanner { ... }
+```
+
+### 3. Java boxed types in Kotlin generics
+
+When Java code uses boxed types in generics (e.g., `ArrayList<Pair<Integer, Integer>>`), Kotlin requires primitive types: `ArrayList<Pair<Int, Int>>`. Using `Integer` in Kotlin generics causes a type mismatch with methods that expect `Pair<Int, Int>`.
+
+**Fix**: Always use Kotlin primitive types (`Int`, `Long`, `Boolean`) in generic type arguments, never Java boxed types (`Integer`, `Long`, `Boolean`).
+
+### 4. Kotlin-to-Kotlin: `fun` stays as function call
+
+When calling existing Kotlin code that defines `fun getOriginalContext()`, you must call it as `getOriginalContext()`, not property-style `originalContext`. This is different from calling Java getters from Kotlin, where property syntax works.
+
+**Why**: Kotlin only synthesizes property access for Java getters. Kotlin `fun` declarations are always function calls, even if they follow the `getFoo()` naming pattern.
+
+**Applies to**: `EvaluationContext.getOriginalContext()`, `EvaluationContext.getCurrentQueryContext()`, `CacheHost.getCachePrimeGuess()`, `QueryContext.getScope()`
+
+### 5. `override` when hiding superclass methods
+
+When a superclass defines `open fun copy()` and a subclass has its own `fun copy()`, Kotlin requires `override` — the method won't silently hide the parent like in Java.
+
+**Symptom**: `'copy' hides member of supertype 'ExternalDataInstance' and needs an 'override' modifier`
+
+## Observations
+
+- Wave 5 had more JVM interop issues than prior waves because the `cases` package has deep inheritance hierarchies mixing interfaces (still using `fun` methods from Java-era conversions) with Kotlin constructor properties.
+- The `AbstractTreeElement` interface defines many methods (`getMult()`, `getName()`, `isLeaf()`) that were converted to `fun` in earlier waves. Child elements that use constructor properties for these values will always hit the JVM signature clash pattern.
+- Consider converting `AbstractTreeElement` method-style declarations to `val` properties in a future cleanup pass — this would eliminate the clash pattern entirely.


### PR DESCRIPTION
## Summary
- Add Wave 5 case-management learnings doc (`docs/learnings/2026-03-09-wave5-case-management-learnings.md`)
- Add 4 new items (16-19) to the Kotlin Conversion Checklist in CLAUDE.md
- Update Wave 5 status to Done in project table

## New checklist items
16. **JVM signature clash: `val` vs `fun`** — constructor `val foo` generates `getFoo()` clashing with interface `override fun getFoo()`
17. **JVM signature clash: field vs getter** — `var foo` generates `getFoo()` clashing with explicit `fun getFoo()`
18. **Java boxed types in generics** — `Pair<Integer, Integer>` must be `Pair<Int, Int>`
19. **Kotlin-to-Kotlin `fun` calls** — no property access synthesis for Kotlin `fun` declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)