### PR TITLE
docs: Wave 6 learnings and conversion checklist updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ commcare-ios/
 | 3 | xpath-engine | 134 | Done (PR #13 merged) |
 | 4 | xform-parser | 27 | Done (PR #21) |
 | 5 | case-management | 60 | Done (PR #24) |
-| 6 | suite-and-session | 93 | Open (Issue #8) |
+| 6 | suite-and-session | 93 | Done (PR #26) |
 | 7 | resources | 28 | Open (Issue #9) |
 | 8 | commcare-core-services | 71 | Open (Issue #10) |
 
@@ -67,6 +67,7 @@ After Phase 1: KMP multiplatform targets (Issue #11), then final verification (I
 - **Wave 4 XForm parser learnings**: `docs/learnings/2026-03-09-wave4-xform-parser-learnings.md` — companion method inheritance, `@JvmField` vs `open`, companion `protected` limitation, smart cast on `var`, `const val` auto-inline
 - **J2K vs AI conversion**: `docs/learnings/2026-03-09-j2k-converter-vs-ai-conversion.md` — why we chose AI-driven conversion over IntelliJ's J2K converter
 - **Wave 5 case-management learnings**: `docs/learnings/2026-03-09-wave5-case-management-learnings.md` — JVM signature clashes (constructor `val` vs interface method, field vs getter), Java boxed types in generics, Kotlin-to-Kotlin method calls
+- **Wave 6 suite-session learnings**: `docs/learnings/2026-03-10-wave6-suite-session-learnings.md` — `internal` hides from Java in other source sets, property getter/setter clashes, nullable return types Java silently allowed
 
 ## Kotlin Conversion Checklist
 
@@ -91,6 +92,8 @@ When converting Java files to Kotlin in commcare-core, check for these **before 
 17. **JVM signature clash: field vs getter**: A `var foo` field generates `getFoo()`, which clashes with an explicit `fun getFoo()`. Fix: rename the backing field to `_foo`.
 18. **Java boxed types in generics**: `Pair<Integer, Integer>` must be `Pair<Int, Int>` in Kotlin. Never use Java boxed types in Kotlin generic type arguments.
 19. **Kotlin-to-Kotlin `fun` calls**: When calling Kotlin code that defines `fun getFoo()`, use `getFoo()` not `foo`. Kotlin only synthesizes property access for *Java* getters, not Kotlin `fun` declarations.
+20. **`internal` hides from other source sets**: Kotlin `internal` mangles names in bytecode. Java code in separate Gradle source sets (ccapi, cli, test) can't access `internal` properties. Add explicit public getter methods.
+21. **Property getter/setter clash**: A `var foo` auto-generates `getFoo()`/`setFoo()`. Don't also define explicit `fun setFoo()` — remove it and let callers use property syntax.
 
 ## PR Rules
 

--- a/docs/learnings/2026-03-10-wave6-suite-session-learnings.md
+++ b/docs/learnings/2026-03-10-wave6-suite-session-learnings.md
@@ -1,0 +1,56 @@
+# Wave 6: Suite-and-Session Conversion Learnings
+
+**Date**: 2026-03-10
+**Wave**: 6 — suite-and-session (93 files)
+**PR**: #26
+
+## New Pitfalls
+
+### 1. `internal` visibility hides properties from Java in other source sets
+
+Kotlin `internal` compiles to `public` in bytecode but with a mangled name. Java code in the same module *can* access it, but Java code in separate Gradle source sets (like `ccapi` or `cli`) sees mangled names and effectively can't use them.
+
+**Symptom**: `error: cannot find symbol` in Java files calling `detail.getFields()`, `field.getHeader()`, etc.
+
+**Fix**: Add explicit public getter methods alongside `internal` properties:
+```kotlin
+// The property is internal (for Kotlin callers in the same module)
+internal val fields: Array<DetailField> = ...
+
+// Explicit getter for Java callers in other source sets
+fun getFields(): Array<DetailField> = fields
+```
+
+**Root cause**: The original Java code had package-private or public fields. Converting to `internal` preserves same-module Kotlin access, but breaks Java callers in different source sets (ccapi, cli, test). This is distinct from the `protected` → `internal` pitfall (#10) because it affects cross-source-set access, not cross-package access.
+
+### 2. Property getter/setter clashes with explicit methods
+
+When converting a Java class that has both a field and an explicit getter/setter method (e.g., `Exception loadException` + `void setLoadException(Exception e)`), the Kotlin `var` property auto-generates the same getter/setter, causing a platform declaration clash.
+
+**Symptom**: `Platform declaration clash: The following declarations have the same JVM signature`
+
+**Fix**: Remove the explicit method and let the property handle it:
+```kotlin
+// BAD — clash
+var loadException: Exception? = null
+fun setLoadException(e: Exception?) { loadException = e }
+
+// GOOD — property handles getter/setter
+var loadException: Exception? = null
+```
+
+Update call sites from `obj.setLoadException(e)` to `obj.loadException = e`.
+
+### 3. Nullable return types that Java silently allowed
+
+Java methods can return `null` even with a non-null-looking return type. When converting to Kotlin, if the return type is made non-null but the method *can* return null at runtime, you get NPEs.
+
+**Example**: `CommCareSession.getNeededDatum()` was converted as returning `SessionDatum` (non-null) with `!!`, but Java callers checked for null returns. The fix was to return `SessionDatum?`.
+
+**Rule**: When a Java method's return value is checked for null by *any* caller, make the Kotlin return type nullable.
+
+## Observations
+
+- Wave 6 was the largest wave yet (93 files) and the `suite/model` package (45 files) has deep serialization with `Externalizable`. The `readExternal`/`writeExternal` methods are particularly tricky because `ExtUtil.writeNumeric` takes `Long` and `readExternal` takes non-nullable `PrototypeFactory`.
+- The ccapi/cli source sets are a new source of errors not seen in prior waves — they're separate Gradle source sets that compile against `main` output, so `internal` visibility creates a gap that plain `protected`/`public` in Java did not.
+- Parser classes (36 files in `xml/`) were relatively straightforward since they mostly extend `TransactionParser<T>` or `ElementParser<T>` which were already Kotlin.


### PR DESCRIPTION
## Summary
- Add Wave 6 suite-and-session learnings doc
- Add 2 new checklist items (20-21): `internal` hides from other source sets, property getter/setter clash
- Update Wave 6 status to Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)