### PR TITLE
docs: Wave 8 learnings and status update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ commcare-ios/
 | 4 | xform-parser | 27 | Done (PR #21) |
 | 5 | case-management | 60 | Done (PR #24) |
 | 6 | suite-and-session | 93 | Done (PR #26) |
-| 7 | resources | 28 | Open (Issue #9) |
-| 8 | commcare-core-services | 71 | Open (Issue #10) |
+| 7 | resources | 28 | Done (PR #28) |
+| 8 | commcare-core-services | 71 | Done (PR #29) |
 
 After Phase 1: KMP multiplatform targets (Issue #11), then final verification (Issue #12).
 
@@ -68,6 +68,7 @@ After Phase 1: KMP multiplatform targets (Issue #11), then final verification (I
 - **J2K vs AI conversion**: `docs/learnings/2026-03-09-j2k-converter-vs-ai-conversion.md` — why we chose AI-driven conversion over IntelliJ's J2K converter
 - **Wave 5 case-management learnings**: `docs/learnings/2026-03-09-wave5-case-management-learnings.md` — JVM signature clashes (constructor `val` vs interface method, field vs getter), Java boxed types in generics, Kotlin-to-Kotlin method calls
 - **Wave 6 suite-session learnings**: `docs/learnings/2026-03-10-wave6-suite-session-learnings.md` — `internal` hides from Java in other source sets, property getter/setter clashes, nullable return types Java silently allowed
+- **Wave 8 core-services learnings**: `docs/learnings/2026-03-10-wave8-core-services-learnings.md` — `@JvmField protected` for cross-source-set Java subclasses, OkHttp 4/Okio 2 API migration, `const val` requires compile-time constants
 
 ## Kotlin Conversion Checklist
 

--- a/docs/learnings/2026-03-10-wave8-core-services-learnings.md
+++ b/docs/learnings/2026-03-10-wave8-core-services-learnings.md
@@ -1,0 +1,52 @@
+# Wave 8: CommCare Core Services Learnings
+
+**Date:** 2026-03-10
+**Wave:** 8 (commcare-core-services, 71 files)
+**PR:** #29
+
+## New Patterns
+
+### 1. `@JvmField protected` for cross-source-set Java subclasses
+
+Kotlin `protected val/var` generates a private backing field + protected getter/setter. Java subclasses in other Gradle source sets (cli, test) that access `super.field` directly will fail because the field is private in bytecode.
+
+**Fix:** Add `@JvmField` to expose the field directly:
+```kotlin
+@JvmField
+protected val mPlatform: CommCarePlatform?
+
+@JvmField
+protected var caseParser: TransactionParserFactory? = null
+```
+
+This is distinct from the `@JvmField` + `open` incompatibility (checklist item 12) — here the properties are not `open`.
+
+### 2. OkHttp 4 Kotlin property syntax
+
+OkHttp 4 deprecated Java-style method accessors in favor of Kotlin properties:
+- `response.code()` → `response.code`
+- `request.url()` → `request.url`
+- `url.scheme()` → `url.scheme`
+- `url.host()` → `url.host`
+- `HttpUrl.parse(str)` → `str.toHttpUrlOrNull()`
+
+### 3. Okio 2 extension functions
+
+Okio 2 moved factory methods to extension functions:
+- `Okio.buffer(Okio.source(stream))` → `stream.source().buffer()`
+
+### 4. `const val` requires compile-time constants
+
+`const val` in companion objects requires a compile-time constant initializer. Method calls like `TimeUnit.MINUTES.toMillis(2)` are not constant. Use `@JvmField val` instead:
+```kotlin
+@JvmField val CONNECTION_TIMEOUT = TimeUnit.MINUTES.toMillis(2)
+```
+
+### 5. Kotlin interfaces are not SAM types for Kotlin callers
+
+When a Kotlin interface has a single abstract method, Kotlin callers cannot pass a lambda — only Java callers can use SAM conversion with Kotlin interfaces. Kotlin callers must use explicit `object : InterfaceName { ... }` syntax.
+
+## Reinforced Patterns
+
+- Property getter/setter clash (checklist item 17/20): `var enforceSecureEndpoint` + explicit `fun setEnforceSecureEndpoint()` — remove the explicit method
+- Nullable parameters from Java (checklist item 1): `CaseIndexTable?` needed because test passes null


### PR DESCRIPTION
## Summary

- Updates CLAUDE.md wave status table: Wave 8 → Done (PR #29)
- Adds Wave 8 learnings doc covering `@JvmField protected`, OkHttp 4/Okio 2 migration, `const val` constraints, Kotlin SAM conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)