### PR TITLE
Phase 2 Wave 4: Platform abstractions (crypto, HTTP, files, URL, JSON)

### DIFF
--- a/commcare-core/build.gradle.kts
+++ b/commcare-core/build.gradle.kts
@@ -9,6 +9,7 @@ buildscript {
 
 plugins {
     kotlin("multiplatform") version "2.0.21"
+    kotlin("plugin.serialization") version "2.0.21"
 }
 
 repositories {
@@ -32,7 +33,9 @@ kotlin {
 
     sourceSets {
         val commonMain by getting {
-            // Future home of shared code
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+            }
         }
 
         val jvmMain by getting {

--- a/commcare-core/src/commonMain/kotlin/org/commcare/core/interfaces/PlatformCrypto.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/core/interfaces/PlatformCrypto.kt
@@ -1,0 +1,39 @@
+package org.commcare.core.interfaces
+
+/**
+ * Cross-platform cryptography interface.
+ * Replaces javax.crypto and java.security for KMP compatibility.
+ */
+expect object PlatformCrypto {
+    /**
+     * Generate a SHA-256 hash of the input bytes.
+     */
+    fun sha256(data: ByteArray): ByteArray
+
+    /**
+     * Generate an MD5 hash of the input bytes.
+     */
+    fun md5(data: ByteArray): ByteArray
+
+    /**
+     * Generate a random byte array of the given size.
+     */
+    fun randomBytes(size: Int): ByteArray
+
+    /**
+     * AES encrypt data with the given key.
+     * Returns IV prepended to ciphertext.
+     */
+    fun aesEncrypt(data: ByteArray, key: ByteArray): ByteArray
+
+    /**
+     * AES decrypt data with the given key.
+     * Expects IV prepended to ciphertext (as produced by aesEncrypt).
+     */
+    fun aesDecrypt(data: ByteArray, key: ByteArray): ByteArray
+
+    /**
+     * Generate an AES key of the given bit length (128, 192, or 256).
+     */
+    fun generateAesKey(bits: Int = 256): ByteArray
+}

--- a/commcare-core/src/commonMain/kotlin/org/commcare/core/interfaces/PlatformFiles.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/core/interfaces/PlatformFiles.kt
@@ -1,0 +1,16 @@
+package org.commcare.core.interfaces
+
+/**
+ * Cross-platform file system operations.
+ * Replaces java.io.File and java.nio.file for KMP compatibility.
+ */
+expect object PlatformFiles {
+    fun readBytes(path: String): ByteArray
+    fun writeBytes(path: String, data: ByteArray)
+    fun exists(path: String): Boolean
+    fun delete(path: String): Boolean
+    fun isDirectory(path: String): Boolean
+    fun listDir(path: String): List<String>
+    fun fileSize(path: String): Long
+    fun createTempFile(prefix: String, suffix: String): String
+}

--- a/commcare-core/src/commonMain/kotlin/org/commcare/core/interfaces/PlatformHttpClient.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/core/interfaces/PlatformHttpClient.kt
@@ -1,0 +1,31 @@
+package org.commcare.core.interfaces
+
+/**
+ * Cross-platform HTTP client interface.
+ * Replaces OkHttp/Retrofit for KMP compatibility.
+ *
+ * On JVM, wraps OkHttp. On iOS, wraps URLSession.
+ */
+interface PlatformHttpClient {
+    fun execute(request: HttpRequest): HttpResponse
+}
+
+data class HttpRequest(
+    val url: String,
+    val method: String = "GET",
+    val headers: Map<String, String> = emptyMap(),
+    val body: ByteArray? = null,
+    val contentType: String? = null
+)
+
+data class HttpResponse(
+    val code: Int,
+    val headers: Map<String, String>,
+    val body: ByteArray?,
+    val errorBody: ByteArray? = null
+)
+
+/**
+ * Factory function to create a platform-specific HTTP client.
+ */
+expect fun createHttpClient(): PlatformHttpClient

--- a/commcare-core/src/commonMain/kotlin/org/commcare/core/interfaces/PlatformUrl.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/core/interfaces/PlatformUrl.kt
@@ -1,0 +1,19 @@
+package org.commcare.core.interfaces
+
+/**
+ * Cross-platform URL parsing and validation.
+ * Replaces java.net.URL for KMP compatibility.
+ */
+expect class PlatformUrl(url: String) {
+    val scheme: String
+    val host: String
+    val port: Int
+    val path: String
+    val query: String?
+    override fun toString(): String
+}
+
+/**
+ * Returns true if the given string is a valid URL.
+ */
+expect fun isValidUrl(url: String): Boolean

--- a/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformCrypto.kt
+++ b/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformCrypto.kt
@@ -1,0 +1,41 @@
+package org.commcare.core.interfaces
+
+/**
+ * iOS cryptography implementation.
+ * Uses CommonCrypto via Kotlin/Native interop.
+ *
+ * Note: Full CommonCrypto interop requires cinterop configuration.
+ * This implementation provides the structure; the actual interop calls
+ * will be wired up when building on macOS with Xcode.
+ */
+actual object PlatformCrypto {
+
+    actual fun sha256(data: ByteArray): ByteArray {
+        // Will use CC_SHA256 via cinterop
+        TODO("iOS SHA-256 implementation requires CommonCrypto cinterop")
+    }
+
+    actual fun md5(data: ByteArray): ByteArray {
+        // Will use CC_MD5 via cinterop
+        TODO("iOS MD5 implementation requires CommonCrypto cinterop")
+    }
+
+    actual fun randomBytes(size: Int): ByteArray {
+        // Will use SecRandomCopyBytes via cinterop
+        TODO("iOS randomBytes implementation requires Security framework cinterop")
+    }
+
+    actual fun aesEncrypt(data: ByteArray, key: ByteArray): ByteArray {
+        // Will use CCCrypt with kCCAlgorithmAES via cinterop
+        TODO("iOS AES encrypt implementation requires CommonCrypto cinterop")
+    }
+
+    actual fun aesDecrypt(data: ByteArray, key: ByteArray): ByteArray {
+        // Will use CCCrypt with kCCAlgorithmAES via cinterop
+        TODO("iOS AES decrypt implementation requires CommonCrypto cinterop")
+    }
+
+    actual fun generateAesKey(bits: Int): ByteArray {
+        return randomBytes(bits / 8)
+    }
+}

--- a/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformFiles.kt
+++ b/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformFiles.kt
@@ -1,0 +1,39 @@
+package org.commcare.core.interfaces
+
+/**
+ * iOS file system operations.
+ * Will use NSFileManager via Kotlin/Native interop.
+ */
+actual object PlatformFiles {
+    actual fun readBytes(path: String): ByteArray {
+        TODO("iOS readBytes requires NSFileManager cinterop")
+    }
+
+    actual fun writeBytes(path: String, data: ByteArray) {
+        TODO("iOS writeBytes requires NSFileManager cinterop")
+    }
+
+    actual fun exists(path: String): Boolean {
+        TODO("iOS exists requires NSFileManager cinterop")
+    }
+
+    actual fun delete(path: String): Boolean {
+        TODO("iOS delete requires NSFileManager cinterop")
+    }
+
+    actual fun isDirectory(path: String): Boolean {
+        TODO("iOS isDirectory requires NSFileManager cinterop")
+    }
+
+    actual fun listDir(path: String): List<String> {
+        TODO("iOS listDir requires NSFileManager cinterop")
+    }
+
+    actual fun fileSize(path: String): Long {
+        TODO("iOS fileSize requires NSFileManager cinterop")
+    }
+
+    actual fun createTempFile(prefix: String, suffix: String): String {
+        TODO("iOS createTempFile requires NSTemporaryDirectory cinterop")
+    }
+}

--- a/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformHttpClient.kt
+++ b/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformHttpClient.kt
@@ -1,0 +1,13 @@
+package org.commcare.core.interfaces
+
+/**
+ * iOS HTTP client.
+ * Will use NSURLSession via Kotlin/Native interop.
+ */
+class IosHttpClient : PlatformHttpClient {
+    override fun execute(request: HttpRequest): HttpResponse {
+        TODO("iOS HTTP client requires Foundation NSURLSession cinterop")
+    }
+}
+
+actual fun createHttpClient(): PlatformHttpClient = IosHttpClient()

--- a/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformUrl.kt
+++ b/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformUrl.kt
@@ -1,0 +1,60 @@
+package org.commcare.core.interfaces
+
+/**
+ * Pure Kotlin URL parser for iOS.
+ * Parses scheme://host:port/path?query format.
+ */
+actual class PlatformUrl actual constructor(url: String) {
+    actual val scheme: String
+    actual val host: String
+    actual val port: Int
+    actual val path: String
+    actual val query: String?
+
+    init {
+        val schemeEnd = url.indexOf("://")
+        if (schemeEnd < 0) throw IllegalArgumentException("Malformed URL: $url")
+        scheme = url.substring(0, schemeEnd)
+
+        val afterScheme = url.substring(schemeEnd + 3)
+        val pathStart = afterScheme.indexOf('/')
+        val hostPort = if (pathStart >= 0) afterScheme.substring(0, pathStart) else afterScheme
+        val pathAndQuery = if (pathStart >= 0) afterScheme.substring(pathStart) else ""
+
+        val colonIdx = hostPort.indexOf(':')
+        if (colonIdx >= 0) {
+            host = hostPort.substring(0, colonIdx)
+            port = hostPort.substring(colonIdx + 1).toIntOrNull() ?: -1
+        } else {
+            host = hostPort
+            port = -1
+        }
+
+        val queryIdx = pathAndQuery.indexOf('?')
+        if (queryIdx >= 0) {
+            path = pathAndQuery.substring(0, queryIdx)
+            query = pathAndQuery.substring(queryIdx + 1)
+        } else {
+            path = pathAndQuery
+            query = null
+        }
+    }
+
+    actual override fun toString(): String {
+        val sb = StringBuilder()
+        sb.append(scheme).append("://").append(host)
+        if (port >= 0) sb.append(':').append(port)
+        sb.append(path)
+        if (query != null) sb.append('?').append(query)
+        return sb.toString()
+    }
+}
+
+actual fun isValidUrl(url: String): Boolean {
+    return try {
+        PlatformUrl(url)
+        true
+    } catch (e: Exception) {
+        false
+    }
+}

--- a/commcare-core/src/jvmMain/kotlin/org/commcare/core/interfaces/PlatformCrypto.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/commcare/core/interfaces/PlatformCrypto.kt
@@ -1,0 +1,49 @@
+package org.commcare.core.interfaces
+
+import java.security.MessageDigest
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+actual object PlatformCrypto {
+    private const val GCM_IV_LENGTH = 12
+    private const val GCM_TAG_LENGTH = 128
+
+    actual fun sha256(data: ByteArray): ByteArray {
+        return MessageDigest.getInstance("SHA-256").digest(data)
+    }
+
+    actual fun md5(data: ByteArray): ByteArray {
+        return MessageDigest.getInstance("MD5").digest(data)
+    }
+
+    actual fun randomBytes(size: Int): ByteArray {
+        val bytes = ByteArray(size)
+        SecureRandom().nextBytes(bytes)
+        return bytes
+    }
+
+    actual fun aesEncrypt(data: ByteArray, key: ByteArray): ByteArray {
+        val iv = randomBytes(GCM_IV_LENGTH)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "AES"), GCMParameterSpec(GCM_TAG_LENGTH, iv))
+        val ciphertext = cipher.doFinal(data)
+        return iv + ciphertext
+    }
+
+    actual fun aesDecrypt(data: ByteArray, key: ByteArray): ByteArray {
+        val iv = data.copyOfRange(0, GCM_IV_LENGTH)
+        val ciphertext = data.copyOfRange(GCM_IV_LENGTH, data.size)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "AES"), GCMParameterSpec(GCM_TAG_LENGTH, iv))
+        return cipher.doFinal(ciphertext)
+    }
+
+    actual fun generateAesKey(bits: Int): ByteArray {
+        val keyGen = KeyGenerator.getInstance("AES")
+        keyGen.init(bits)
+        return keyGen.generateKey().encoded
+    }
+}

--- a/commcare-core/src/jvmMain/kotlin/org/commcare/core/interfaces/PlatformFiles.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/commcare/core/interfaces/PlatformFiles.kt
@@ -1,0 +1,15 @@
+package org.commcare.core.interfaces
+
+import java.io.File
+
+actual object PlatformFiles {
+    actual fun readBytes(path: String): ByteArray = File(path).readBytes()
+    actual fun writeBytes(path: String, data: ByteArray) = File(path).writeBytes(data)
+    actual fun exists(path: String): Boolean = File(path).exists()
+    actual fun delete(path: String): Boolean = File(path).delete()
+    actual fun isDirectory(path: String): Boolean = File(path).isDirectory
+    actual fun listDir(path: String): List<String> = File(path).list()?.toList() ?: emptyList()
+    actual fun fileSize(path: String): Long = File(path).length()
+    actual fun createTempFile(prefix: String, suffix: String): String =
+        File.createTempFile(prefix, suffix).absolutePath
+}

--- a/commcare-core/src/jvmMain/kotlin/org/commcare/core/interfaces/PlatformHttpClient.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/commcare/core/interfaces/PlatformHttpClient.kt
@@ -1,0 +1,55 @@
+package org.commcare.core.interfaces
+
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+class JvmHttpClient : PlatformHttpClient {
+    private val client = OkHttpClient()
+
+    override fun execute(request: HttpRequest): HttpResponse {
+        val builder = Request.Builder().url(request.url)
+
+        for ((name, value) in request.headers) {
+            builder.header(name, value)
+        }
+
+        val body = request.body
+        when (request.method.uppercase()) {
+            "GET" -> builder.get()
+            "POST" -> builder.post(
+                (body ?: ByteArray(0)).toRequestBody(request.contentType?.toMediaTypeOrNull())
+            )
+            "PUT" -> builder.put(
+                (body ?: ByteArray(0)).toRequestBody(request.contentType?.toMediaTypeOrNull())
+            )
+            "DELETE" -> {
+                if (body != null) {
+                    builder.delete(body.toRequestBody(request.contentType?.toMediaTypeOrNull()))
+                } else {
+                    builder.delete()
+                }
+            }
+        }
+
+        val response = client.newCall(builder.build()).execute()
+        return HttpResponse(
+            code = response.code,
+            headers = response.headers.toMap()
+                .mapValues { it.value.firstOrNull() ?: "" },
+            body = response.body?.bytes(),
+            errorBody = null
+        )
+    }
+}
+
+private fun okhttp3.Headers.toMap(): Map<String, List<String>> {
+    val result = mutableMapOf<String, MutableList<String>>()
+    for (i in 0 until size) {
+        result.getOrPut(name(i)) { mutableListOf() }.add(value(i))
+    }
+    return result
+}
+
+actual fun createHttpClient(): PlatformHttpClient = JvmHttpClient()

--- a/commcare-core/src/jvmMain/kotlin/org/commcare/core/interfaces/PlatformUrl.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/commcare/core/interfaces/PlatformUrl.kt
@@ -1,0 +1,25 @@
+package org.commcare.core.interfaces
+
+import java.net.MalformedURLException
+import java.net.URL
+
+actual class PlatformUrl actual constructor(url: String) {
+    private val javaUrl = URL(url)
+
+    actual val scheme: String get() = javaUrl.protocol
+    actual val host: String get() = javaUrl.host
+    actual val port: Int get() = javaUrl.port
+    actual val path: String get() = javaUrl.path
+    actual val query: String? get() = javaUrl.query
+
+    actual override fun toString(): String = javaUrl.toString()
+}
+
+actual fun isValidUrl(url: String): Boolean {
+    return try {
+        URL(url)
+        true
+    } catch (e: MalformedURLException) {
+        false
+    }
+}

--- a/commcare-core/src/test/java/org/commcare/core/interfaces/PlatformAbstractionsTest.java
+++ b/commcare-core/src/test/java/org/commcare/core/interfaces/PlatformAbstractionsTest.java
@@ -1,0 +1,134 @@
+package org.commcare.core.interfaces;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for platform abstraction layer (Wave 4).
+ */
+public class PlatformAbstractionsTest {
+
+    // --- URL Tests ---
+
+    @Test
+    public void testUrlParsing() {
+        PlatformUrl url = new PlatformUrl("https://www.example.com:8080/path/to/resource?key=value");
+        assertEquals("https", url.getScheme());
+        assertEquals("www.example.com", url.getHost());
+        assertEquals(8080, url.getPort());
+        assertEquals("/path/to/resource", url.getPath());
+        assertEquals("key=value", url.getQuery());
+    }
+
+    @Test
+    public void testUrlParsingNoPort() {
+        PlatformUrl url = new PlatformUrl("http://example.com/path");
+        assertEquals("http", url.getScheme());
+        assertEquals("example.com", url.getHost());
+        assertEquals(-1, url.getPort());
+        assertEquals("/path", url.getPath());
+        assertNull(url.getQuery());
+    }
+
+    @Test
+    public void testUrlToString() {
+        String original = "https://commcare.example.com/api/v1/cases";
+        PlatformUrl url = new PlatformUrl(original);
+        assertEquals(original, url.toString());
+    }
+
+    @Test
+    public void testIsValidUrl() {
+        assertTrue(PlatformUrlKt.isValidUrl("https://example.com"));
+        assertTrue(PlatformUrlKt.isValidUrl("http://localhost:8080/path?q=1"));
+        assertFalse(PlatformUrlKt.isValidUrl("not a url"));
+        assertFalse(PlatformUrlKt.isValidUrl(""));
+    }
+
+    // --- Crypto Tests ---
+
+    @Test
+    public void testSha256() {
+        byte[] hash = PlatformCrypto.INSTANCE.sha256("hello".getBytes());
+        assertNotNull(hash);
+        assertEquals(32, hash.length); // SHA-256 is 32 bytes
+    }
+
+    @Test
+    public void testSha256Deterministic() {
+        byte[] hash1 = PlatformCrypto.INSTANCE.sha256("test".getBytes());
+        byte[] hash2 = PlatformCrypto.INSTANCE.sha256("test".getBytes());
+        assertArrayEquals(hash1, hash2);
+    }
+
+    @Test
+    public void testMd5() {
+        byte[] hash = PlatformCrypto.INSTANCE.md5("hello".getBytes());
+        assertNotNull(hash);
+        assertEquals(16, hash.length); // MD5 is 16 bytes
+    }
+
+    @Test
+    public void testRandomBytes() {
+        byte[] bytes = PlatformCrypto.INSTANCE.randomBytes(32);
+        assertNotNull(bytes);
+        assertEquals(32, bytes.length);
+    }
+
+    @Test
+    public void testAesRoundTrip() {
+        byte[] key = PlatformCrypto.INSTANCE.generateAesKey(256);
+        byte[] plaintext = "Hello, CommCare!".getBytes();
+        byte[] encrypted = PlatformCrypto.INSTANCE.aesEncrypt(plaintext, key);
+        byte[] decrypted = PlatformCrypto.INSTANCE.aesDecrypt(encrypted, key);
+        assertArrayEquals(plaintext, decrypted);
+    }
+
+    @Test
+    public void testGenerateAesKey() {
+        byte[] key128 = PlatformCrypto.INSTANCE.generateAesKey(128);
+        assertEquals(16, key128.length);
+        byte[] key256 = PlatformCrypto.INSTANCE.generateAesKey(256);
+        assertEquals(32, key256.length);
+    }
+
+    // --- File I/O Tests ---
+
+    @Test
+    public void testFileRoundTrip() throws Exception {
+        String path = PlatformFiles.INSTANCE.createTempFile("test", ".dat");
+        try {
+            byte[] data = "test file content".getBytes();
+            PlatformFiles.INSTANCE.writeBytes(path, data);
+            assertTrue(PlatformFiles.INSTANCE.exists(path));
+            byte[] read = PlatformFiles.INSTANCE.readBytes(path);
+            assertArrayEquals(data, read);
+            assertEquals(data.length, PlatformFiles.INSTANCE.fileSize(path));
+            assertFalse(PlatformFiles.INSTANCE.isDirectory(path));
+        } finally {
+            PlatformFiles.INSTANCE.delete(path);
+            assertFalse(PlatformFiles.INSTANCE.exists(path));
+        }
+    }
+
+    @Test
+    public void testListDir() throws Exception {
+        String tempFile = PlatformFiles.INSTANCE.createTempFile("listdir", ".tmp");
+        try {
+            File f = new File(tempFile);
+            String dir = f.getParent();
+            assertTrue(PlatformFiles.INSTANCE.isDirectory(dir));
+            assertTrue(PlatformFiles.INSTANCE.listDir(dir).size() > 0);
+        } finally {
+            PlatformFiles.INSTANCE.delete(tempFile);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **PlatformUrl**: expect class for URL parsing/validation (JVM wraps `java.net.URL`, iOS pure Kotlin parser)
- **PlatformCrypto**: expect object for SHA-256, MD5 hashing, AES-GCM encrypt/decrypt, `SecureRandom` (JVM wraps `javax.crypto`, iOS stubs for CommonCrypto cinterop)
- **PlatformFiles**: expect object for file read/write/exists/delete/list/size/createTemp (JVM wraps `java.io.File`, iOS stubs for `NSFileManager`)
- **PlatformHttpClient**: interface + expect factory for HTTP requests (JVM wraps OkHttp, iOS stubs for `NSURLSession`)
- **JSON**: Added `kotlinx-serialization-json:1.7.3` to commonMain dependencies + serialization plugin, replacing `org.json` for future cross-platform use
- 12 JVM tests covering URL parsing, crypto round-trip, file I/O round-trip

No existing consumer files modified — abstraction layer only. iOS implementations use `TODO()` stubs where platform cinterop is required (CommonCrypto, NSFileManager, NSURLSession).

Closes #37

## Test plan

- [x] All expect/actual declarations compile in commonMain/jvmMain/iosMain
- [x] `kotlinx-serialization-json` resolves and compiles
- [x] 12 new platform abstraction tests pass (URL, crypto, file I/O)
- [x] `./gradlew compileKotlinJvm compileJava` passes
- [x] `./gradlew jvmTest` passes — **748 tests, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)