### PR TITLE
Phase 2 Wave 7: Replace XML parser types with platform abstractions

### DIFF
--- a/commcare-core/src/commonMain/kotlin/org/javarosa/xml/PlatformXmlParserException.kt
+++ b/commcare-core/src/commonMain/kotlin/org/javarosa/xml/PlatformXmlParserException.kt
@@ -1,0 +1,10 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package org.javarosa.xml
+
+/**
+ * Cross-platform XML parser exception replacement.
+ * On JVM, this is a typealias to org.xmlpull.v1.XmlPullParserException.
+ * On iOS, this is a simple Exception subclass.
+ */
+expect open class PlatformXmlParserException(message: String) : Exception

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/xml/PlatformXmlParserExceptionIos.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/xml/PlatformXmlParserExceptionIos.kt
@@ -1,0 +1,5 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package org.javarosa.xml
+
+actual open class PlatformXmlParserException actual constructor(message: String) : Exception(message)

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/PlatformXmlParserExceptionJvm.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/PlatformXmlParserExceptionJvm.kt
@@ -1,0 +1,5 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package org.javarosa.xml
+
+actual typealias PlatformXmlParserException = org.xmlpull.v1.XmlPullParserException

--- a/commcare-core/src/main/java/org/commcare/core/parse/CommCareTransactionParserFactory.kt
+++ b/commcare-core/src/main/java/org/commcare/core/parse/CommCareTransactionParserFactory.kt
@@ -13,7 +13,7 @@ import org.commcare.xml.bulk.LinearBulkProcessingCaseXmlParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -110,7 +110,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
                 @Throws(
                     InvalidStructureException::class,
                     PlatformIOException::class,
-                    XmlPullParserException::class,
+                    PlatformXmlParserException::class,
                     UnfullfilledRequirementsException::class
                 )
                 override fun parse(): String {

--- a/commcare-core/src/main/java/org/commcare/core/parse/ParseUtils.kt
+++ b/commcare-core/src/main/java/org/commcare/core/parse/ParseUtils.kt
@@ -5,7 +5,7 @@ import org.commcare.data.xml.DataModelPullParser
 import org.commcare.data.xml.TransactionParserFactory
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
 
@@ -18,7 +18,7 @@ object ParseUtils {
     @Throws(
         InvalidStructureException::class,
         UnfullfilledRequirementsException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         PlatformIOException::class
     )
     fun parseIntoSandbox(stream: InputStream, sandbox: UserSandbox) {
@@ -29,7 +29,7 @@ object ParseUtils {
     @Throws(
         InvalidStructureException::class,
         UnfullfilledRequirementsException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         PlatformIOException::class
     )
     fun parseIntoSandbox(stream: InputStream, sandbox: UserSandbox, failfast: Boolean) {
@@ -41,7 +41,7 @@ object ParseUtils {
         InvalidStructureException::class,
         PlatformIOException::class,
         UnfullfilledRequirementsException::class,
-        XmlPullParserException::class
+        PlatformXmlParserException::class
     )
     fun parseIntoSandbox(
         stream: InputStream,
@@ -58,7 +58,7 @@ object ParseUtils {
         PlatformIOException::class,
         InvalidStructureException::class,
         UnfullfilledRequirementsException::class,
-        XmlPullParserException::class
+        PlatformXmlParserException::class
     )
     fun parseIntoSandbox(
         stream: InputStream,

--- a/commcare-core/src/main/java/org/commcare/core/parse/UserXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/core/parse/UserXmlParser.kt
@@ -7,7 +7,7 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -26,7 +26,7 @@ open class UserXmlParser : TransactionParser<User> {
     @Throws(
         InvalidStructureException::class,
         PlatformIOException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         UnfullfilledRequirementsException::class
     )
     override fun parse(): User {

--- a/commcare-core/src/main/java/org/commcare/core/process/XmlFormRecordProcessor.kt
+++ b/commcare-core/src/main/java/org/commcare/core/process/XmlFormRecordProcessor.kt
@@ -7,7 +7,7 @@ import org.commcare.xml.CaseXmlParser
 import org.commcare.xml.LedgerXmlParsers
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
 
@@ -26,7 +26,7 @@ object XmlFormRecordProcessor {
     @Throws(
         InvalidStructureException::class,
         PlatformIOException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         UnfullfilledRequirementsException::class
     )
     fun process(sandbox: UserSandbox, stream: InputStream) {
@@ -45,7 +45,7 @@ object XmlFormRecordProcessor {
     @Throws(
         InvalidStructureException::class,
         PlatformIOException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         UnfullfilledRequirementsException::class
     )
     fun process(stream: InputStream, factory: TransactionParserFactory) {

--- a/commcare-core/src/main/java/org/commcare/resources/model/ResourceInstaller.kt
+++ b/commcare-core/src/main/java/org/commcare/resources/model/ResourceInstaller.kt
@@ -7,7 +7,7 @@ import org.javarosa.core.reference.Reference
 import org.javarosa.core.util.externalizable.Externalizable
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Vector
 
@@ -47,7 +47,7 @@ interface ResourceInstaller<T : CommCarePlatform> : Externalizable {
         PlatformIOException::class,
         InvalidReferenceException::class,
         InvalidStructureException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         UnfullfilledRequirementsException::class
     )
     fun initialize(platform: T, isUpgrade: Boolean): Boolean

--- a/commcare-core/src/main/java/org/commcare/resources/model/ResourceTable.kt
+++ b/commcare-core/src/main/java/org/commcare/resources/model/ResourceTable.kt
@@ -13,7 +13,7 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.core.util.SizeBoundUniqueVector
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import java.io.FileNotFoundException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Hashtable
@@ -949,7 +949,7 @@ open class ResourceTable {
             throw ResourceInitializationException(r, e)
         } catch (e: InvalidReferenceException) {
             throw ResourceInitializationException(r, e)
-        } catch (e: XmlPullParserException) {
+        } catch (e: PlatformXmlParserException) {
             throw ResourceInitializationException(r, e)
         } catch (e: UnfullfilledRequirementsException) {
             throw ResourceInitializationException(r, e)

--- a/commcare-core/src/main/java/org/commcare/resources/model/installers/BasicInstaller.kt
+++ b/commcare-core/src/main/java/org/commcare/resources/model/installers/BasicInstaller.kt
@@ -14,7 +14,7 @@ import org.javarosa.core.util.externalizable.DeserializationException
 import org.javarosa.core.util.externalizable.PrototypeFactory
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
@@ -31,7 +31,7 @@ open class BasicInstaller : ResourceInstaller<CommCarePlatform> {
         PlatformIOException::class,
         InvalidReferenceException::class,
         InvalidStructureException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         UnfullfilledRequirementsException::class
     )
     override fun initialize(platform: CommCarePlatform, isUpgrade: Boolean): Boolean {

--- a/commcare-core/src/main/java/org/commcare/resources/model/installers/CacheInstaller.kt
+++ b/commcare-core/src/main/java/org/commcare/resources/model/installers/CacheInstaller.kt
@@ -17,7 +17,7 @@ import org.javarosa.core.util.externalizable.ExtUtil
 import org.javarosa.core.util.externalizable.PrototypeFactory
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
@@ -60,7 +60,7 @@ abstract class CacheInstaller<T : Persistable> : ResourceInstaller<CommCarePlatf
         PlatformIOException::class,
         InvalidReferenceException::class,
         InvalidStructureException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         UnfullfilledRequirementsException::class
     )
     override fun initialize(platform: CommCarePlatform, isUpgrade: Boolean): Boolean {

--- a/commcare-core/src/main/java/org/commcare/resources/model/installers/LocaleFileInstaller.kt
+++ b/commcare-core/src/main/java/org/commcare/resources/model/installers/LocaleFileInstaller.kt
@@ -23,7 +23,7 @@ import org.javarosa.core.util.externalizable.ExtWrapMap
 import org.javarosa.core.util.externalizable.PrototypeFactory
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
@@ -60,7 +60,7 @@ class LocaleFileInstaller : ResourceInstaller<CommCarePlatform> {
         PlatformIOException::class,
         InvalidReferenceException::class,
         InvalidStructureException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         UnfullfilledRequirementsException::class
     )
     override fun initialize(platform: CommCarePlatform, isUpgrade: Boolean): Boolean {

--- a/commcare-core/src/main/java/org/commcare/resources/model/installers/LoginImageInstaller.kt
+++ b/commcare-core/src/main/java/org/commcare/resources/model/installers/LoginImageInstaller.kt
@@ -4,7 +4,7 @@ import org.commcare.util.CommCarePlatform
 import org.javarosa.core.reference.InvalidReferenceException
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -19,7 +19,7 @@ class LoginImageInstaller : BasicInstaller() {
         PlatformIOException::class,
         InvalidReferenceException::class,
         InvalidStructureException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         UnfullfilledRequirementsException::class
     )
     override fun initialize(platform: CommCarePlatform, isUpgrade: Boolean): Boolean {

--- a/commcare-core/src/main/java/org/commcare/resources/model/installers/OfflineUserRestoreInstaller.kt
+++ b/commcare-core/src/main/java/org/commcare/resources/model/installers/OfflineUserRestoreInstaller.kt
@@ -11,7 +11,7 @@ import org.javarosa.core.reference.InvalidReferenceException
 import org.javarosa.core.reference.Reference
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -30,7 +30,7 @@ class OfflineUserRestoreInstaller : CacheInstaller<OfflineUserRestore>() {
         PlatformIOException::class,
         InvalidReferenceException::class,
         InvalidStructureException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         UnfullfilledRequirementsException::class
     )
     override fun initialize(platform: CommCarePlatform, isUpgrade: Boolean): Boolean {
@@ -60,7 +60,7 @@ class OfflineUserRestoreInstaller : CacheInstaller<OfflineUserRestore>() {
             cacheLocation = offlineUserRestore.getID()
         } catch (e: PlatformIOException) {
             throw UnresolvedResourceException(r, e.message)
-        } catch (e: XmlPullParserException) {
+        } catch (e: PlatformXmlParserException) {
             throw UnresolvedResourceException(r, e.message)
         } catch (e: InvalidStructureException) {
             throw UnresolvedResourceException(r, e.message)

--- a/commcare-core/src/main/java/org/commcare/resources/model/installers/ProfileInstaller.kt
+++ b/commcare-core/src/main/java/org/commcare/resources/model/installers/ProfileInstaller.kt
@@ -18,7 +18,7 @@ import org.javarosa.core.util.externalizable.ExtUtil
 import org.javarosa.core.util.externalizable.PrototypeFactory
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
@@ -55,7 +55,7 @@ class ProfileInstaller : CacheInstaller<Profile> {
         PlatformIOException::class,
         InvalidReferenceException::class,
         InvalidStructureException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         UnfullfilledRequirementsException::class
     )
     override fun initialize(platform: CommCarePlatform, isUpgrade: Boolean): Boolean {
@@ -147,7 +147,7 @@ class ProfileInstaller : CacheInstaller<Profile> {
             }
             e.printStackTrace()
             return false
-        } catch (e: XmlPullParserException) {
+        } catch (e: PlatformXmlParserException) {
             if (e.message != null) {
                 Logger.log(LogTypes.TYPE_RESOURCES, "XML Parse exception fetching profile: " + e.message)
             }

--- a/commcare-core/src/main/java/org/commcare/resources/model/installers/SuiteInstaller.kt
+++ b/commcare-core/src/main/java/org/commcare/resources/model/installers/SuiteInstaller.kt
@@ -18,7 +18,7 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.core.util.SizeBoundUniqueVector
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Vector
 
@@ -31,7 +31,7 @@ class SuiteInstaller : CacheInstaller<Suite>() {
         PlatformIOException::class,
         InvalidReferenceException::class,
         InvalidStructureException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         UnfullfilledRequirementsException::class
     )
     override fun initialize(platform: CommCarePlatform, isUpgrade: Boolean): Boolean {
@@ -83,7 +83,7 @@ class SuiteInstaller : CacheInstaller<Suite>() {
                 val exception = UnreliableSourceException(r, e.message)
                 exception.initCause(e)
                 throw exception
-            } catch (e: XmlPullParserException) {
+            } catch (e: PlatformXmlParserException) {
                 e.printStackTrace()
                 return false
             } finally {

--- a/commcare-core/src/main/java/org/commcare/session/RemoteQuerySessionManager.kt
+++ b/commcare-core/src/main/java/org/commcare/session/RemoteQuerySessionManager.kt
@@ -26,7 +26,7 @@ import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.javarosa.xpath.XPathException
 import org.javarosa.xpath.expr.FunctionUtils
 import org.javarosa.xpath.expr.XPathExpression
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
 import java.net.URL
@@ -318,7 +318,7 @@ class RemoteQuerySessionManager private constructor(
             return Pair(null, e.message)
         } catch (e: PlatformIOException) {
             return Pair(null, e.message)
-        } catch (e: XmlPullParserException) {
+        } catch (e: PlatformXmlParserException) {
             return Pair(null, e.message)
         } catch (e: UnfullfilledRequirementsException) {
             return Pair(null, e.message)

--- a/commcare-core/src/main/java/org/commcare/suite/model/OfflineUserRestore.kt
+++ b/commcare-core/src/main/java/org/commcare/suite/model/OfflineUserRestore.kt
@@ -15,7 +15,7 @@ import org.javarosa.core.util.externalizable.PrototypeFactory
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 
 import java.io.ByteArrayInputStream
 import java.io.DataInputStream
@@ -41,7 +41,7 @@ class OfflineUserRestore : Persistable {
 
     @Throws(
         UnfullfilledRequirementsException::class, PlatformIOException::class, InvalidStructureException::class,
-        XmlPullParserException::class, InvalidReferenceException::class
+        PlatformXmlParserException::class, InvalidReferenceException::class
     )
     constructor(reference: String?) {
         this.reference = reference
@@ -101,7 +101,7 @@ class OfflineUserRestore : Persistable {
 
     @Throws(
         UnfullfilledRequirementsException::class, PlatformIOException::class, InvalidStructureException::class,
-        XmlPullParserException::class, InvalidReferenceException::class
+        PlatformXmlParserException::class, InvalidReferenceException::class
     )
     private fun checkThatRestoreIsValidAndSetUsername() {
         val factory = TransactionParserFactory { parser ->
@@ -145,7 +145,7 @@ class OfflineUserRestore : Persistable {
         @JvmStatic
         @Throws(
             UnfullfilledRequirementsException::class, PlatformIOException::class, InvalidStructureException::class,
-            XmlPullParserException::class, InvalidReferenceException::class
+            PlatformXmlParserException::class, InvalidReferenceException::class
         )
         fun buildInMemoryUserRestore(restoreStream: InputStream): OfflineUserRestore {
             val offlineUserRestore = OfflineUserRestore()

--- a/commcare-core/src/main/java/org/commcare/xml/ActionParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/ActionParser.kt
@@ -8,7 +8,7 @@ import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Vector
 
@@ -23,7 +23,7 @@ class ActionParser(parser: KXmlParser) : CommCareElementParser<Action>(parser) {
         const val NAME_ACTION: String = "action"
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Action {
         this.checkNode(NAME_ACTION)
 

--- a/commcare-core/src/main/java/org/commcare/xml/AssertionSetParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/AssertionSetParser.kt
@@ -7,7 +7,7 @@ import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Vector
 
@@ -16,7 +16,7 @@ import java.util.Vector
  */
 class AssertionSetParser(parser: KXmlParser) : ElementParser<AssertionSet>(parser) {
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): AssertionSet {
         this.checkNode("assertions")
 

--- a/commcare-core/src/main/java/org/commcare/xml/BestEffortBlockParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/BestEffortBlockParser.kt
@@ -4,7 +4,7 @@ import org.commcare.data.xml.TransactionParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Hashtable
 
@@ -26,7 +26,7 @@ abstract class BestEffortBlockParser(
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     override fun parse(): Hashtable<String, String> {
         val name = parser.name

--- a/commcare-core/src/main/java/org/commcare/xml/CalloutParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/CalloutParser.kt
@@ -5,7 +5,7 @@ import org.commcare.suite.model.DetailField
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Hashtable
 import java.util.Vector
@@ -18,7 +18,7 @@ import java.util.Vector
  */
 class CalloutParser(parser: KXmlParser) : ElementParser<Callout>(parser) {
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Callout {
         val actionName = parser.getAttributeValue(null, "action")
         val image = parser.getAttributeValue(null, "image")

--- a/commcare-core/src/main/java/org/commcare/xml/CaseXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/CaseXmlParser.kt
@@ -32,7 +32,7 @@ import org.javarosa.core.util.externalizable.SerializationLimitationException
 import org.javarosa.xml.util.ActionableInvalidStructureException
 import org.javarosa.xml.util.InvalidStructureException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.NoSuchElementException
 
@@ -71,7 +71,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
         this.storage = storage
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Case? {
         checkNode(CASE_NODE)
 
@@ -136,7 +136,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
         return null
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun createCase(caseId: String, modified: java.util.Date, userId: String?): Case {
         val data = arrayOfNulls<String>(3)
         var caseForBlock: Case? = null
@@ -192,7 +192,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
         return caseForBlock
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun updateCase(caseForBlock: Case, caseId: String) {
         while (nextTagInBlock(CASE_UPDATE_NODE)) {
             val key = parser.name
@@ -239,7 +239,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
         onIndexDisrupted(caseId)
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun indexCase(caseForBlock: Case, caseId: String) {
         while (nextTagInBlock(CASE_INDEX_NODE)) {
             val indexName = parser.name
@@ -279,7 +279,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
         }
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun processCaseAttachment(caseForBlock: Case) {
         while (nextTagInBlock(CASE_ATTACHMENT_NODE)) {
             val attachmentName = parser.name

--- a/commcare-core/src/main/java/org/commcare/xml/CommCareElementParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/CommCareElementParser.kt
@@ -5,7 +5,7 @@ import org.commcare.suite.model.Text
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -19,7 +19,7 @@ abstract class CommCareElementParser<T>(parser: KXmlParser) : ElementParser<T>(p
     /**
      * Build a DisplayUnit object by parsing the contents of a display tag.
      */
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     fun parseDisplayBlock(): DisplayUnit {
         var imageValue: Text? = null
         var audioValue: Text? = null

--- a/commcare-core/src/main/java/org/commcare/xml/DetailFieldParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/DetailFieldParser.kt
@@ -9,7 +9,7 @@ import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -22,7 +22,7 @@ class DetailFieldParser(
     private val id: String?
 ) : CommCareElementParser<DetailField>(parser) {
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): DetailField {
         checkNode("field")
         val builder = DetailField.Builder()
@@ -106,7 +106,7 @@ class DetailFieldParser(
         builder.setEndpointAction(EndpointAction(id, isBackground))
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseStyle(builder: DetailField.Builder) {
         //style
         if (parser.name.lowercase() == "style") {
@@ -122,7 +122,7 @@ class DetailFieldParser(
         }
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseTemplate(builder: DetailField.Builder) {
         //Template
         checkNode("template")
@@ -154,7 +154,7 @@ class DetailFieldParser(
         builder.setTemplate(template)
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseSort(builder: DetailField.Builder) {
         val order = parser.getAttributeValue(null, "order")
         if (order != null && "" != order) {

--- a/commcare-core/src/main/java/org/commcare/xml/DetailGroupParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/DetailGroupParser.kt
@@ -6,7 +6,7 @@ import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 class DetailGroupParser(parser: KXmlParser) : CommCareElementParser<DetailGroup>(parser) {
@@ -17,7 +17,7 @@ class DetailGroupParser(parser: KXmlParser) : CommCareElementParser<DetailGroup>
         const val ATTRIBUTE_NAME_HEADER_ROWS: String = "header-rows"
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): DetailGroup {
         checkNode(NAME_GROUP)
         val functionStr = parser.getAttributeValue(null, ATTRIBUTE_NAME_FUNCTION)

--- a/commcare-core/src/main/java/org/commcare/xml/DetailParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/DetailParser.kt
@@ -13,7 +13,7 @@ import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Vector
 
@@ -26,7 +26,7 @@ open class DetailParser(parser: KXmlParser) : CommCareElementParser<Detail>(pars
         private const val NAME_NO_ITEMS_TEXT = "no_items_text"
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Detail {
         checkNode("detail")
 

--- a/commcare-core/src/main/java/org/commcare/xml/EndpointParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/EndpointParser.kt
@@ -8,7 +8,7 @@ import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Vector
 
@@ -26,7 +26,7 @@ class EndpointParser(parser: KXmlParser) : ElementParser<Endpoint>(parser) {
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     override fun parse(): Endpoint {
         val endpointId = parser.getAttributeValue(null, "id")

--- a/commcare-core/src/main/java/org/commcare/xml/EntryParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/EntryParser.kt
@@ -19,7 +19,7 @@ import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.net.MalformedURLException
 import java.net.URL
@@ -57,7 +57,7 @@ class EntryParser private constructor(
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     override fun parse(): Entry {
         this.checkNode(parserBlockTag)
@@ -126,7 +126,7 @@ class EntryParser private constructor(
         throw RuntimeException("Misconfigured entry parser with unsupported '$parserBlockTag' tag.")
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseCommandDisplay(): DisplayUnit? {
         parser.nextTag()
         var display: DisplayUnit? = null
@@ -145,7 +145,7 @@ class EntryParser private constructor(
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     private fun parseSessionData(data: Vector<SessionDatum>) {
         while (nextTagInBlock("session")) {
@@ -154,7 +154,7 @@ class EntryParser private constructor(
         }
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseStack(stackOps: Vector<StackOperation>) {
         val sop = StackOpParser(parser)
         while (this.nextTagInBlock(StackOpParser.NAME_STACK)) {
@@ -162,7 +162,7 @@ class EntryParser private constructor(
         }
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parsePost(): PostRequest {
         val urlString = parser.getAttributeValue(null, "url")
             ?: throw InvalidStructureException(

--- a/commcare-core/src/main/java/org/commcare/xml/FixtureIndexSchemaParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/FixtureIndexSchemaParser.kt
@@ -6,7 +6,7 @@ import org.javarosa.xml.TreeElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -38,7 +38,7 @@ class FixtureIndexSchemaParser(
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     override fun parse(): FixtureIndexSchema {
         checkNode(INDICE_SCHEMA)

--- a/commcare-core/src/main/java/org/commcare/xml/FixtureXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/FixtureXmlParser.kt
@@ -10,7 +10,7 @@ import org.javarosa.xml.TreeElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -69,7 +69,7 @@ open class FixtureXmlParser(
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     override fun parse(): FormInstance? {
         this.checkNode("fixture")

--- a/commcare-core/src/main/java/org/commcare/xml/GeoOverlayParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/GeoOverlayParser.kt
@@ -5,7 +5,7 @@ import org.commcare.suite.model.GeoOverlay
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -20,7 +20,7 @@ internal class GeoOverlayParser(parser: KXmlParser) : ElementParser<GeoOverlay>(
         private const val NAME_LABEL = "label"
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): GeoOverlay {
         var title: DisplayUnit? = null
         var coordinates: DisplayUnit? = null

--- a/commcare-core/src/main/java/org/commcare/xml/GlobalParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/GlobalParser.kt
@@ -5,7 +5,7 @@ import org.commcare.suite.model.Global
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Vector
 
@@ -19,7 +19,7 @@ internal class GlobalParser(parser: KXmlParser) : ElementParser<Global>(parser) 
         val NAME_GLOBAL: String = "global"
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Global {
         val geoOverlays = Vector<GeoOverlay>()
         while (nextTagInBlock(NAME_GLOBAL)) {

--- a/commcare-core/src/main/java/org/commcare/xml/GraphParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/GraphParser.kt
@@ -13,7 +13,7 @@ import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -21,7 +21,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  */
 open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parser) {
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Graph {
         val graph = Graph()
         val type = parser.getAttributeValue(null, "type")
@@ -54,7 +54,7 @@ open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parse
      * (which contains a single <text>), y (also contains a single <text>),
      * and then another <text> for the annotation's actual text.
      */
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseAnnotation(graph: Graph) {
         checkNode("annotation")
 
@@ -81,7 +81,7 @@ open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parse
     /*
      * Helper for parse; handles a configuration element, which is a set of <text> elements, each with an id.
      */
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseConfiguration(data: Configurable) {
         checkNode("configuration")
 
@@ -100,7 +100,7 @@ open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parse
      * Helper for parse; handles a single series, which is an optional <configuration> followed by an <x>, a <y>,
      * and, if this graph is a bubble graph, a <radius>.
      */
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseSeries(type: String): XYSeries {
         checkNode("series")
         val nodeSet = parser.getAttributeValue(null, "nodeset")
@@ -155,7 +155,7 @@ open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parse
     /*
      * Move parser along until it hits a start tag.
      */
-    @Throws(PlatformIOException::class, XmlPullParserException::class)
+    @Throws(PlatformIOException::class, PlatformXmlParserException::class)
     private fun nextStartTag() {
         do {
             parser.nextTag()

--- a/commcare-core/src/main/java/org/commcare/xml/GridParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/GridParser.kt
@@ -4,7 +4,7 @@ import org.commcare.suite.model.DetailField.Builder
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -17,7 +17,7 @@ class GridParser(
     parser: KXmlParser
 ) : ElementParser<Int>(parser) {
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Int {
         checkNode("grid")
         val gridx = parser.getAttributeValue(null, "grid-x")

--- a/commcare-core/src/main/java/org/commcare/xml/IndexedFixtureXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/IndexedFixtureXmlParser.kt
@@ -12,7 +12,7 @@ import org.javarosa.xml.TreeElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -52,7 +52,7 @@ class IndexedFixtureXmlParser(
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     override fun parse(): StorageIndexedTreeElementModel? {
         checkNode("fixture")

--- a/commcare-core/src/main/java/org/commcare/xml/LedgerXmlParsers.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/LedgerXmlParsers.kt
@@ -7,7 +7,7 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.NoSuchElementException
 import java.util.Vector
@@ -37,7 +37,7 @@ class LedgerXmlParsers(
         private const val FINAL_NAME = "entry"
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Array<Ledger> {
         this.checkNode(arrayOf(TAG_BALANCE, TRANSFER))
 
@@ -67,7 +67,7 @@ class LedgerXmlParsers(
                     object : ElementParser<Array<Ledger>?>(this.parser) {
                         @Throws(
                             InvalidStructureException::class, PlatformIOException::class,
-                            XmlPullParserException::class
+                            PlatformXmlParserException::class
                         )
                         override fun parse(): Array<Ledger>? {
                             val productId = parser.getAttributeValue(null, ENTRY_ID)
@@ -128,7 +128,7 @@ class LedgerXmlParsers(
                     object : ElementParser<Array<Ledger>?>(this.parser) {
                         @Throws(
                             InvalidStructureException::class, PlatformIOException::class,
-                            XmlPullParserException::class
+                            PlatformXmlParserException::class
                         )
                         override fun parse(): Array<Ledger>? {
                             val productId = parser.getAttributeValue(null, ENTRY_ID)

--- a/commcare-core/src/main/java/org/commcare/xml/MarkupParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/MarkupParser.kt
@@ -4,7 +4,7 @@ import org.commcare.suite.model.DetailField.Builder
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 class MarkupParser(
@@ -12,7 +12,7 @@ class MarkupParser(
     parser: KXmlParser
 ) : ElementParser<Int>(parser) {
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Int {
         parser.nextTag()
 

--- a/commcare-core/src/main/java/org/commcare/xml/MenuParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/MenuParser.kt
@@ -9,7 +9,7 @@ import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Hashtable
 import java.util.Vector
@@ -19,7 +19,7 @@ import java.util.Vector
  */
 class MenuParser(parser: KXmlParser) : CommCareElementParser<Menu>(parser) {
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Menu {
         checkNode("menu")
 

--- a/commcare-core/src/main/java/org/commcare/xml/ProfileParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/ProfileParser.kt
@@ -13,7 +13,7 @@ import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
 import java.util.Vector
@@ -44,7 +44,7 @@ class ProfileParser(
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     override fun parse(): Profile {
         checkNode("profile")
@@ -72,7 +72,7 @@ class ProfileParser(
             } while (eventType != KXmlParser.END_DOCUMENT)
 
             return profile
-        } catch (e: XmlPullParserException) {
+        } catch (e: PlatformXmlParserException) {
             // TODO Auto-generated catch block
             e.printStackTrace()
             throw InvalidStructureException("Pull Parse Exception, malformed XML.", parser)
@@ -187,7 +187,7 @@ class ProfileParser(
         }
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseLogin() {
         // Get the resource block or fail out
         getNextTagInBlock("login")
@@ -195,7 +195,7 @@ class ProfileParser(
         table.addResource(resource, table.getInstallers().getLoginImageInstaller(), resourceId, initialResourceStatus)
     }
 
-    @Throws(XmlPullParserException::class, PlatformIOException::class, InvalidStructureException::class)
+    @Throws(PlatformXmlParserException::class, PlatformIOException::class, InvalidStructureException::class)
     private fun parseFeatures(profile: Profile) {
         while (nextTagInBlock("features")) {
             val tag = parser.name.lowercase()
@@ -238,7 +238,7 @@ class ProfileParser(
         }
     }
 
-    @Throws(InvalidStructureException::class, XmlPullParserException::class, PlatformIOException::class)
+    @Throws(InvalidStructureException::class, PlatformXmlParserException::class, PlatformIOException::class)
     private fun parseCredentials(): Vector<Credential> {
         val appCredentials = Vector<Credential>()
         while (nextTagInBlock(NAME_CREDENTIALS)) {
@@ -258,7 +258,7 @@ class ProfileParser(
         return appCredentials
     }
 
-    @Throws(InvalidStructureException::class, XmlPullParserException::class, PlatformIOException::class)
+    @Throws(InvalidStructureException::class, PlatformXmlParserException::class, PlatformIOException::class)
     private fun parseDependencies(): Vector<AndroidPackageDependency> {
         val appDependencies = Vector<AndroidPackageDependency>()
         while (nextTagInBlock(NAME_DEPENDENCIES)) {
@@ -272,7 +272,7 @@ class ProfileParser(
         return appDependencies
     }
 
-    @Throws(InvalidStructureException::class, XmlPullParserException::class, PlatformIOException::class)
+    @Throws(InvalidStructureException::class, PlatformXmlParserException::class, PlatformIOException::class)
     private fun parseSuite() {
         // Get the resource block or fail out
         getNextTagInBlock("suite")

--- a/commcare-core/src/main/java/org/commcare/xml/QueryDataParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/QueryDataParser.kt
@@ -9,7 +9,7 @@ import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -50,7 +50,7 @@ class QueryDataParser(parser: KXmlParser) : CommCareElementParser<QueryData>(par
         }
     }
 
-    @Throws(InvalidStructureException::class, XmlPullParserException::class, PlatformIOException::class)
+    @Throws(InvalidStructureException::class, PlatformXmlParserException::class, PlatformIOException::class)
     override fun parse(): QueryData {
         checkNode("data")
 

--- a/commcare-core/src/main/java/org/commcare/xml/QueryGroupParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/QueryGroupParser.kt
@@ -5,7 +5,7 @@ import org.commcare.suite.model.QueryGroup
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 class QueryGroupParser(parser: KXmlParser) : CommCareElementParser<QueryGroup>(parser) {
@@ -18,7 +18,7 @@ class QueryGroupParser(parser: KXmlParser) : CommCareElementParser<QueryGroup>(p
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     override fun parse(): QueryGroup {
         checkNode(NAME_GROUP)

--- a/commcare-core/src/main/java/org/commcare/xml/QueryPromptParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/QueryPromptParser.kt
@@ -13,7 +13,7 @@ import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 class QueryPromptParser(parser: KXmlParser) : CommCareElementParser<QueryPrompt>(parser) {
@@ -45,7 +45,7 @@ class QueryPromptParser(parser: KXmlParser) : CommCareElementParser<QueryPrompt>
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     override fun parse(): QueryPrompt {
         val appearance = parser.getAttributeValue(null, ATTR_APPEARANCE)
@@ -93,7 +93,7 @@ class QueryPromptParser(parser: KXmlParser) : CommCareElementParser<QueryPrompt>
         )
     }
 
-    @Throws(InvalidStructureException::class, XmlPullParserException::class, PlatformIOException::class)
+    @Throws(InvalidStructureException::class, PlatformXmlParserException::class, PlatformIOException::class)
     private fun parseRequiredBlock(key: String?): QueryPromptCondition {
         val testStr = parser.getAttributeValue(null, ATTR_VALIDATION_TEST)
             ?: throw InvalidStructureException("No test condition defined in <required> for prompt $key")
@@ -111,7 +111,7 @@ class QueryPromptParser(parser: KXmlParser) : CommCareElementParser<QueryPrompt>
         return QueryPromptCondition(test, message)
     }
 
-    @Throws(InvalidStructureException::class, XmlPullParserException::class, PlatformIOException::class)
+    @Throws(InvalidStructureException::class, PlatformXmlParserException::class, PlatformIOException::class)
     private fun parseValidationBlock(key: String?): QueryPromptCondition {
         val testStr = parser.getAttributeValue(null, ATTR_VALIDATION_TEST)
             ?: throw InvalidStructureException("No test condition defined in validation for prompt $key")
@@ -129,7 +129,7 @@ class QueryPromptParser(parser: KXmlParser) : CommCareElementParser<QueryPrompt>
         return QueryPromptCondition(test, message)
     }
 
-    @Throws(PlatformIOException::class, XmlPullParserException::class, InvalidStructureException::class)
+    @Throws(PlatformIOException::class, PlatformXmlParserException::class, InvalidStructureException::class)
     private fun parseItemset(): ItemsetBinding {
         val itemset = ItemsetBinding()
         itemset.contextRef = TreeReference.rootRef()

--- a/commcare-core/src/main/java/org/commcare/xml/ResourceParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/ResourceParser.kt
@@ -6,7 +6,7 @@ import org.commcare.resources.model.ResourceLocation
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Vector
 
@@ -15,7 +15,7 @@ class ResourceParser(
     val maximumAuthority: Int
 ) : ElementParser<Resource>(parser) {
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Resource {
         checkNode("resource")
 

--- a/commcare-core/src/main/java/org/commcare/xml/RootParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/RootParser.kt
@@ -4,7 +4,7 @@ import org.javarosa.core.reference.RootTranslator
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -12,7 +12,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  */
 class RootParser(parser: KXmlParser) : ElementParser<RootTranslator>(parser) {
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): RootTranslator {
         this.checkNode("root")
 

--- a/commcare-core/src/main/java/org/commcare/xml/SessionDatumParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/SessionDatumParser.kt
@@ -15,7 +15,7 @@ import org.javarosa.core.util.OrderedHashtable
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.net.MalformedURLException
 import java.net.URL
@@ -32,7 +32,7 @@ class SessionDatumParser(parser: KXmlParser) : CommCareElementParser<SessionDatu
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     override fun parse(): SessionDatum {
         val name = parser.name
@@ -108,7 +108,7 @@ class SessionDatumParser(parser: KXmlParser) : CommCareElementParser<SessionDatu
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     private fun parseRemoteQueryDatum(): RemoteQueryDatum {
         val userQueryPrompts = OrderedHashtable<String, QueryPrompt>()

--- a/commcare-core/src/main/java/org/commcare/xml/StackFrameStepParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/StackFrameStepParser.kt
@@ -7,7 +7,7 @@ import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.net.MalformedURLException
 import java.net.URL
@@ -17,7 +17,7 @@ import java.net.URL
  */
 internal class StackFrameStepParser(parser: KXmlParser) : ElementParser<StackFrameStep>(parser) {
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): StackFrameStep {
         val operation = parser.name
         val value = parser.getAttributeValue(null, "value")
@@ -37,7 +37,7 @@ internal class StackFrameStepParser(parser: KXmlParser) : ElementParser<StackFra
         }
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseQuery(): StackFrameStep {
         val queryId = parser.getAttributeValue(null, "id")
         val url = parser.getAttributeValue(null, "value")
@@ -59,7 +59,7 @@ internal class StackFrameStepParser(parser: KXmlParser) : ElementParser<StackFra
         return step
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseJump(): StackFrameStep {
         val id = parser.getAttributeValue(null, "id")
         val step = StackFrameStep(SessionFrame.STATE_SMART_LINK, id, null)
@@ -70,7 +70,7 @@ internal class StackFrameStepParser(parser: KXmlParser) : ElementParser<StackFra
         return step
     }
 
-    @Throws(XmlPullParserException::class, PlatformIOException::class, InvalidStructureException::class)
+    @Throws(PlatformXmlParserException::class, PlatformIOException::class, InvalidStructureException::class)
     private fun parseValue(type: String, datumId: String?): StackFrameStep {
         //TODO: ... require this to have a value!!!! It's not processing this properly
         var value = parser.getAttributeValue(null, "value")

--- a/commcare-core/src/main/java/org/commcare/xml/StackOpParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/StackOpParser.kt
@@ -6,7 +6,7 @@ import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Vector
 
@@ -19,7 +19,7 @@ class StackOpParser(parser: KXmlParser) : ElementParser<StackOperation>(parser) 
         const val NAME_STACK: String = "stack"
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): StackOperation {
         val operation = parser.name
 
@@ -50,7 +50,7 @@ class StackOpParser(parser: KXmlParser) : ElementParser<StackOperation>(parser) 
         }
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun getChildren(operation: String): Vector<StackFrameStep> {
         val elements = Vector<StackFrameStep>()
         val sfep = StackFrameStepParser(parser)

--- a/commcare-core/src/main/java/org/commcare/xml/StyleParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/StyleParser.kt
@@ -4,7 +4,7 @@ import org.commcare.suite.model.DetailField.Builder
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
@@ -18,7 +18,7 @@ class StyleParser(
     parser: KXmlParser
 ) : ElementParser<Int>(parser) {
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Int {
         val fontSize = parser.getAttributeValue(null, "font-size")
         builder.setFontSize(fontSize)

--- a/commcare-core/src/main/java/org/commcare/xml/SuiteParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/SuiteParser.kt
@@ -14,7 +14,7 @@ import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
 import java.util.Hashtable
@@ -78,7 +78,7 @@ open class SuiteParser : ElementParser<Suite> {
 
     @Throws(
         InvalidStructureException::class, PlatformIOException::class,
-        XmlPullParserException::class, UnfullfilledRequirementsException::class
+        PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     override fun parse(): Suite {
         checkNode("suite")
@@ -183,7 +183,7 @@ open class SuiteParser : ElementParser<Suite> {
             } while (eventType != KXmlParser.END_DOCUMENT)
 
             return Suite(version, details, entries, menus, endpoints)
-        } catch (e: XmlPullParserException) {
+        } catch (e: PlatformXmlParserException) {
             e.printStackTrace()
             throw InvalidStructureException("Pull Parse Exception, malformed XML.", parser)
         }

--- a/commcare-core/src/main/java/org/commcare/xml/TextParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/TextParser.kt
@@ -5,14 +5,14 @@ import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.parser.XPathSyntaxException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Hashtable
 import java.util.Vector
 
 class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Text {
         val texts = Vector<Text>()
 
@@ -20,7 +20,7 @@ class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
         val entryLevel = parser.depth
         try {
             parser.next()
-        } catch (e: XmlPullParserException) {
+        } catch (e: PlatformXmlParserException) {
             // TODO Auto-generated catch block
             e.printStackTrace()
         } catch (e: PlatformIOException) {
@@ -41,7 +41,7 @@ class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
         }
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     internal fun parseBody(): Text? {
         //TODO: Should prevent compositing text and xpath/locales
         val texts = Vector<Text>()
@@ -89,7 +89,7 @@ class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
         }
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseLocale(): Text {
         checkNode("locale")
         val id = parser.getAttributeValue(null, "id")
@@ -120,7 +120,7 @@ class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
         }
     }
 
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseXPath(): Text {
         checkNode("xpath")
         val function = parser.getAttributeValue(null, "function")

--- a/commcare-core/src/main/java/org/commcare/xml/bulk/BulkElementParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/bulk/BulkElementParser.kt
@@ -6,7 +6,7 @@ import org.javarosa.xml.TreeElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.LinkedHashMap
@@ -55,7 +55,7 @@ abstract class BulkElementParser<T>(parser: KXmlParser) : TransactionParser<Tree
     @Throws(
         InvalidStructureException::class,
         PlatformIOException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         UnfullfilledRequirementsException::class
     )
     override fun parse(): TreeElement {
@@ -71,7 +71,7 @@ abstract class BulkElementParser<T>(parser: KXmlParser) : TransactionParser<Tree
         return subElement
     }
 
-    @Throws(PlatformIOException::class, XmlPullParserException::class, InvalidStructureException::class)
+    @Throws(PlatformIOException::class, PlatformXmlParserException::class, InvalidStructureException::class)
     fun processCurrentBuffer() {
         currentOperatingSet = HashMap()
         performBulkRead(currentBulkReadSet, currentOperatingSet)
@@ -90,7 +90,7 @@ abstract class BulkElementParser<T>(parser: KXmlParser) : TransactionParser<Tree
         currentBulkReadCount = 0
     }
 
-    @Throws(PlatformIOException::class, XmlPullParserException::class, InvalidStructureException::class)
+    @Throws(PlatformIOException::class, PlatformXmlParserException::class, InvalidStructureException::class)
     override fun flush() {
         processCurrentBuffer()
     }
@@ -134,7 +134,7 @@ abstract class BulkElementParser<T>(parser: KXmlParser) : TransactionParser<Tree
      * @param currentOperatingSet the destination mapping from each ID to a matching model
      *                            (if one exists)
      */
-    @Throws(InvalidStructureException::class, PlatformIOException::class, XmlPullParserException::class)
+    @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     protected abstract fun performBulkRead(
         currentBulkReadSet: Set<String>,
         currentOperatingSet: MutableMap<String, T>

--- a/commcare-core/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.kt
@@ -20,7 +20,7 @@ import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.expr.XPathPathExpr
 import org.javarosa.xpath.expr.XPathStringLiteral
 import org.kxml2.io.KXmlParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
 import java.util.Hashtable
@@ -293,7 +293,7 @@ object TreeUtilities {
                 return xmlStreamToTreeElement(inputStream, "instance")
             } catch (e: UnfullfilledRequirementsException) {
                 throw PlatformIOException(e.message)
-            } catch (e: XmlPullParserException) {
+            } catch (e: PlatformXmlParserException) {
                 throw PlatformIOException(e.message)
             }
         } finally {
@@ -312,7 +312,7 @@ object TreeUtilities {
     @Throws(
         PlatformIOException::class,
         UnfullfilledRequirementsException::class,
-        XmlPullParserException::class,
+        PlatformXmlParserException::class,
         InvalidStructureException::class
     )
     fun xmlStreamToTreeElement(stream: InputStream?, instanceId: String?): TreeElement {

--- a/commcare-core/src/main/java/org/javarosa/xform/parse/XFormParser.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/parse/XFormParser.kt
@@ -47,8 +47,8 @@ import org.kxml2.io.KXmlParser
 import org.kxml2.kdom.Document
 import org.kxml2.kdom.Element
 import org.kxml2.kdom.Node
-import org.xmlpull.v1.XmlPullParser
-import org.xmlpull.v1.XmlPullParserException
+import org.javarosa.xml.PlatformXmlParser
+import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
 import java.io.InputStreamReader
@@ -612,9 +612,9 @@ class XFormParser {
                 }
 
                 parser.setInput(reader)
-                parser.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true)
+                parser.setFeature(PlatformXmlParser.FEATURE_PROCESS_NAMESPACES, true)
                 doc.parse(parser)
-            } catch (e: XmlPullParserException) {
+            } catch (e: PlatformXmlParserException) {
                 val errorMsg = "XML Syntax Error at Line: ${e.lineNumber}, Column: ${e.columnNumber}!"
                 System.err.println(errorMsg)
                 e.printStackTrace()


### PR DESCRIPTION
## Summary
- Create `PlatformXmlParserException` expect/actual (typealias to `XmlPullParserException` on JVM, `Exception` subclass on iOS)
- Replace `XmlPullParserException` with `PlatformXmlParserException` across 20 .kt files
- Replace `XmlPullParser` import/constants with `PlatformXmlParser` in 41 .kt files
- 63 `kxml2` imports remain — these files extend Java base classes (`ElementParser`, `TransactionParser`) and require the kxml2 library directly

## Key decisions
- **kxml2 direct usage cannot be abstracted**: 46 files use `KXmlParser` as constructor parameter type (passed by Java `ElementParser` base class). 8 files use `kxml2.kdom.Element` DOM types. These require the kxml2 library and stay in jvmMain.
- **Java base classes block commonMain migration**: `ElementParser.java` and `TransactionParser.java` create `KXmlParser` instances from `InputStream` and pass them to Kotlin subclasses. Moving these parsers requires converting Java base classes too.

## Test plan
- [x] `./gradlew build` passes (includes metadata, JVM, Java compilation + tests)
- [x] 748 tests, 0 failures
- [x] No `org.xmlpull` imports in commonMain

🤖 Generated with [Claude Code](https://claude.com/claude-code)