### PR TITLE
docs: iOS CI learnings and status updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ commcare-ios/
 | 5 | Move pure Kotlin to commonMain | 82 moved | #38 | Done (PR #51) |
 | 6 | Migrate serialization consumers | 208 mod, 87 commonMain | #39 | Done (PR #53) |
 | 7 | Migrate XML consumers | 54 mod | #40 | Done (PR #55) |
-| 8 | iOS app shell | 12 new | #41 | Done (PR #57, needs macOS verify) |
+| 8 | iOS app shell | 12 new | #41 | Done (PR #57, iOS CI verified PR #60) |
 | 9 | E2E validation | ~5 new | #42 | Open (needs macOS) |
 
 **Dependency graph:** Waves 1-4 create abstractions (can partially overlap). Waves 5-7 move files (depend on respective abstraction waves). Wave 8 needs macOS. Wave 9 is final validation.
@@ -86,6 +86,8 @@ commcare-ios/
 - **Wave 5 case-management learnings**: `docs/learnings/2026-03-09-wave5-case-management-learnings.md` — JVM signature clashes (constructor `val` vs interface method, field vs getter), Java boxed types in generics, Kotlin-to-Kotlin method calls
 - **Wave 6 suite-session learnings**: `docs/learnings/2026-03-10-wave6-suite-session-learnings.md` — `internal` hides from Java in other source sets, property getter/setter clashes, nullable return types Java silently allowed
 - **Wave 8 core-services learnings**: `docs/learnings/2026-03-10-wave8-core-services-learnings.md` — `@JvmField protected` for cross-source-set Java subclasses, OkHttp 4/Okio 2 API migration, `const val` requires compile-time constants
+- **Phase 2 KMP migration learnings**: `docs/learnings/2026-03-10-wave6-7-kmp-migration-learnings.md` — compileCommonMainKotlinMetadata strictness, transitive dependency bottleneck, PlatformIOException typealias
+- **iOS CI learnings**: `docs/learnings/2026-03-10-ios-ci-learnings.md` — iOS-specific API differences, commonMain visibility from app module, CI strategy
 
 ## Kotlin Conversion Checklist
 

--- a/docs/learnings/2026-03-10-ios-ci-learnings.md
+++ b/docs/learnings/2026-03-10-ios-ci-learnings.md
@@ -1,0 +1,32 @@
+# iOS CI and Build Learnings
+
+## String(CharArray, Int, Int) is deprecated on iOS/Native
+
+**Problem:** `PlatformDataInputStream.readUTF()` used `String(chars, 0, charCount)` which compiled fine on JVM but failed on iOS Native with a deprecation error (treated as error in framework linking).
+
+**Fix:** Use `chars.concatToString(0, charCount)` — the Kotlin common stdlib replacement.
+
+**Lesson:** `String(CharArray)` and `String(CharArray, Int, Int)` constructors are JVM-specific. In commonMain or iosMain, use `CharArray.concatToString()`.
+
+## App commonMain can only see commcare-core commonMain
+
+**Problem:** `app/src/commonMain/` imported `XPathParseTool` from commcare-core, but XPathParseTool is in `src/main/java/` (jvmMain), not commonMain.
+
+**Root cause:** KMP dependency resolution for commonMain only exposes the dependency's commonMain source set. The app's commonMain cannot see any jvmMain or iosMain code from commcare-core.
+
+**Fix:** The app's commonMain can only reference types defined in commcare-core's commonMain (e.g., `PlatformIOException`, `ListMultimap`, `PlatformDataInputStream`). For now, the app shell uses a static screen — the real verification is that `linkDebugFrameworkIosSimulatorArm64` succeeds, confirming the iOS framework links correctly.
+
+**Lesson:** When adding engine integration to the app, either move the needed types to commonMain or create expect/actual wrappers.
+
+## iOS CI requires macOS runners
+
+**Problem:** Linux CI agents cannot build iOS frameworks — Kotlin/Native iOS compilation requires Xcode toolchain.
+
+**Solution:** Use `runs-on: macos-14` in GitHub Actions for iOS builds. The workflow runs `linkDebugFrameworkIosSimulatorArm64` which compiles all commonMain + iosMain Kotlin code into a native iOS framework.
+
+**CI strategy:**
+- `kotlin-tests.yml` — runs on Linux, tests JVM compilation + unit tests (fast, ~1.5min)
+- `ios-build.yml` — runs on macOS-14, builds iOS framework (slower, ~6min)
+- Both trigger on PRs touching `commcare-core/`
+
+**Lesson:** Keep iOS CI enabled on PRs touching commcare-core so regressions in commonMain/iosMain are caught early. The macOS runner cost is justified by catching iOS-specific issues that JVM tests miss.


### PR DESCRIPTION
## Summary
- Add `docs/learnings/2026-03-10-ios-ci-learnings.md` with three learnings from enabling iOS CI:
  - `String(CharArray, Int, Int)` deprecated on Native — use `concatToString()`
  - App commonMain can only see commcare-core commonMain (not jvmMain)
  - iOS CI requires macOS runners, strategy for dual CI workflows
- Update CLAUDE.md Wave 8 status: "needs macOS verify" → "iOS CI verified PR #60"
- Add Wave 6-7 KMP and iOS CI learnings to Key Docs section

## Test plan
- [x] Doc-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)