### PR TITLE
Phase 3 Wave 2: Migrate XML consumers to PlatformXmlParser

### DIFF
--- a/commcare-core/src/commonMain/kotlin/org/javarosa/xml/PlatformXmlParser.kt
+++ b/commcare-core/src/commonMain/kotlin/org/javarosa/xml/PlatformXmlParser.kt
@@ -4,22 +4,41 @@ package org.javarosa.xml
  * Cross-platform XML pull parser interface mirroring XmlPullParser/KXmlParser API.
  * On JVM, implemented by wrapping kxml2's KXmlParser.
  * On iOS, implemented with a pure Kotlin state-machine parser.
+ *
+ * Simple getters are declared as Kotlin properties so that both
+ * property syntax (parser.name) and getter syntax (parser.getName())
+ * work seamlessly from Kotlin and Java callers.
  */
 interface PlatformXmlParser {
     fun next(): Int
-    fun getEventType(): Int
-    fun getName(): String?
-    fun getNamespace(): String?
-    fun getText(): String?
-    fun isWhitespace(): Boolean
-    fun getDepth(): Int
+    val eventType: Int
+    val name: String?
+    val namespace: String?
+    val text: String?
+    val isWhitespace: Boolean
+    val depth: Int
+    val attributeCount: Int
+    val positionDescription: String
+    val prefix: String?
+
     fun getAttributeValue(namespace: String?, name: String): String?
-    fun getAttributeCount(): Int
     fun getAttributeName(index: Int): String
     fun getAttributeNamespace(index: Int): String
     fun getAttributePrefix(index: Int): String?
     fun getAttributeValue(index: Int): String
     fun getNamespace(prefix: String?): String
+
+    /**
+     * Returns the text content of the current element.
+     * Advances parser past the end tag.
+     */
+    fun nextText(): String
+
+    /**
+     * Advances to the next start or end tag, skipping whitespace text events.
+     * Returns the event type (START_TAG or END_TAG).
+     */
+    fun nextTag(): Int
 
     companion object {
         const val START_DOCUMENT = 0

--- a/commcare-core/src/commonTest/kotlin/org/javarosa/xml/XmlParserTest.kt
+++ b/commcare-core/src/commonTest/kotlin/org/javarosa/xml/XmlParserTest.kt
@@ -15,16 +15,16 @@ class XmlParserTest {
         val xml = "<root>hello</root>"
         val parser = createXmlParser(xml.encodeToByteArray())
 
-        assertEquals(PlatformXmlParser.START_DOCUMENT, parser.getEventType())
+        assertEquals(PlatformXmlParser.START_DOCUMENT, parser.eventType)
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next())
-        assertEquals("root", parser.getName())
+        assertEquals("root", parser.name)
 
         assertEquals(PlatformXmlParser.TEXT, parser.next())
-        assertEquals("hello", parser.getText())
+        assertEquals("hello", parser.text)
 
         assertEquals(PlatformXmlParser.END_TAG, parser.next())
-        assertEquals("root", parser.getName())
+        assertEquals("root", parser.name)
 
         assertEquals(PlatformXmlParser.END_DOCUMENT, parser.next())
     }
@@ -35,8 +35,8 @@ class XmlParserTest {
         val parser = createXmlParser(xml.encodeToByteArray())
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next())
-        assertEquals("item", parser.getName())
-        assertEquals(2, parser.getAttributeCount())
+        assertEquals("item", parser.name)
+        assertEquals(2, parser.attributeCount)
         assertEquals("123", parser.getAttributeValue(null, "id"))
         assertEquals("case", parser.getAttributeValue(null, "type"))
     }
@@ -58,9 +58,9 @@ class XmlParserTest {
         var foundCaseName = false
         var caseNameText: String? = null
         while (parser.next() != PlatformXmlParser.END_DOCUMENT) {
-            if (parser.getEventType() == PlatformXmlParser.START_TAG && parser.getName() == "case_name") {
+            if (parser.eventType == PlatformXmlParser.START_TAG && parser.name == "case_name") {
                 parser.next() // TEXT
-                caseNameText = parser.getText()
+                caseNameText = parser.text
                 foundCaseName = true
                 break
             }
@@ -76,19 +76,19 @@ class XmlParserTest {
         val parser = createXmlParser(xml.encodeToByteArray())
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next()) // data
-        assertEquals("data", parser.getName())
+        assertEquals("data", parser.name)
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next()) // empty
-        assertEquals("empty", parser.getName())
+        assertEquals("empty", parser.name)
 
         assertEquals(PlatformXmlParser.END_TAG, parser.next()) // /empty
-        assertEquals("empty", parser.getName())
+        assertEquals("empty", parser.name)
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next()) // next
-        assertEquals("next", parser.getName())
+        assertEquals("next", parser.name)
 
         assertEquals(PlatformXmlParser.TEXT, parser.next())
-        assertEquals("ok", parser.getText())
+        assertEquals("ok", parser.text)
     }
 
     @Test
@@ -97,12 +97,12 @@ class XmlParserTest {
         val parser = createXmlParser(xml.encodeToByteArray())
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next())
-        assertEquals("html", parser.getName())
-        assertEquals("http://www.w3.org/1999/xhtml", parser.getNamespace())
+        assertEquals("html", parser.name)
+        assertEquals("http://www.w3.org/1999/xhtml", parser.namespace)
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next())
-        assertEquals("body", parser.getName())
-        assertEquals("http://www.w3.org/1999/xhtml", parser.getNamespace())
+        assertEquals("body", parser.name)
+        assertEquals("http://www.w3.org/1999/xhtml", parser.namespace)
     }
 
     @Test
@@ -112,7 +112,7 @@ class XmlParserTest {
 
         parser.next() // START_TAG
         parser.next() // TEXT
-        assertEquals("1 < 2 & 3 > 0", parser.getText())
+        assertEquals("1 < 2 & 3 > 0", parser.text)
     }
 
     @Test
@@ -122,7 +122,7 @@ class XmlParserTest {
 
         parser.next() // START_TAG
         parser.next() // TEXT (CDATA content)
-        assertEquals("<not>xml</not>", parser.getText())
+        assertEquals("<not>xml</not>", parser.text)
     }
 
     @Test
@@ -153,8 +153,8 @@ class XmlParserTest {
         // Verify we can walk the entire XForm without errors
         val elementNames = mutableListOf<String>()
         while (parser.next() != PlatformXmlParser.END_DOCUMENT) {
-            if (parser.getEventType() == PlatformXmlParser.START_TAG) {
-                elementNames.add(parser.getName()!!)
+            if (parser.eventType == PlatformXmlParser.START_TAG) {
+                elementNames.add(parser.name!!)
             }
         }
 
@@ -178,7 +178,7 @@ class XmlParserTest {
         // Verify correct event sequence regardless of depth reporting details
         val events = mutableListOf<Pair<Int, String?>>()
         while (parser.next() != PlatformXmlParser.END_DOCUMENT) {
-            events.add(Pair(parser.getEventType(), parser.getName()))
+            events.add(Pair(parser.eventType, parser.name))
         }
 
         assertEquals(PlatformXmlParser.START_TAG, events[0].first)

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/xml/PlatformXmlParserIos.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/xml/PlatformXmlParserIos.kt
@@ -11,15 +11,15 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
 
     private val input: String = data.decodeToString()
     private var pos = 0
-    private var eventType = PlatformXmlParser.START_DOCUMENT
-    private var depth = 0
+    private var _eventType = PlatformXmlParser.START_DOCUMENT
+    private var _depth = 0
 
     // Current event state
     private var currentName: String? = null
     private var currentNamespace: String? = null
     private var currentText: String? = null
     private var currentPrefix: String? = null
-    private var attributes = mutableListOf<Attribute>()
+    private var _attributes = mutableListOf<Attribute>()
     private var isEmptyElement = false
     private var pendingEndTag = false
 
@@ -36,16 +36,16 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
     override fun next(): Int {
         if (pendingEndTag) {
             pendingEndTag = false
-            depth--
-            eventType = PlatformXmlParser.END_TAG
-            return eventType
+            _depth--
+            _eventType = PlatformXmlParser.END_TAG
+            return _eventType
         }
 
         skipWhitespaceAndComments()
 
         if (pos >= input.length) {
-            eventType = PlatformXmlParser.END_DOCUMENT
-            return eventType
+            _eventType = PlatformXmlParser.END_DOCUMENT
+            return _eventType
         }
 
         if (input[pos] == '<') {
@@ -72,32 +72,32 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
             parseText()
         }
 
-        return eventType
+        return _eventType
     }
 
-    override fun getEventType(): Int = eventType
-    override fun getName(): String? = currentName
-    override fun getNamespace(): String? = currentNamespace
-    override fun getText(): String? = currentText
-    override fun getDepth(): Int = depth
+    override val eventType: Int get() = _eventType
+    override val name: String? get() = currentName
+    override val namespace: String? get() = currentNamespace
+    override val text: String? get() = currentText
+    override val depth: Int get() = _depth
 
-    override fun isWhitespace(): Boolean {
-        val text = currentText ?: return true
-        return text.all { it == ' ' || it == '\t' || it == '\n' || it == '\r' }
+    override val isWhitespace: Boolean get() {
+        val t = currentText ?: return true
+        return t.all { it == ' ' || it == '\t' || it == '\n' || it == '\r' }
     }
 
     override fun getAttributeValue(namespace: String?, name: String): String? {
-        return attributes.find { attr ->
+        return _attributes.find { attr ->
             attr.name == name && (namespace == null || namespace.isEmpty() || attr.namespace == namespace)
         }?.value
     }
 
-    override fun getAttributeCount(): Int = attributes.size
+    override val attributeCount: Int get() = _attributes.size
 
-    override fun getAttributeName(index: Int): String = attributes[index].name
-    override fun getAttributeNamespace(index: Int): String = attributes[index].namespace
-    override fun getAttributePrefix(index: Int): String? = attributes[index].prefix
-    override fun getAttributeValue(index: Int): String = attributes[index].value
+    override fun getAttributeName(index: Int): String = _attributes[index].name
+    override fun getAttributeNamespace(index: Int): String = _attributes[index].namespace
+    override fun getAttributePrefix(index: Int): String? = _attributes[index].prefix
+    override fun getAttributeValue(index: Int): String = _attributes[index].value
 
     override fun getNamespace(prefix: String?): String {
         val p = prefix ?: ""
@@ -107,12 +107,46 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
         return ""
     }
 
+    override fun nextText(): String {
+        if (_eventType != PlatformXmlParser.START_TAG) {
+            throw RuntimeException("nextText() called not on START_TAG")
+        }
+        val event = next()
+        if (event == PlatformXmlParser.TEXT) {
+            val result = currentText ?: ""
+            val endEvent = next()
+            if (endEvent != PlatformXmlParser.END_TAG) {
+                throw RuntimeException("nextText(): expected END_TAG after text, got $endEvent")
+            }
+            return result
+        } else if (event == PlatformXmlParser.END_TAG) {
+            return ""
+        } else {
+            throw RuntimeException("nextText(): unexpected event type $event")
+        }
+    }
+
+    override fun nextTag(): Int {
+        var event = next()
+        while (event == PlatformXmlParser.TEXT && isWhitespace) {
+            event = next()
+        }
+        if (event != PlatformXmlParser.START_TAG && event != PlatformXmlParser.END_TAG) {
+            throw RuntimeException("nextTag(): unexpected event type $event")
+        }
+        return event
+    }
+
+    override val positionDescription: String get() = "@position $pos"
+
+    override val prefix: String? get() = currentPrefix
+
     // --- Parsing Methods ---
 
     private fun parseStartTag() {
         pos++ // skip '<'
         val qname = readName()
-        attributes.clear()
+        _attributes.clear()
         val nsDeclarations = mutableMapOf<String, String>()
 
         // Parse attributes
@@ -132,7 +166,7 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
                 nsDeclarations[attrQName.substring(6)] = attrValue
             } else {
                 val (attrPrefix, attrLocal) = splitQName(attrQName)
-                attributes.add(Attribute("", attrPrefix, attrLocal, attrValue))
+                _attributes.add(Attribute("", attrPrefix, attrLocal, attrValue))
             }
         }
 
@@ -144,23 +178,23 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
         }
         expect('>')
 
-        depth++
+        _depth++
 
         // Push namespace scope
-        while (namespaceStack.size < depth) {
+        while (namespaceStack.size < _depth) {
             namespaceStack.add(mutableMapOf())
         }
-        namespaceStack[depth - 1] = nsDeclarations.toMutableMap()
+        namespaceStack[_depth - 1] = nsDeclarations.toMutableMap()
 
         // Resolve element namespace
-        val (prefix, localName) = splitQName(qname)
-        currentPrefix = prefix
+        val (pfx, localName) = splitQName(qname)
+        currentPrefix = pfx
         currentName = localName
-        currentNamespace = resolveNamespace(prefix)
+        currentNamespace = resolveNamespace(pfx)
         currentText = null
 
         // Resolve attribute namespaces
-        attributes = attributes.map { attr ->
+        _attributes = _attributes.map { attr ->
             if (attr.prefix != null && attr.prefix.isNotEmpty()) {
                 attr.copy(namespace = resolveNamespace(attr.prefix))
             } else {
@@ -168,7 +202,7 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
             }
         }.toMutableList()
 
-        eventType = PlatformXmlParser.START_TAG
+        _eventType = PlatformXmlParser.START_TAG
 
         if (isEmptyElement) {
             pendingEndTag = true
@@ -181,19 +215,19 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
         skipSpaces()
         expect('>')
 
-        val (prefix, localName) = splitQName(qname)
+        val (pfx, localName) = splitQName(qname)
         currentName = localName
-        currentNamespace = resolveNamespace(prefix)
+        currentNamespace = resolveNamespace(pfx)
         currentText = null
-        attributes.clear()
+        _attributes.clear()
 
         // Pop namespace scope
-        if (depth > 0 && depth <= namespaceStack.size) {
-            namespaceStack[depth - 1].clear()
+        if (_depth > 0 && _depth <= namespaceStack.size) {
+            namespaceStack[_depth - 1].clear()
         }
-        depth--
+        _depth--
 
-        eventType = PlatformXmlParser.END_TAG
+        _eventType = PlatformXmlParser.END_TAG
     }
 
     private fun parseText() {
@@ -204,8 +238,8 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
         currentText = decodeEntities(input.substring(start, pos))
         currentName = null
         currentNamespace = null
-        attributes.clear()
-        eventType = PlatformXmlParser.TEXT
+        _attributes.clear()
+        _eventType = PlatformXmlParser.TEXT
     }
 
     private fun parseCData() {
@@ -216,8 +250,8 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
         pos = end + 3
         currentName = null
         currentNamespace = null
-        attributes.clear()
-        eventType = PlatformXmlParser.TEXT
+        _attributes.clear()
+        _eventType = PlatformXmlParser.TEXT
     }
 
     private fun parseProcessingInstruction() {
@@ -227,13 +261,11 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
     }
 
     private fun skipDeclaration() {
-        // Handle <!-- ... --> comments and <!DOCTYPE ...>
         if (input.startsWith("<!--", pos)) {
             val end = input.indexOf("-->", pos + 4)
             if (end == -1) throw RuntimeException("Unclosed comment")
             pos = end + 3
         } else {
-            // DOCTYPE or other declaration — skip to matching >
             var nestLevel = 1
             pos += 2 // skip "<!"
             while (pos < input.length && nestLevel > 0) {
@@ -266,13 +298,13 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
     private fun readAttributeValue(): String {
         val quote = input[pos]
         if (quote != '"' && quote != '\'') throw RuntimeException("Expected quote at position $pos")
-        pos++ // skip opening quote
+        pos++
         val start = pos
         while (pos < input.length && input[pos] != quote) {
             pos++
         }
         val value = input.substring(start, pos)
-        pos++ // skip closing quote
+        pos++
         return decodeEntities(value)
     }
 
@@ -331,7 +363,7 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
                         } else if (entity.startsWith("#")) {
                             sb.append(entity.substring(1).toInt().toChar())
                         } else {
-                            sb.append("&$entity;") // unknown entity, preserve as-is
+                            sb.append("&$entity;")
                         }
                     }
                 }

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/PlatformXmlParserJvm.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/PlatformXmlParserJvm.kt
@@ -2,33 +2,38 @@ package org.javarosa.xml
 
 import org.kxml2.io.KXmlParser
 import java.io.ByteArrayInputStream
+import java.io.InputStream
 
 /**
  * JVM implementation of PlatformXmlParser wrapping kxml2's KXmlParser.
  */
-class JvmXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
-    private val parser = KXmlParser()
+class JvmXmlParser private constructor(private val parser: KXmlParser) : PlatformXmlParser {
 
-    init {
+    constructor(data: ByteArray, encoding: String) : this(KXmlParser()) {
         parser.setInput(ByteArrayInputStream(data), encoding)
         parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, true)
     }
 
     override fun next(): Int = mapEventType(parser.next())
-    override fun getEventType(): Int = mapEventType(parser.eventType)
-    override fun getName(): String? = parser.name
-    override fun getNamespace(): String? = parser.namespace
-    override fun getText(): String? = parser.text
-    override fun isWhitespace(): Boolean = parser.isWhitespace
-    override fun getDepth(): Int = parser.depth
+    override val eventType: Int get() = mapEventType(parser.eventType)
+    override val name: String? get() = parser.name
+    override val namespace: String? get() = parser.namespace
+    override val text: String? get() = parser.text
+    override val isWhitespace: Boolean get() = parser.isWhitespace
+    override val depth: Int get() = parser.depth
+    override val attributeCount: Int get() = parser.attributeCount
+    override val positionDescription: String get() = parser.positionDescription
+    override val prefix: String? get() = parser.prefix
+
     override fun getAttributeValue(namespace: String?, name: String): String? =
         parser.getAttributeValue(namespace, name)
-    override fun getAttributeCount(): Int = parser.attributeCount
     override fun getAttributeName(index: Int): String = parser.getAttributeName(index)
     override fun getAttributeNamespace(index: Int): String = parser.getAttributeNamespace(index)
     override fun getAttributePrefix(index: Int): String? = parser.getAttributePrefix(index)
     override fun getAttributeValue(index: Int): String = parser.getAttributeValue(index)
     override fun getNamespace(prefix: String?): String = parser.getNamespace(prefix)
+    override fun nextText(): String = parser.nextText()
+    override fun nextTag(): Int = mapEventType(parser.nextTag())
 
     private fun mapEventType(kxmlType: Int): Int {
         return when (kxmlType) {
@@ -38,6 +43,28 @@ class JvmXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
             KXmlParser.END_TAG -> PlatformXmlParser.END_TAG
             KXmlParser.TEXT -> PlatformXmlParser.TEXT
             else -> kxmlType
+        }
+    }
+
+    companion object {
+        /**
+         * Wrap an existing KXmlParser instance as a PlatformXmlParser.
+         * The KXmlParser should already be configured (setInput, setFeature called).
+         */
+        @JvmStatic
+        fun wrap(parser: KXmlParser): JvmXmlParser = JvmXmlParser(parser)
+
+        /**
+         * Create a PlatformXmlParser from an InputStream.
+         * Configures namespace processing and advances past START_DOCUMENT.
+         */
+        @JvmStatic
+        fun fromStream(stream: InputStream): PlatformXmlParser {
+            val parser = KXmlParser()
+            parser.setInput(stream, "UTF-8")
+            parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, true)
+            parser.next() // advance past START_DOCUMENT to first tag
+            return JvmXmlParser(parser)
         }
     }
 }

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/PlatformXmlSerializerJvm.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/PlatformXmlSerializerJvm.kt
@@ -2,16 +2,31 @@ package org.javarosa.xml
 
 import org.kxml2.io.KXmlSerializer
 import java.io.ByteArrayOutputStream
+import java.io.OutputStream
 
 /**
  * JVM implementation of PlatformXmlSerializer wrapping kxml2's KXmlSerializer.
  */
-class JvmXmlSerializer : PlatformXmlSerializer {
-    private val baos = ByteArrayOutputStream()
-    private val serializer = KXmlSerializer()
+class JvmXmlSerializer private constructor(
+    internal val serializer: KXmlSerializer,
+    private val baos: ByteArrayOutputStream?
+) : PlatformXmlSerializer {
 
-    init {
-        serializer.setOutput(baos, "UTF-8")
+    constructor() : this(KXmlSerializer(), ByteArrayOutputStream()) {
+        serializer.setOutput(baos!!, "UTF-8")
+    }
+
+    constructor(stream: OutputStream, encoding: String) : this(KXmlSerializer(), null) {
+        serializer.setOutput(stream, encoding)
+    }
+
+    companion object {
+        /**
+         * Wrap an existing KXmlSerializer instance as a PlatformXmlSerializer.
+         * The KXmlSerializer should already be configured (setOutput called).
+         */
+        @JvmStatic
+        fun wrap(serializer: KXmlSerializer): JvmXmlSerializer = JvmXmlSerializer(serializer, null)
     }
 
     override fun startDocument(encoding: String?, standalone: Boolean?) {
@@ -48,7 +63,9 @@ class JvmXmlSerializer : PlatformXmlSerializer {
 
     override fun toByteArray(): ByteArray {
         serializer.flush()
-        return baos.toByteArray()
+        return baos?.toByteArray() ?: throw UnsupportedOperationException(
+            "toByteArray() not supported for stream-based serializer"
+        )
     }
 }
 

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/dom/InterningKXmlParserJvm.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/dom/InterningKXmlParserJvm.kt
@@ -1,0 +1,37 @@
+package org.javarosa.xml.dom
+
+import org.javarosa.core.util.Interner
+import org.kxml2.io.KXmlParser
+
+/**
+ * JVM-only KXmlParser subclass that interns string results.
+ * Used during Document.parse() to ensure DOM nodes contain interned strings.
+ * This extends KXmlParser directly so it can be passed to Document.parse().
+ */
+internal class InterningKXmlParserJvm(
+    private val stringCache: Interner<String>
+) : KXmlParser() {
+
+    override fun getAttributeName(index: Int): String =
+        stringCache.intern(super.getAttributeName(index))
+
+    override fun getAttributeNamespace(index: Int): String =
+        stringCache.intern(super.getAttributeNamespace(index))
+
+    override fun getAttributePrefix(index: Int): String? {
+        val value = super.getAttributePrefix(index) ?: return null
+        return stringCache.intern(value)
+    }
+
+    override fun getAttributeValue(index: Int): String =
+        stringCache.intern(super.getAttributeValue(index))
+
+    override fun getNamespace(prefix: String?): String =
+        stringCache.intern(super.getNamespace(prefix))
+
+    override fun getText(): String =
+        stringCache.intern(super.getText())
+
+    override fun getName(): String =
+        stringCache.intern(super.getName())
+}

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/dom/XmlDocumentHelper.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/dom/XmlDocumentHelper.kt
@@ -1,0 +1,33 @@
+package org.javarosa.xml.dom
+
+import org.javarosa.core.util.Interner
+import org.kxml2.io.KXmlParser
+import java.io.Reader
+
+/**
+ * JVM-only helper for parsing XML documents using kxml2's DOM.
+ * Encapsulates the KXmlParser creation and Document.parse() calls
+ * so that consumer code doesn't need to import kxml2 directly.
+ */
+object XmlDocumentHelper {
+
+    /**
+     * Parse an XML document from a Reader into a kxml2 Document.
+     * Optionally applies string interning for memory efficiency.
+     */
+    @JvmStatic
+    fun parseDocument(reader: Reader, stringCache: Interner<String>?): XmlDocument {
+        val parser: KXmlParser = if (stringCache != null) {
+            InterningKXmlParserJvm(stringCache)
+        } else {
+            KXmlParser()
+        }
+
+        parser.setInput(reader)
+        parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, true)
+
+        val doc = XmlDocument()
+        doc.parse(parser)
+        return doc
+    }
+}

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/dom/XmlDomExtensions.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/dom/XmlDomExtensions.kt
@@ -1,0 +1,57 @@
+package org.javarosa.xml.dom
+
+import org.javarosa.xml.JvmXmlSerializer
+import org.kxml2.io.KXmlSerializer
+import java.io.ByteArrayOutputStream
+import java.io.DataOutputStream
+import java.io.OutputStreamWriter
+
+/**
+ * JVM-only extensions for kxml2 DOM serialization.
+ * These provide the bridge between PlatformXmlSerializer and kxml2's write() methods.
+ */
+object XmlDomWriter {
+
+    /**
+     * Serialize an Element to a String.
+     */
+    @JvmStatic
+    fun elementToString(e: XmlElement): String? {
+        val serializer = KXmlSerializer()
+        val bos = ByteArrayOutputStream()
+        val dos = DataOutputStream(bos)
+        try {
+            serializer.setOutput(dos, null)
+            e.write(serializer)
+            serializer.flush()
+            return String(bos.toByteArray(), Charsets.UTF_8)
+        } catch (ex: Exception) {
+            ex.printStackTrace()
+            return null
+        }
+    }
+
+    /**
+     * Serialize a Document to UTF-8 bytes, checking for unsupported unicode surrogates.
+     */
+    @JvmStatic
+    fun getUtfBytesFromDocument(doc: XmlDocument): ByteArray {
+        val serializer = object : KXmlSerializer() {
+            override fun text(text: String): org.xmlpull.v1.XmlSerializer {
+                try {
+                    return super.text(text)
+                } catch (e: IllegalArgumentException) {
+                    throw UnsupportedUnicodeSurrogatesException(text)
+                }
+            }
+        }
+        val bos = ByteArrayOutputStream()
+        val osw = OutputStreamWriter(bos, "UTF-8")
+        serializer.setOutput(osw)
+        doc.write(serializer)
+        serializer.flush()
+        return bos.toByteArray()
+    }
+
+    class UnsupportedUnicodeSurrogatesException(message: String) : RuntimeException(message)
+}

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/dom/XmlDomTypealiases.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/dom/XmlDomTypealiases.kt
@@ -1,0 +1,10 @@
+package org.javarosa.xml.dom
+
+/**
+ * JVM-only typealiases for kxml2 DOM types.
+ * These files use the kxml2 DOM tree for XForm parsing on JVM.
+ * On iOS, an alternative DOM implementation will be needed.
+ */
+typealias XmlDocument = org.kxml2.kdom.Document
+typealias XmlElement = org.kxml2.kdom.Element
+typealias XmlNode = org.kxml2.kdom.Node

--- a/commcare-core/src/main/java/org/commcare/core/parse/CaseInstanceXmlTransactionParserFactory.kt
+++ b/commcare-core/src/main/java/org/commcare/core/parse/CaseInstanceXmlTransactionParserFactory.kt
@@ -5,7 +5,7 @@ import org.commcare.data.xml.TransactionParser
 import org.commcare.data.xml.TransactionParserFactory
 import org.commcare.modern.engine.cases.CaseIndexTable
 import org.commcare.xml.bulk.BulkCaseInstanceXmlParser
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Transaction factory for parsing the case instance xml as defined in
@@ -28,7 +28,7 @@ class CaseInstanceXmlTransactionParserFactory(
         return object : TransactionParserFactory {
             var created: BulkCaseInstanceXmlParser? = null
 
-            override fun getParser(parser: KXmlParser): TransactionParser<*> {
+            override fun getParser(parser: PlatformXmlParser): TransactionParser<*> {
                 if (created == null) {
                     created = BulkCaseInstanceXmlParser(parser, sandbox.getCaseStorage(), caseIndexTable)
                 }
@@ -37,7 +37,7 @@ class CaseInstanceXmlTransactionParserFactory(
         }
     }
 
-    override fun getParser(parser: KXmlParser): TransactionParser<*>? {
+    override fun getParser(parser: PlatformXmlParser): TransactionParser<*>? {
         val name = parser.name
         if ("case".equals(name, ignoreCase = true)) {
             return caseParser.getParser(parser)

--- a/commcare-core/src/main/java/org/commcare/core/parse/CommCareTransactionParserFactory.kt
+++ b/commcare-core/src/main/java/org/commcare/core/parse/CommCareTransactionParserFactory.kt
@@ -12,9 +12,9 @@ import org.commcare.xml.LedgerXmlParsers
 import org.commcare.xml.bulk.LinearBulkProcessingCaseXmlParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * The CommCare Transaction Parser Factory (whew!) wraps all of the current
@@ -64,7 +64,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
         this.initStockParser()
     }
 
-    override fun getParser(parser: KXmlParser): TransactionParser<*>? {
+    override fun getParser(parser: PlatformXmlParser): TransactionParser<*>? {
         val namespace = parser.namespace
         val name = parser.name
         if (LedgerXmlParsers.STOCK_XML_NAMESPACE == namespace) {
@@ -92,7 +92,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
             val isIndexedAttr = parser.getAttributeValue(null, "indexed")
             val isIndexed = "true" == isIndexedAttr
             req()
-            processedFixtures.add(id)
+            processedFixtures.add(id!!)
             if (isIndexed) {
                 val schema = fixtureSchemas[id]
                 return IndexedFixtureXmlParser(parser, id, schema, sandbox)
@@ -141,7 +141,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
         userParser = object : TransactionParserFactory {
             var created: UserXmlParser? = null
 
-            override fun getParser(parser: KXmlParser): TransactionParser<*> {
+            override fun getParser(parser: PlatformXmlParser): TransactionParser<*> {
                 if (created == null) {
                     created = UserXmlParser(parser, sandbox.getUserStorage())
                 }
@@ -154,7 +154,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
         fixtureParser = object : TransactionParserFactory {
             var created: FixtureXmlParser? = null
 
-            override fun getParser(parser: KXmlParser): TransactionParser<*> {
+            override fun getParser(parser: PlatformXmlParser): TransactionParser<*> {
                 if (created == null) {
                     created = FixtureXmlParser(parser, true, sandbox.getUserFixtureStorage())
                 }
@@ -185,7 +185,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
         return object : TransactionParserFactory {
             var created: CaseXmlParser? = null
 
-            override fun getParser(parser: KXmlParser): TransactionParser<*> {
+            override fun getParser(parser: PlatformXmlParser): TransactionParser<*> {
                 if (created == null) {
                     created = CaseXmlParser(parser, sandbox.getCaseStorage())
                 }
@@ -198,7 +198,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
         return object : TransactionParserFactory {
             var created: LinearBulkProcessingCaseXmlParser? = null
 
-            override fun getParser(parser: KXmlParser): TransactionParser<*> {
+            override fun getParser(parser: PlatformXmlParser): TransactionParser<*> {
                 if (created == null) {
                     created = LinearBulkProcessingCaseXmlParser(parser, sandbox.getCaseStorage())
                 }

--- a/commcare-core/src/main/java/org/commcare/core/parse/UserXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/core/parse/UserXmlParser.kt
@@ -6,9 +6,9 @@ import org.javarosa.core.model.utils.DateUtils
 import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * @author ctsims
@@ -17,9 +17,9 @@ open class UserXmlParser : TransactionParser<User> {
 
     private var storage: IStorageUtilityIndexed<User>? = null
 
-    constructor(parser: KXmlParser) : super(parser)
+    constructor(parser: PlatformXmlParser) : super(parser)
 
-    constructor(parser: KXmlParser, storage: IStorageUtilityIndexed<User>) : super(parser) {
+    constructor(parser: PlatformXmlParser, storage: IStorageUtilityIndexed<User>) : super(parser) {
         this.storage = storage
     }
 
@@ -58,7 +58,7 @@ open class UserXmlParser : TransactionParser<User> {
 
         // Now look for optional components
         while (this.nextTagInBlock("registration")) {
-            val tag = parser.name.lowercase()
+            val tag = parser.name!!.lowercase()
 
             if (tag == "registering_phone_id") {
                 parser.nextText()
@@ -71,7 +71,7 @@ open class UserXmlParser : TransactionParser<User> {
                     val key = this.parser.getAttributeValue(null, "key")
                     val value = this.parser.nextText()
 
-                    u.setProperty(key, value)
+                    u.setProperty(key!!, value)
                 }
 
                 // This should be the last block in the registration stuff...

--- a/commcare-core/src/main/java/org/commcare/data/xml/DataModelPullParser.java
+++ b/commcare-core/src/main/java/org/commcare/data/xml/DataModelPullParser.java
@@ -3,9 +3,9 @@ package org.commcare.data.xml;
 import org.commcare.resources.model.CommCareOTARestoreListener;
 import org.javarosa.core.log.WrappedException;
 import org.javarosa.xml.ElementParser;
+import org.xmlpull.v1.XmlPullParserException;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
-import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/commcare-core/src/main/java/org/commcare/data/xml/TransactionParser.java
+++ b/commcare-core/src/main/java/org/commcare/data/xml/TransactionParser.java
@@ -1,9 +1,9 @@
 package org.commcare.data.xml;
 
 import org.javarosa.xml.ElementParser;
-import org.javarosa.xml.util.InvalidStructureException;
-import org.kxml2.io.KXmlParser;
+import org.javarosa.xml.PlatformXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
+import org.javarosa.xml.util.InvalidStructureException;
 
 import java.io.IOException;
 
@@ -11,7 +11,7 @@ import java.io.IOException;
  * @author ctsims
  */
 public abstract class TransactionParser<T> extends ElementParser<T> {
-    public TransactionParser(KXmlParser parser) {
+    public TransactionParser(PlatformXmlParser parser) {
         super(parser);
     }
 

--- a/commcare-core/src/main/java/org/commcare/data/xml/TransactionParserFactory.java
+++ b/commcare-core/src/main/java/org/commcare/data/xml/TransactionParserFactory.java
@@ -1,7 +1,7 @@
 package org.commcare.data.xml;
 
-import org.kxml2.io.KXmlParser;
+import org.javarosa.xml.PlatformXmlParser;
 
 public interface TransactionParserFactory {
-    TransactionParser getParser(KXmlParser parser);
+    TransactionParser getParser(PlatformXmlParser parser);
 }

--- a/commcare-core/src/main/java/org/commcare/suite/model/OfflineUserRestore.kt
+++ b/commcare-core/src/main/java/org/commcare/suite/model/OfflineUserRestore.kt
@@ -14,7 +14,6 @@ import org.javarosa.core.util.externalizable.ExtUtil
 import org.javarosa.core.util.externalizable.PrototypeFactory
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 
 import java.io.ByteArrayInputStream
@@ -23,6 +22,7 @@ import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
 import java.io.UnsupportedEncodingException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * User restore xml file sometimes present in apps.
@@ -106,7 +106,7 @@ class OfflineUserRestore : Persistable {
     private fun checkThatRestoreIsValidAndSetUsername() {
         val factory = TransactionParserFactory { parser ->
             val name = parser.name
-            if ("registration" == name.lowercase()) {
+            if ("registration" == name?.lowercase()) {
                 return@TransactionParserFactory buildUserParser(parser)
             }
             null
@@ -116,7 +116,7 @@ class OfflineUserRestore : Persistable {
         parser.parse()
     }
 
-    private fun buildUserParser(parser: KXmlParser): TransactionParser<*> {
+    private fun buildUserParser(parser: PlatformXmlParser): TransactionParser<*> {
         return object : UserXmlParser(parser) {
             @Throws(PlatformIOException::class, InvalidStructureException::class)
             override fun commit(parsed: User) {

--- a/commcare-core/src/main/java/org/commcare/xml/ActionParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/ActionParser.kt
@@ -7,16 +7,16 @@ import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Parses case list actions, which when triggered manipulate the session stack
  *
  * @author ctsims
  */
-class ActionParser(parser: KXmlParser) : CommCareElementParser<Action>(parser) {
+class ActionParser(parser: PlatformXmlParser) : CommCareElementParser<Action>(parser) {
 
     companion object {
         const val NAME_ACTION: String = "action"

--- a/commcare-core/src/main/java/org/commcare/xml/AssertionSetParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/AssertionSetParser.kt
@@ -6,14 +6,14 @@ import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * @author ctsims
  */
-class AssertionSetParser(parser: KXmlParser) : ElementParser<AssertionSet>(parser) {
+class AssertionSetParser(parser: PlatformXmlParser) : ElementParser<AssertionSet>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): AssertionSet {

--- a/commcare-core/src/main/java/org/commcare/xml/BestEffortBlockParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/BestEffortBlockParser.kt
@@ -3,9 +3,9 @@ package org.commcare.xml
 import org.commcare.data.xml.TransactionParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * This parser is for scanning through a block making a best-effort to identify a few
@@ -16,7 +16,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * @author ctsims
  */
 abstract class BestEffortBlockParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val elements: Array<String>
 ) : TransactionParser<HashMap<String, String>>(parser) {
 
@@ -35,8 +35,8 @@ abstract class BestEffortBlockParser(
         var expected: String? = null
         while (this.nextTagInBlock(name)) {
             if (expecting) {
-                if (parser.eventType == KXmlParser.TEXT) {
-                    ret[expected!!] = parser.text
+                if (parser.eventType == PlatformXmlParser.TEXT) {
+                    ret[expected!!] = parser.text!!
                 }
                 expecting = false
             }

--- a/commcare-core/src/main/java/org/commcare/xml/CalloutParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/CalloutParser.kt
@@ -4,9 +4,9 @@ import org.commcare.suite.model.Callout
 import org.commcare.suite.model.DetailField
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Parser used in DetailParser to parse the defintions of callouts used in
@@ -14,7 +14,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  *
  * @author wspride
  */
-class CalloutParser(parser: KXmlParser) : ElementParser<Callout>(parser) {
+class CalloutParser(parser: PlatformXmlParser) : ElementParser<Callout>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Callout {
@@ -31,9 +31,9 @@ class CalloutParser(parser: KXmlParser) : ElementParser<Callout>(parser) {
         while (nextTagInBlock("lookup")) {
             val tagName = parser.name
             if ("extra" == tagName) {
-                extras[parser.getAttributeValue(null, "key")] = parser.getAttributeValue(null, "value")
+                extras[parser.getAttributeValue(null, "key")!!] = parser.getAttributeValue(null, "value")!!
             } else if ("response" == tagName) {
-                responses.add(parser.getAttributeValue(null, "key"))
+                responses.add(parser.getAttributeValue(null, "key")!!)
             } else if ("field" == tagName) {
                 responseDetailField = DetailFieldParser(parser, null, "'lookup callout detail field'").parse()
             }

--- a/commcare-core/src/main/java/org/commcare/xml/CaseXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/CaseXmlParser.kt
@@ -31,10 +31,10 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.core.util.externalizable.SerializationLimitationException
 import org.javarosa.xml.util.ActionableInvalidStructureException
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.NoSuchElementException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * The CaseXML Parser is responsible for processing and performing
@@ -54,7 +54,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
     private val storage: IStorageUtilityIndexed<*>
     private val acceptCreateOverwrites: Boolean
 
-    constructor(parser: KXmlParser, storage: IStorageUtilityIndexed<*>) : this(parser, true, storage)
+    constructor(parser: PlatformXmlParser, storage: IStorageUtilityIndexed<*>) : this(parser, true, storage)
 
     /**
      * Creates a Parser for case blocks in the XML stream provided.
@@ -64,7 +64,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
      *                               contains create actions for cases which already exist.
      */
     constructor(
-        parser: KXmlParser, acceptCreateOverwrites: Boolean,
+        parser: PlatformXmlParser, acceptCreateOverwrites: Boolean,
         storage: IStorageUtilityIndexed<*>
     ) : super(parser) {
         this.acceptCreateOverwrites = acceptCreateOverwrites
@@ -79,9 +79,9 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
         validateMandatoryProperty(CASE_PROPERTY_CASE_ID, caseId, "", parser)
 
         val dateModified = parser.getAttributeValue(null, CASE_PROPERTY_DATE_MODIFIED)
-        validateMandatoryProperty(CASE_PROPERTY_DATE_MODIFIED, dateModified, caseId, parser)
+        validateMandatoryProperty(CASE_PROPERTY_DATE_MODIFIED, dateModified, caseId!!, parser)
 
-        val modified = DateUtils.parseDateTime(dateModified)
+        val modified = DateUtils.parseDateTime(dateModified!!)
 
         val userId = parser.getAttributeValue(null, CASE_PROPERTY_USER_ID)
 
@@ -89,27 +89,27 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
         var isCreateOrUpdate = false
 
         while (nextTagInBlock(CASE_NODE)) {
-            val action = parser.name.lowercase()
+            val action = parser.name!!.lowercase()
             when (action) {
                 CASE_CREATE_NODE -> {
-                    caseForBlock = createCase(caseId, modified!!, userId)
+                    caseForBlock = createCase(caseId!!, modified!!, userId)
                     isCreateOrUpdate = true
                 }
                 CASE_UPDATE_NODE -> {
-                    caseForBlock = loadCase(caseForBlock, caseId, true)
-                    updateCase(caseForBlock!!, caseId)
+                    caseForBlock = loadCase(caseForBlock, caseId!!, true)
+                    updateCase(caseForBlock!!, caseId!!)
                     isCreateOrUpdate = true
                 }
                 CASE_CLOSE_NODE -> {
-                    caseForBlock = loadCase(caseForBlock, caseId, true)
-                    closeCase(caseForBlock!!, caseId)
+                    caseForBlock = loadCase(caseForBlock, caseId!!, true)
+                    closeCase(caseForBlock!!, caseId!!)
                 }
                 CASE_INDEX_NODE -> {
-                    caseForBlock = loadCase(caseForBlock, caseId, false)
-                    indexCase(caseForBlock!!, caseId)
+                    caseForBlock = loadCase(caseForBlock, caseId!!, false)
+                    indexCase(caseForBlock!!, caseId!!)
                 }
                 CASE_ATTACHMENT_NODE -> {
-                    caseForBlock = loadCase(caseForBlock, caseId, false)
+                    caseForBlock = loadCase(caseForBlock, caseId!!, false)
                     processCaseAttachment(caseForBlock!!)
                 }
             }
@@ -129,7 +129,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
             }
 
             if (isCreateOrUpdate) {
-                onCaseCreateUpdate(caseId)
+                onCaseCreateUpdate(caseId!!)
             }
         }
 
@@ -195,7 +195,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun updateCase(caseForBlock: Case, caseId: String) {
         while (nextTagInBlock(CASE_UPDATE_NODE)) {
-            val key = parser.name
+            val key = parser.name!!
             val value = parser.nextText().trim()
 
             when (key) {
@@ -282,7 +282,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun processCaseAttachment(caseForBlock: Case) {
         while (nextTagInBlock(CASE_ATTACHMENT_NODE)) {
-            val attachmentName = parser.name
+            val attachmentName = parser.name!!
             val src = parser.getAttributeValue(null, CASE_PROPERTY_ATTACHMENT_SRC)
             val from = parser.getAttributeValue(null, CASE_PROPERTY_ATTACHMENT_FROM)
             val fileName = parser.getAttributeValue(null, CASE_PROPERTY_ATTACHMENT_NAME)
@@ -304,7 +304,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
     protected open fun removeAttachment(caseForBlock: Case, attachmentName: String) {
     }
 
-    protected open fun processAttachment(src: String?, from: String?, name: String?, parser: KXmlParser): String? {
+    protected open fun processAttachment(src: String?, from: String?, name: String?, parser: PlatformXmlParser): String? {
         return null
     }
 

--- a/commcare-core/src/main/java/org/commcare/xml/CaseXmlParserUtil.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/CaseXmlParserUtil.kt
@@ -6,7 +6,7 @@ import org.javarosa.core.model.instance.TreeElement
 import org.javarosa.xml.util.ActionableInvalidStructureException
 import org.javarosa.xml.util.InvalidCasePropertyLengthException
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 
 class CaseXmlParserUtil {
     companion object {
@@ -40,7 +40,7 @@ class CaseXmlParserUtil {
 
         @JvmStatic
         @Throws(InvalidStructureException::class)
-        fun validateMandatoryProperty(key: String, value: Any?, caseId: String, parser: KXmlParser) {
+        fun validateMandatoryProperty(key: String, value: Any?, caseId: String, parser: PlatformXmlParser) {
             if (value == null || value == "") {
                 val error = String.format("The %s attribute of a <case> %s wasn't set", key, caseId)
                 throw InvalidStructureException.readableInvalidStructureException(error, parser)

--- a/commcare-core/src/main/java/org/commcare/xml/CommCareElementParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/CommCareElementParser.kt
@@ -4,9 +4,9 @@ import org.commcare.suite.model.DisplayUnit
 import org.commcare.suite.model.Text
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Element parser extended with parsing function(s) that create CommCare
@@ -14,7 +14,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  *
  * @author Phillip Mates
  */
-abstract class CommCareElementParser<T>(parser: KXmlParser) : ElementParser<T>(parser) {
+abstract class CommCareElementParser<T>(parser: PlatformXmlParser) : ElementParser<T>(parser) {
 
     /**
      * Build a DisplayUnit object by parsing the contents of a display tag.

--- a/commcare-core/src/main/java/org/commcare/xml/DetailFieldParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/DetailFieldParser.kt
@@ -8,16 +8,16 @@ import org.javarosa.core.model.Constants
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Parser for <field> elements of a suite's detail definitions.
  * Contains text templates, as well as layout and sorting options
  */
 class DetailFieldParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val graphParser: GraphParser?,
     private val id: String?
 ) : CommCareElementParser<DetailField>(parser) {
@@ -75,7 +75,7 @@ class DetailFieldParser(
             //sort details
             checkNode(arrayOf("sort", "background", "endpoint_action", "alt_text"))
 
-            val name = parser.name.lowercase()
+            val name = parser.name!!.lowercase()
 
             if (name == "sort") {
                 parseSort(builder)
@@ -109,7 +109,7 @@ class DetailFieldParser(
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseStyle(builder: DetailField.Builder) {
         //style
-        if (parser.name.lowercase() == "style") {
+        if (parser.name!!.lowercase() == "style") {
             val styleParser = StyleParser(builder, parser)
             styleParser.parse()
             //Header

--- a/commcare-core/src/main/java/org/commcare/xml/DetailGroupParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/DetailGroupParser.kt
@@ -5,11 +5,11 @@ import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
-class DetailGroupParser(parser: KXmlParser) : CommCareElementParser<DetailGroup>(parser) {
+class DetailGroupParser(parser: PlatformXmlParser) : CommCareElementParser<DetailGroup>(parser) {
 
     companion object {
         const val NAME_GROUP: String = "group"

--- a/commcare-core/src/main/java/org/commcare/xml/DetailParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/DetailParser.kt
@@ -12,14 +12,14 @@ import org.javarosa.core.util.OrderedHashtable
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * @author ctsims
  */
-open class DetailParser(parser: KXmlParser) : CommCareElementParser<Detail>(parser) {
+open class DetailParser(parser: PlatformXmlParser) : CommCareElementParser<Detail>(parser) {
 
     companion object {
         private const val NAME_NO_ITEMS_TEXT = "no_items_text"
@@ -46,7 +46,7 @@ open class DetailParser(parser: KXmlParser) : CommCareElementParser<Detail>(pars
         getNextTagInBlock("title")
         val title: DisplayUnit
 
-        if ("text" == parser.name.lowercase()) {
+        if ("text" == parser.name!!.lowercase()) {
             title = DisplayUnit(TextParser(parser).parse())
         } else {
             title = parseDisplayBlock()
@@ -66,33 +66,33 @@ open class DetailParser(parser: KXmlParser) : CommCareElementParser<Detail>(pars
         var detailGroup: DetailGroup? = null
 
         while (nextTagInBlock("detail")) {
-            if (GlobalParser.NAME_GLOBAL == parser.name.lowercase()) {
+            if (GlobalParser.NAME_GLOBAL == parser.name!!.lowercase()) {
                 checkNode(GlobalParser.NAME_GLOBAL)
                 global = GlobalParser(parser).parse()
                 parser.nextTag()
             }
-            if ("lookup" == parser.name.lowercase()) {
+            if ("lookup" == parser.name!!.lowercase()) {
                 checkNode("lookup")
                 callout = CalloutParser(parser).parse()
                 parser.nextTag()
             }
-            if (NAME_NO_ITEMS_TEXT == parser.name.lowercase()) {
+            if (NAME_NO_ITEMS_TEXT == parser.name!!.lowercase()) {
                 checkNode("no_items_text")
                 getNextTagInBlock("no_items_text")
-                if ("text" == parser.name.lowercase()) {
+                if ("text" == parser.name!!.lowercase()) {
                     noItemsText = TextParser(parser).parse()
                 }
                 continue
             }
-            if ("select_text" == parser.name.lowercase()) {
+            if ("select_text" == parser.name!!.lowercase()) {
                 checkNode("select_text")
                 getNextTagInBlock("select_text")
-                if ("text" == parser.name.lowercase()) {
+                if ("text" == parser.name!!.lowercase()) {
                     selectText = TextParser(parser).parse()
                 }
                 continue
             }
-            if ("variables" == parser.name.lowercase()) {
+            if ("variables" == parser.name!!.lowercase()) {
                 while (nextTagInBlock("variables")) {
                     val function = parser.getAttributeValue(null, "function")
                         ?: throw InvalidStructureException(
@@ -106,11 +106,11 @@ open class DetailParser(parser: KXmlParser) : CommCareElementParser<Detail>(pars
                             "Invalid XPath function $function. ${e.message}", parser
                         )
                     }
-                    variables[parser.name] = function
+                    variables[parser.name!!] = function
                 }
                 continue
             }
-            if ("focus" == parser.name.lowercase()) {
+            if ("focus" == parser.name!!.lowercase()) {
                 focusFunction = parser.getAttributeValue(null, "function")
                 if (focusFunction == null) {
                     throw InvalidStructureException(

--- a/commcare-core/src/main/java/org/commcare/xml/EndpointParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/EndpointParser.kt
@@ -7,11 +7,11 @@ import org.javarosa.core.model.instance.ExternalDataInstance.Companion.JR_SELECT
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
-class EndpointParser(parser: KXmlParser) : ElementParser<Endpoint>(parser) {
+class EndpointParser(parser: PlatformXmlParser) : ElementParser<Endpoint>(parser) {
 
     companion object {
         @JvmField
@@ -42,7 +42,7 @@ class EndpointParser(parser: KXmlParser) : ElementParser<Endpoint>(parser) {
         val arguments = ArrayList<EndpointArgument>()
 
         while (nextTagInBlock(NAME_ENDPOINT)) {
-            val tagName = parser.name.lowercase()
+            val tagName = parser.name!!.lowercase()
             if (tagName.contentEquals(NAME_ARGUMENT)) {
                 val argumentID = parser.getAttributeValue(null, ATTR_ARGUMENT_ID)
                 if (argumentID == null || argumentID.isEmpty()) {

--- a/commcare-core/src/main/java/org/commcare/xml/EntryParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/EntryParser.kt
@@ -18,17 +18,17 @@ import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.net.MalformedURLException
 import java.net.URL
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * @author ctsims
  */
 class EntryParser private constructor(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val parserBlockTag: String
 ) : CommCareElementParser<Entry>(parser) {
 
@@ -38,17 +38,17 @@ class EntryParser private constructor(
         const val REMOTE_REQUEST_TAG: String = "remote-request"
 
         @JvmStatic
-        fun buildViewParser(parser: KXmlParser): EntryParser {
+        fun buildViewParser(parser: PlatformXmlParser): EntryParser {
             return EntryParser(parser, VIEW_ENTRY_TAG)
         }
 
         @JvmStatic
-        fun buildEntryParser(parser: KXmlParser): EntryParser {
+        fun buildEntryParser(parser: PlatformXmlParser): EntryParser {
             return EntryParser(parser, FORM_ENTRY_TAG)
         }
 
         @JvmStatic
-        fun buildRemoteSyncParser(parser: KXmlParser): EntryParser {
+        fun buildRemoteSyncParser(parser: PlatformXmlParser): EntryParser {
             return EntryParser(parser, REMOTE_REQUEST_TAG)
         }
     }
@@ -71,14 +71,14 @@ class EntryParser private constructor(
         var post: PostRequest? = null
 
         while (nextTagInBlock(parserBlockTag)) {
-            val tagName = parser.name
+            val tagName = parser.name!!
             if ("form" == tagName) {
                 if (parserBlockTag == VIEW_ENTRY_TAG) {
                     throw InvalidStructureException("<$parserBlockTag>'s cannot specify XForms!!", parser)
                 }
                 xFormNamespace = parser.nextText()
             } else if ("command" == tagName) {
-                commandId = parser.getAttributeValue(null, "id")
+                commandId = parser.getAttributeValue(null, "id")!!
                 display = parseCommandDisplay()
             } else if ("instance" == tagName.lowercase()) {
                 ParseInstance.parseInstance(instances, parser)

--- a/commcare-core/src/main/java/org/commcare/xml/FixtureIndexSchemaParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/FixtureIndexSchemaParser.kt
@@ -5,9 +5,9 @@ import org.commcare.data.xml.TransactionParser
 import org.javarosa.xml.TreeElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Parses fixture index schemas into an object representation:
@@ -22,7 +22,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * @author Phillip Mates (pmates@dimagi.com)
  */
 class FixtureIndexSchemaParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val fixtureSchemas: MutableMap<String, FixtureIndexSchema>,
     private val processedFixtures: Set<String>
 ) : TransactionParser<FixtureIndexSchema>(parser) {

--- a/commcare-core/src/main/java/org/commcare/xml/FixtureXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/FixtureXmlParser.kt
@@ -9,9 +9,9 @@ import org.javarosa.core.util.externalizable.ExtUtil
 import org.javarosa.xml.TreeElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * The Fixture XML Parser is responsible for parsing incoming fixture data and
@@ -20,7 +20,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * @author ctsims
  */
 open class FixtureXmlParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val overwrite: Boolean,
     @JvmField var storage: IStorageUtilityIndexed<FormInstance>
 ) : TransactionParser<FormInstance>(parser) {

--- a/commcare-core/src/main/java/org/commcare/xml/GeoOverlayParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/GeoOverlayParser.kt
@@ -4,14 +4,14 @@ import org.commcare.suite.model.DisplayUnit
 import org.commcare.suite.model.GeoOverlay
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Parses the defintion for a [GeoOverlay] element
  */
-internal class GeoOverlayParser(parser: KXmlParser) : ElementParser<GeoOverlay>(parser) {
+internal class GeoOverlayParser(parser: PlatformXmlParser) : ElementParser<GeoOverlay>(parser) {
 
     companion object {
         @JvmField
@@ -25,7 +25,7 @@ internal class GeoOverlayParser(parser: KXmlParser) : ElementParser<GeoOverlay>(
         var title: DisplayUnit? = null
         var coordinates: DisplayUnit? = null
         while (nextTagInBlock(NAME_GEO_OVERLAY)) {
-            val tagName = parser.name.lowercase()
+            val tagName = parser.name!!.lowercase()
             if (NAME_COORDINATES.contentEquals(tagName)) {
                 nextTagInBlock(NAME_COORDINATES)
                 coordinates = DisplayUnit(TextParser(parser).parse())

--- a/commcare-core/src/main/java/org/commcare/xml/GlobalParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/GlobalParser.kt
@@ -4,14 +4,14 @@ import org.commcare.suite.model.GeoOverlay
 import org.commcare.suite.model.Global
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Parser used in DetailParser to parse the defintion of Global element used in case-select and case-detail views
  */
-internal class GlobalParser(parser: KXmlParser) : ElementParser<Global>(parser) {
+internal class GlobalParser(parser: PlatformXmlParser) : ElementParser<Global>(parser) {
 
     companion object {
         @JvmField
@@ -22,7 +22,7 @@ internal class GlobalParser(parser: KXmlParser) : ElementParser<Global>(parser) 
     override fun parse(): Global {
         val geoOverlays = ArrayList<GeoOverlay>()
         while (nextTagInBlock(NAME_GLOBAL)) {
-            if (GeoOverlayParser.NAME_GEO_OVERLAY == parser.name.lowercase()) {
+            if (GeoOverlayParser.NAME_GEO_OVERLAY == parser.name!!.lowercase()) {
                 val geoOverlay = GeoOverlayParser(parser).parse()
                 geoOverlays.add(geoOverlay)
             }

--- a/commcare-core/src/main/java/org/commcare/xml/GraphParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/GraphParser.kt
@@ -12,14 +12,14 @@ import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Created by jschweers on 1/28/2016.
  */
-open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parser) {
+open class GraphParser(parser: PlatformXmlParser) : ElementParser<DetailTemplate>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Graph {
@@ -91,9 +91,9 @@ open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parse
             if (parser.name == "text") {
                 val id = parser.getAttributeValue(null, "id")
                 val t = textParser.parse()
-                data.setConfiguration(id, t)
+                data.setConfiguration(id!!, t)
             }
-        } while (parser.eventType != KXmlParser.END_TAG || parser.name != "configuration")
+        } while (parser.eventType != PlatformXmlParser.END_TAG || parser.name != "configuration")
     }
 
     /*
@@ -124,7 +124,7 @@ open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parse
             (series as BubbleSeries).setRadius(parseFunction("radius"))
         }
 
-        while (parser.eventType != KXmlParser.END_TAG || parser.name != "series") {
+        while (parser.eventType != PlatformXmlParser.END_TAG || parser.name != "series") {
             parser.nextTag()
         }
 
@@ -141,7 +141,7 @@ open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parse
     @Throws(InvalidStructureException::class)
     private fun parseFunction(name: String): String {
         checkNode(name)
-        val function = parser.getAttributeValue(null, "function")
+        val function = parser.getAttributeValue(null, "function")!!
         try {
             XPathParseTool.parseXPath(function)
         } catch (e: XPathSyntaxException) {
@@ -159,6 +159,6 @@ open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parse
     private fun nextStartTag() {
         do {
             parser.nextTag()
-        } while (parser.eventType != KXmlParser.START_TAG)
+        } while (parser.eventType != PlatformXmlParser.START_TAG)
     }
 }

--- a/commcare-core/src/main/java/org/commcare/xml/GridParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/GridParser.kt
@@ -3,9 +3,9 @@ package org.commcare.xml
 import org.commcare.suite.model.DetailField.Builder
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Parser used in DetailParser to parse the Grid attributes for a GridEntityView
@@ -14,7 +14,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  */
 class GridParser(
     val builder: Builder,
-    parser: KXmlParser
+    parser: PlatformXmlParser
 ) : ElementParser<Int>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)

--- a/commcare-core/src/main/java/org/commcare/xml/IndexedFixtureXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/IndexedFixtureXmlParser.kt
@@ -11,9 +11,9 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.xml.TreeElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Creates a table for the indexed fixture and parses each element into a
@@ -28,7 +28,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * @author Phillip Mates (pmates@dimagi.com)
  */
 class IndexedFixtureXmlParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val fixtureName: String?,
     schema: FixtureIndexSchema?,
     private val sandbox: UserSandbox

--- a/commcare-core/src/main/java/org/commcare/xml/LedgerXmlParsers.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/LedgerXmlParsers.kt
@@ -6,10 +6,10 @@ import org.javarosa.core.model.utils.DateUtils
 import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.NoSuchElementException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Contains all of the logic for parsing transactions in xml that pertain to
@@ -18,7 +18,7 @@ import java.util.NoSuchElementException
  * @author ctsims
  */
 class LedgerXmlParsers(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     val storage: IStorageUtilityIndexed<Ledger>
 ) : TransactionParser<Array<Ledger>>(parser) {
 
@@ -40,7 +40,7 @@ class LedgerXmlParsers(
     override fun parse(): Array<Ledger> {
         this.checkNode(arrayOf(TAG_BALANCE, TRANSFER))
 
-        val name = parser.name.lowercase()
+        val name = parser.name!!.lowercase()
 
         val toWrite = ArrayList<Ledger>()
 
@@ -84,7 +84,7 @@ class LedgerXmlParsers(
                                 }
                                 val quantity = this.parseInt(quantityString)
 
-                                ledger.setEntry(sectionId, productId, quantity)
+                                ledger.setEntry(sectionId, productId!!, quantity)
                             }
                             return null
                         }
@@ -146,12 +146,12 @@ class LedgerXmlParsers(
                                 val quantity = this.parseInt(quantityString)
 
                                 sourceLeger?.setEntry(
-                                    sectionId, productId,
-                                    sourceLeger.getEntry(sectionId, productId) - quantity
+                                    sectionId, productId!!,
+                                    sourceLeger.getEntry(sectionId, productId!!) - quantity
                                 )
                                 destinationLedger?.setEntry(
-                                    sectionId, productId,
-                                    destinationLedger.getEntry(sectionId, productId) + quantity
+                                    sectionId, productId!!,
+                                    destinationLedger.getEntry(sectionId, productId!!) + quantity
                                 )
                             }
                             return null

--- a/commcare-core/src/main/java/org/commcare/xml/MarkupParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/MarkupParser.kt
@@ -3,13 +3,13 @@ package org.commcare.xml
 import org.commcare.suite.model.DetailField.Builder
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 class MarkupParser(
     val builder: Builder,
-    parser: KXmlParser
+    parser: PlatformXmlParser
 ) : ElementParser<Int>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)

--- a/commcare-core/src/main/java/org/commcare/xml/MenuParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/MenuParser.kt
@@ -8,14 +8,14 @@ import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * @author ctsims
  */
-class MenuParser(parser: KXmlParser) : CommCareElementParser<Menu>(parser) {
+class MenuParser(parser: PlatformXmlParser) : CommCareElementParser<Menu>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Menu {
@@ -58,9 +58,9 @@ class MenuParser(parser: KXmlParser) : CommCareElementParser<Menu>(parser) {
         val commandIds = ArrayList<String>()
         val relevantExprs = ArrayList<String?>()
         while (nextTagInBlock("menu")) {
-            val tagName = parser.name
+            val tagName = parser.name!!
             if (tagName == "command") {
-                commandIds.add(parser.getAttributeValue(null, "id"))
+                commandIds.add(parser.getAttributeValue(null, "id")!!)
                 val relevantExpr = parser.getAttributeValue(null, "relevant")
                 if (relevantExpr == null) {
                     relevantExprs.add(null)

--- a/commcare-core/src/main/java/org/commcare/xml/ParseInstance.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/ParseInstance.kt
@@ -2,15 +2,15 @@ package org.commcare.xml
 
 import org.javarosa.core.model.instance.DataInstance
 import org.javarosa.core.model.instance.ExternalDataInstance
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 
 class ParseInstance {
     companion object {
         @JvmStatic
-        fun parseInstance(instances: HashMap<String, DataInstance<*>>, parser: KXmlParser) {
+        fun parseInstance(instances: HashMap<String, DataInstance<*>>, parser: PlatformXmlParser) {
             val instanceId = parser.getAttributeValue(null, "id")
             val location = parser.getAttributeValue(null, "src")
-            instances[instanceId] = ExternalDataInstance(location, instanceId)
+            instances[instanceId!!] = ExternalDataInstance(location, instanceId)
         }
     }
 }

--- a/commcare-core/src/main/java/org/commcare/xml/ProfileParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/ProfileParser.kt
@@ -12,10 +12,10 @@ import org.javarosa.core.util.PropertyUtils
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * @author ctsims
@@ -54,8 +54,8 @@ class ProfileParser(
             var eventType: Int
             eventType = parser.eventType
             do {
-                if (eventType == KXmlParser.START_TAG) {
-                    when (parser.name.lowercase()) {
+                if (eventType == PlatformXmlParser.START_TAG) {
+                    when (parser.name!!.lowercase()) {
                         "property" -> parseProperty(profile)
                         "root" -> {
                             val root = RootParser(this.parser).parse()
@@ -68,7 +68,7 @@ class ProfileParser(
                     }
                 }
                 eventType = parser.next()
-            } while (eventType != KXmlParser.END_DOCUMENT)
+            } while (eventType != PlatformXmlParser.END_DOCUMENT)
 
             return profile
         } catch (e: PlatformXmlParserException) {
@@ -168,8 +168,8 @@ class ProfileParser(
     }
 
     private fun parseProperty(profile: Profile) {
-        val key = parser.getAttributeValue(null, "key")
-        val value = parser.getAttributeValue(null, "value")
+        val key = parser.getAttributeValue(null, "key")!!
+        val value = parser.getAttributeValue(null, "value")!!
         val force = parser.getAttributeValue(null, "force")
         addPropertySetter(profile, key, value, force)
     }
@@ -197,7 +197,7 @@ class ProfileParser(
     @Throws(PlatformXmlParserException::class, PlatformIOException::class, InvalidStructureException::class)
     private fun parseFeatures(profile: Profile) {
         while (nextTagInBlock("features")) {
-            val tag = parser.name.lowercase()
+            val tag = parser.name!!.lowercase()
             val active = parser.getAttributeValue(null, "active")
             var isActive = false
             if (active != null && active.lowercase() == "true") {
@@ -214,9 +214,9 @@ class ProfileParser(
                 //nothing (yet)
             } else if (tag == "users") {
                 while (nextTagInBlock("users")) {
-                    if (parser.name.lowercase() == "registration") {
+                    if (parser.name!!.lowercase() == "registration") {
                         profile.addPropertySetter("user_reg_namespace", parser.nextText(), true)
-                    } else if (parser.name.lowercase() == "logo") {
+                    } else if (parser.name!!.lowercase() == "logo") {
                         val logo = parser.nextText()
                         profile.addPropertySetter("cc_login_image", logo, true)
                     } else {
@@ -241,7 +241,7 @@ class ProfileParser(
     private fun parseCredentials(): ArrayList<Credential> {
         val appCredentials = ArrayList<Credential>()
         while (nextTagInBlock(NAME_CREDENTIALS)) {
-            val tag = parser.name.lowercase()
+            val tag = parser.name!!.lowercase()
             if (tag == NAME_CREDENTIAL) {
                 val level = parser.getAttributeValue(null, ATTR_CREDENTIAL_LEVEL)
                 val type = parser.getAttributeValue(null, ATTR_CREDENTIAL_TYPE)
@@ -261,7 +261,7 @@ class ProfileParser(
     private fun parseDependencies(): ArrayList<AndroidPackageDependency> {
         val appDependencies = ArrayList<AndroidPackageDependency>()
         while (nextTagInBlock(NAME_DEPENDENCIES)) {
-            val tag = parser.name.lowercase()
+            val tag = parser.name!!.lowercase()
             if (tag == NAME_ANDROID_PACKAGE) {
                 val appId = parser.getAttributeValue(null, ATTR_ID)
                     ?: throw InvalidStructureException("No id defined for app dependency")

--- a/commcare-core/src/main/java/org/commcare/xml/QueryDataParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/QueryDataParser.kt
@@ -8,14 +8,14 @@ import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Parser for parsing `<data>` elements
  */
-class QueryDataParser(parser: KXmlParser) : CommCareElementParser<QueryData>(parser) {
+class QueryDataParser(parser: PlatformXmlParser) : CommCareElementParser<QueryData>(parser) {
 
     companion object {
         @JvmStatic

--- a/commcare-core/src/main/java/org/commcare/xml/QueryGroupParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/QueryGroupParser.kt
@@ -4,11 +4,11 @@ import org.commcare.suite.model.DisplayUnit
 import org.commcare.suite.model.QueryGroup
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
-class QueryGroupParser(parser: KXmlParser) : CommCareElementParser<QueryGroup>(parser) {
+class QueryGroupParser(parser: PlatformXmlParser) : CommCareElementParser<QueryGroup>(parser) {
 
     companion object {
         const val NAME_GROUP: String = "group"

--- a/commcare-core/src/main/java/org/commcare/xml/QueryPromptParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/QueryPromptParser.kt
@@ -12,11 +12,11 @@ import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
-class QueryPromptParser(parser: KXmlParser) : CommCareElementParser<QueryPrompt>(parser) {
+class QueryPromptParser(parser: PlatformXmlParser) : CommCareElementParser<QueryPrompt>(parser) {
 
     companion object {
         private const val NAME_PROMPT = "prompt"

--- a/commcare-core/src/main/java/org/commcare/xml/ResourceParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/ResourceParser.kt
@@ -5,12 +5,12 @@ import org.commcare.resources.model.Resource.Companion.LAZY_VAL_FALSE
 import org.commcare.resources.model.ResourceLocation
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 class ResourceParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     val maximumAuthority: Int
 ) : ElementParser<Resource>(parser) {
 
@@ -18,7 +18,7 @@ class ResourceParser(
     override fun parse(): Resource {
         checkNode("resource")
 
-        val id = parser.getAttributeValue(null, "id")
+        val id = parser.getAttributeValue(null, "id")!!
         val version = parseInt(parser.getAttributeValue(null, "version"))
 
         val descriptor = parser.getAttributeValue(null, "descriptor")
@@ -28,7 +28,7 @@ class ResourceParser(
 
         while (nextTagInBlock("resource")) {
             //New Location
-            val sAuthority = parser.getAttributeValue(null, "authority")
+            val sAuthority = parser.getAttributeValue(null, "authority")!!
             val location = parser.nextText()
             var authority = Resource.RESOURCE_AUTHORITY_REMOTE
             if (sAuthority.lowercase() == "local") {

--- a/commcare-core/src/main/java/org/commcare/xml/RootParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/RootParser.kt
@@ -3,14 +3,14 @@ package org.commcare.xml
 import org.javarosa.core.reference.RootTranslator
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * @author ctsims
  */
-class RootParser(parser: KXmlParser) : ElementParser<RootTranslator>(parser) {
+class RootParser(parser: PlatformXmlParser) : ElementParser<RootTranslator>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): RootTranslator {
@@ -22,7 +22,7 @@ class RootParser(parser: KXmlParser) : ElementParser<RootTranslator>(parser) {
         //Get the child or error out if none exists
         getNextTagInBlock("root")
 
-        val referenceType = parser.name.lowercase()
+        val referenceType = parser.name!!.lowercase()
         val path = parser.getAttributeValue(null, "path")
         return when (referenceType) {
             "filesystem" -> RootTranslator("jr://$id/", "jr://file$path")

--- a/commcare-core/src/main/java/org/commcare/xml/SessionDatumParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/SessionDatumParser.kt
@@ -14,16 +14,16 @@ import org.commcare.suite.model.Text
 import org.javarosa.core.util.OrderedHashtable
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.net.MalformedURLException
 import java.net.URL
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * @author ctsims
  */
-class SessionDatumParser(parser: KXmlParser) : CommCareElementParser<SessionDatum>(parser) {
+class SessionDatumParser(parser: PlatformXmlParser) : CommCareElementParser<SessionDatum>(parser) {
 
     companion object {
         const val DEFAULT_MAX_SELECT_VAL: Int = 100
@@ -98,7 +98,7 @@ class SessionDatumParser(parser: KXmlParser) : CommCareElementParser<SessionDatu
             }
         }
 
-        while (parser.next() == KXmlParser.TEXT) {
+        while (parser.next() == PlatformXmlParser.TEXT) {
             // consume text nodes
         }
 
@@ -142,7 +142,7 @@ class SessionDatumParser(parser: KXmlParser) : CommCareElementParser<SessionDatu
             if ("data" == tagName) {
                 hiddenQueryValues.add(QueryDataParser(parser).parse())
             } else if ("prompt" == tagName) {
-                val key = parser.getAttributeValue(null, "key")
+                val key = parser.getAttributeValue(null, "key")!!
                 userQueryPrompts[key] = QueryPromptParser(parser).parse()
             } else if ("title" == tagName) {
                 nextTagInBlock("title")

--- a/commcare-core/src/main/java/org/commcare/xml/StackFrameStepParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/StackFrameStepParser.kt
@@ -6,16 +6,16 @@ import org.commcare.suite.model.StackFrameStep
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.net.MalformedURLException
 import java.net.URL
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * @author ctsims
  */
-internal class StackFrameStepParser(parser: KXmlParser) : ElementParser<StackFrameStep>(parser) {
+internal class StackFrameStepParser(parser: PlatformXmlParser) : ElementParser<StackFrameStep>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): StackFrameStep {

--- a/commcare-core/src/main/java/org/commcare/xml/StackOpParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/StackOpParser.kt
@@ -5,14 +5,14 @@ import org.commcare.suite.model.StackOperation
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * @author ctsims
  */
-class StackOpParser(parser: KXmlParser) : ElementParser<StackOperation>(parser) {
+class StackOpParser(parser: PlatformXmlParser) : ElementParser<StackOperation>(parser) {
 
     companion object {
         const val NAME_STACK: String = "stack"

--- a/commcare-core/src/main/java/org/commcare/xml/StyleParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/StyleParser.kt
@@ -3,9 +3,9 @@ package org.commcare.xml
 import org.commcare.suite.model.DetailField.Builder
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Parser used by the DetailParser class to parse the style attributes of a
@@ -15,7 +15,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  */
 class StyleParser(
     val builder: Builder,
-    parser: KXmlParser
+    parser: PlatformXmlParser
 ) : ElementParser<Int>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)

--- a/commcare-core/src/main/java/org/commcare/xml/SuiteParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/SuiteParser.kt
@@ -13,10 +13,10 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Parses a suite file resource and creates the associated object
@@ -94,8 +94,8 @@ open class SuiteParser : ElementParser<Suite> {
 
             var eventType = parser.eventType
             do {
-                if (eventType == KXmlParser.START_TAG) {
-                    val tagName = parser.name.lowercase()
+                if (eventType == PlatformXmlParser.START_TAG) {
+                    val tagName = parser.name!!.lowercase()
                     when (tagName) {
                         "entry" -> {
                             val entry = EntryParser.buildEntryParser(parser).parse()
@@ -110,7 +110,7 @@ open class SuiteParser : ElementParser<Suite> {
                             entries[remoteRequestEntry.commandId!!] = remoteRequestEntry
                         }
                         "locale" -> {
-                            val localeKey = parser.getAttributeValue(null, "language")
+                            val localeKey = parser.getAttributeValue(null, "language")!!
                             parser.nextTag()
                             val localeResource = ResourceParser(parser, maximumResourceAuthority).parse()
                             if (!skipResources) {
@@ -122,7 +122,7 @@ open class SuiteParser : ElementParser<Suite> {
                             }
                         }
                         "media" -> {
-                            val path = parser.getAttributeValue(null, "path")
+                            val path = parser.getAttributeValue(null, "path")!!
                             while (this.nextTagInBlock("media")) {
                                 val mediaResource = ResourceParser(parser, maximumResourceAuthority).parse()
                                 if (!skipResources) {
@@ -178,7 +178,7 @@ open class SuiteParser : ElementParser<Suite> {
                     }
                 }
                 eventType = parser.next()
-            } while (eventType != KXmlParser.END_DOCUMENT)
+            } while (eventType != PlatformXmlParser.END_DOCUMENT)
 
             return Suite(version, details, entries, menus, endpoints)
         } catch (e: PlatformXmlParserException) {

--- a/commcare-core/src/main/java/org/commcare/xml/TextParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/TextParser.kt
@@ -4,11 +4,11 @@ import org.commcare.suite.model.Text
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.PlatformXmlParser
 
-class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
+class TextParser(parser: PlatformXmlParser) : ElementParser<Text>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Text {
@@ -26,7 +26,7 @@ class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
             e.printStackTrace()
         }
 
-        while (parser.depth > entryLevel || parser.eventType == KXmlParser.TEXT) {
+        while (parser.depth > entryLevel || parser.eventType == PlatformXmlParser.TEXT) {
             val t = parseBody()
             if (t != null) {
                 texts.add(t)
@@ -47,7 +47,7 @@ class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
         var eventType = parser.eventType
         var text = ""
         do {
-            if (eventType == KXmlParser.START_TAG) {
+            if (eventType == PlatformXmlParser.START_TAG) {
                 //If we were parsing text, commit that up first.
                 if (text.trim() != "") {
                     val t = Text.PlainText(text)
@@ -56,21 +56,21 @@ class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
                 }
 
                 //now parse out the next tag.
-                if (parser.name.lowercase() == "xpath") {
+                if (parser.name!!.lowercase() == "xpath") {
                     val xpathText = parseXPath()
                     texts.add(xpathText)
-                } else if (parser.name.lowercase() == "locale") {
+                } else if (parser.name!!.lowercase() == "locale") {
                     val localeText = parseLocale()
                     texts.add(localeText)
                 }
-            } else if (eventType == KXmlParser.TEXT) {
-                text += parser.text.trim()
+            } else if (eventType == PlatformXmlParser.TEXT) {
+                text += parser.text!!.trim()
             }
 
             //We shouldn't really ever get here as far as things are currently set up
             eventType = parser.next()
             //How do we get out of here? Depth?
-        } while (eventType != KXmlParser.END_TAG)
+        } while (eventType != PlatformXmlParser.END_TAG)
 
         if (text.trim() != "") {
             val t = Text.PlainText(text)

--- a/commcare-core/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.kt
@@ -23,10 +23,10 @@ import org.javarosa.core.model.utils.DateUtils
 import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.core.util.externalizable.SerializationLimitationException
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.LinkedHashMap
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * The BulkCaseInstanceXmlParser Parser is responsible for parsing case instance xml structure
@@ -34,7 +34,7 @@ import java.util.LinkedHashMap
  */
 // todo this and other case parsers duplicates a bunch of logic today that can be unified
 open class BulkCaseInstanceXmlParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val storage: IStorageUtilityIndexed<Case>,
     private val mCaseIndexTable: CaseIndexTable?
 ) : BulkElementParser<Case>(parser), CaseIndexChangeListener {

--- a/commcare-core/src/main/java/org/commcare/xml/bulk/BulkElementParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/bulk/BulkElementParser.kt
@@ -5,11 +5,11 @@ import org.javarosa.core.model.instance.TreeElement
 import org.javarosa.xml.TreeElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.LinkedHashMap
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * A bulk element parser reads multiple types of the same transaction together into a buffer of
@@ -33,7 +33,7 @@ import java.util.LinkedHashMap
  *
  * Created by ctsims on 3/14/2017.
  */
-abstract class BulkElementParser<T>(parser: KXmlParser) : TransactionParser<TreeElement>(parser) {
+abstract class BulkElementParser<T>(parser: PlatformXmlParser) : TransactionParser<TreeElement>(parser) {
 
     @JvmField
     protected var bulkTrigger = 500

--- a/commcare-core/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.kt
@@ -28,10 +28,10 @@ import org.javarosa.core.model.instance.TreeElement
 import org.javarosa.core.model.utils.DateUtils
 import org.javarosa.core.util.externalizable.SerializationLimitationException
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
 
 import java.util.Date
 import java.util.LinkedHashMap
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * A parser which is capable of processing CaseXML transactions in a bulk format.
@@ -43,7 +43,7 @@ import java.util.LinkedHashMap
  *
  * Created by ctsims on 3/14/2017.
  */
-abstract class BulkProcessingCaseXmlParser(parser: KXmlParser) :
+abstract class BulkProcessingCaseXmlParser(parser: PlatformXmlParser) :
     BulkElementParser<Case>(parser), CaseIndexChangeListener {
 
     override fun requestModelReadsForElement(

--- a/commcare-core/src/main/java/org/commcare/xml/bulk/LinearBulkProcessingCaseXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/bulk/LinearBulkProcessingCaseXmlParser.kt
@@ -2,10 +2,10 @@ package org.commcare.xml.bulk
 
 import org.commcare.cases.model.Case
 import org.javarosa.core.services.storage.IStorageUtilityIndexed
-import org.kxml2.io.KXmlParser
 
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.LinkedHashMap
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Reference implementation of BulkProcessingCaseXMLParser which can be used with no platform
@@ -19,7 +19,7 @@ import java.util.LinkedHashMap
  * Created by ctsims on 3/14/2017.
  */
 open class LinearBulkProcessingCaseXmlParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val storage: IStorageUtilityIndexed<Case>
 ) : BulkProcessingCaseXmlParser(parser) {
 

--- a/commcare-core/src/main/java/org/javarosa/core/model/actions/SendAction.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/actions/SendAction.kt
@@ -14,6 +14,7 @@ import org.javarosa.xform.parse.IElementHandler
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.dom.XmlElement
 
 /**
  * A Send Action is responsible for loading a submission template from the form, and performing

--- a/commcare-core/src/main/java/org/javarosa/core/model/actions/SetValueAction.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/actions/SetValueAction.kt
@@ -18,6 +18,7 @@ import org.javarosa.xpath.expr.XPathExpression
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.dom.XmlElement
 
 /**
  * @author ctsims

--- a/commcare-core/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.kt
@@ -19,7 +19,6 @@ import org.javarosa.xpath.expr.XPathEqExpr
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.expr.XPathPathExpr
 import org.javarosa.xpath.expr.XPathStringLiteral
-import org.kxml2.io.KXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream

--- a/commcare-core/src/main/java/org/javarosa/model/xform/DataModelSerializer.kt
+++ b/commcare-core/src/main/java/org/javarosa/model/xform/DataModelSerializer.kt
@@ -5,9 +5,10 @@ import org.javarosa.core.model.instance.DataInstance
 import org.javarosa.core.model.instance.ExternalDataInstance
 import org.javarosa.core.model.instance.InstanceInitializationFactory
 import org.javarosa.core.model.instance.TreeReference
-import org.kxml2.io.KXmlSerializer
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.OutputStream
+import org.javarosa.xml.JvmXmlSerializer
+import org.javarosa.xml.PlatformXmlSerializer
 
 /**
  * A quick rewrite of the basics for writing higher level xml documents straight to
@@ -17,17 +18,16 @@ import java.io.OutputStream
  */
 class DataModelSerializer {
 
-    private val serializer: KXmlSerializer
+    private val serializer: PlatformXmlSerializer
     private val factory: InstanceInitializationFactory?
 
     @Throws(PlatformIOException::class)
     constructor(stream: OutputStream, factory: InstanceInitializationFactory?) {
-        serializer = KXmlSerializer()
-        serializer.setOutput(stream, "UTF-8")
+        serializer = JvmXmlSerializer(stream, "UTF-8")
         this.factory = factory
     }
 
-    constructor(serializer: KXmlSerializer) {
+    constructor(serializer: PlatformXmlSerializer) {
         this.serializer = serializer
         this.factory = null
     }
@@ -51,7 +51,7 @@ class DataModelSerializer {
 
     @Throws(PlatformIOException::class)
     fun serialize(root: AbstractTreeElement) {
-        serializer.startTag(root.getNamespace(), root.getName())
+        serializer.startTag(root.getNamespace(), root.getName()!!)
 
         serializeAttributes(root)
         for (i in 0 until root.getNumChildren()) {
@@ -59,7 +59,7 @@ class DataModelSerializer {
             serializeNode(childAt)
         }
 
-        serializer.endTag(root.getNamespace(), root.getName())
+        serializer.endTag(root.getNamespace(), root.getName()!!)
         serializer.flush()
     }
 
@@ -70,18 +70,18 @@ class DataModelSerializer {
             return
         }
 
-        serializer.startTag(instanceNode.getNamespace(), instanceNode.getName())
+        serializer.startTag(instanceNode.getNamespace(), instanceNode.getName()!!)
         serializeAttributes(instanceNode)
 
         if (instanceNode.getValue() != null) {
-            serializer.text(instanceNode.getValue()!!.uncast().getString())
+            serializer.text(instanceNode.getValue()!!.uncast().getString()!!)
         } else {
             for (i in 0 until instanceNode.getNumChildren()) {
                 serializeNode(instanceNode.getChildAt(i) as AbstractTreeElement)
             }
         }
 
-        serializer.endTag(instanceNode.getNamespace(), instanceNode.getName())
+        serializer.endTag(instanceNode.getNamespace(), instanceNode.getName()!!)
     }
 
     @Throws(PlatformIOException::class)
@@ -89,7 +89,7 @@ class DataModelSerializer {
         for (i in 0 until instanceNode.getAttributeCount()) {
             var value = instanceNode.getAttributeValue(i)
             value = value ?: ""
-            serializer.attribute(instanceNode.getAttributeNamespace(i), instanceNode.getAttributeName(i), value)
+            serializer.attribute(instanceNode.getAttributeNamespace(i), instanceNode.getAttributeName(i)!!, value)
         }
     }
 }

--- a/commcare-core/src/main/java/org/javarosa/model/xform/XFormSerializingVisitor.kt
+++ b/commcare-core/src/main/java/org/javarosa/model/xform/XFormSerializingVisitor.kt
@@ -13,10 +13,10 @@ import org.javarosa.core.services.transport.payload.IDataPayload
 import org.javarosa.core.services.transport.payload.MultiMessagePayload
 import org.javarosa.xform.util.XFormAnswerDataSerializer
 import org.javarosa.xform.util.XFormSerializer
-import org.kxml2.kdom.Document
-import org.kxml2.kdom.Element
-import org.kxml2.kdom.Node
 import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xml.dom.XmlDocument
+import org.javarosa.xml.dom.XmlElement
+import org.javarosa.xml.dom.XmlNode
 
 /**
  * A visitor-esque class which walks a FormInstance and constructs an XML document
@@ -32,7 +32,7 @@ class XFormSerializingVisitor : IInstanceSerializingVisitor {
     /**
      * The XML document containing the instance that is to be returned
      */
-    private var theXmlDoc: Document? = null
+    private var theXmlDoc: XmlDocument? = null
 
     /**
      * The serializer to be used in constructing XML for AnswerData elements
@@ -105,7 +105,7 @@ class XFormSerializingVisitor : IInstanceSerializingVisitor {
     }
 
     override fun visit(tree: FormInstance) {
-        theXmlDoc = Document()
+        theXmlDoc = XmlDocument()
 
         var root: TreeElement? = tree.resolveReference(rootRef!!)
 
@@ -116,7 +116,7 @@ class XFormSerializingVisitor : IInstanceSerializingVisitor {
         }
 
         if (root != null) {
-            theXmlDoc!!.addChild(Node.ELEMENT, serializeNode(root))
+            theXmlDoc!!.addChild(XmlNode.ELEMENT, serializeNode(root))
         }
 
         val top = theXmlDoc!!.getElement(0)
@@ -133,8 +133,8 @@ class XFormSerializingVisitor : IInstanceSerializingVisitor {
         }
     }
 
-    private fun serializeNode(instanceNode: TreeElement): Element? {
-        var e = Element() // don't set anything on this element yet, as it might get overwritten
+    private fun serializeNode(instanceNode: TreeElement): XmlElement? {
+        var e = XmlElement() // don't set anything on this element yet, as it might get overwritten
 
         // don't serialize template nodes or non-relevant nodes
         if ((respectRelevance && !instanceNode.isRelevant) || instanceNode.getMult() == TreeReference.INDEX_TEMPLATE) {
@@ -144,11 +144,11 @@ class XFormSerializingVisitor : IInstanceSerializingVisitor {
         if (instanceNode.getValue() != null) {
             val serializedAnswer = serializer!!.serializeAnswerData(instanceNode.getValue(), instanceNode.getDataType())
 
-            if (serializedAnswer is Element) {
+            if (serializedAnswer is XmlElement) {
                 e = serializedAnswer
             } else if (serializedAnswer is String) {
-                e = Element()
-                e.addChild(Node.TEXT, serializedAnswer)
+                e = XmlElement()
+                e.addChild(XmlNode.TEXT, serializedAnswer)
             } else {
                 throw RuntimeException(
                     "Can't handle serialized output for${instanceNode.getValue()}, $serializedAnswer"
@@ -179,7 +179,7 @@ class XFormSerializingVisitor : IInstanceSerializingVisitor {
                 for (j in 0 until mult) {
                     val child = serializeNode(instanceNode.getChild(childName, j)!!)
                     if (child != null) {
-                        e.addChild(Node.ELEMENT, child)
+                        e.addChild(XmlNode.ELEMENT, child)
                     }
                 }
             }

--- a/commcare-core/src/main/java/org/javarosa/xform/parse/IElementHandler.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/parse/IElementHandler.kt
@@ -1,6 +1,6 @@
 package org.javarosa.xform.parse
 
-import org.kxml2.kdom.Element
+import org.javarosa.xml.dom.XmlElement
 
 /**
  * An IElementHandler is responsible for handling the parsing of a particular
@@ -9,5 +9,5 @@ import org.kxml2.kdom.Element
  * @author Drew Roos
  */
 fun interface IElementHandler {
-    fun handle(p: XFormParser, e: Element, parent: Any)
+    fun handle(p: XFormParser, e: XmlElement, parent: Any)
 }

--- a/commcare-core/src/main/java/org/javarosa/xform/parse/QuestionExtensionParser.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/parse/QuestionExtensionParser.kt
@@ -1,7 +1,7 @@
 package org.javarosa.xform.parse
 
 import org.javarosa.core.model.QuestionDataExtension
-import org.kxml2.kdom.Element
+import org.javarosa.xml.dom.XmlElement
 
 /**
  * A parser for some additional piece of information included with a question in an xform that
@@ -24,13 +24,13 @@ abstract class QuestionExtensionParser {
         this._elementName = elementName
     }
 
-    fun canParse(e: Element): Boolean {
+    fun canParse(e: XmlElement): Boolean {
         return e.name == _elementName
     }
 
     // May return null if the specific extension data being sought is not present for the given
     // element
-    abstract fun parse(e: Element): QuestionDataExtension?
+    abstract fun parse(e: XmlElement): QuestionDataExtension?
 
     abstract fun getUsedAttributes(): Array<String>
 }

--- a/commcare-core/src/main/java/org/javarosa/xform/parse/UploadQuestionExtensionParser.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/parse/UploadQuestionExtensionParser.kt
@@ -2,7 +2,7 @@ package org.javarosa.xform.parse
 
 import org.javarosa.core.model.QuestionDataExtension
 import org.javarosa.core.model.UploadQuestionExtension
-import org.kxml2.kdom.Element
+import org.javarosa.xml.dom.XmlElement
 
 /**
  * An additional parser for the "upload" question type, which can be used to parse any additional
@@ -16,7 +16,7 @@ class UploadQuestionExtensionParser : QuestionExtensionParser() {
         setElementName("upload")
     }
 
-    override fun parse(elt: Element): QuestionDataExtension? {
+    override fun parse(elt: XmlElement): QuestionDataExtension? {
         var s = elt.getAttributeValue(XFormParser.NAMESPACE_JAVAROSA,
                 "imageDimensionScaledMax")
         if (s != null) {

--- a/commcare-core/src/main/java/org/javarosa/xform/parse/XFormParseException.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/parse/XFormParseException.kt
@@ -16,7 +16,7 @@
 
 package org.javarosa.xform.parse
 
-import org.kxml2.kdom.Element
+import org.javarosa.xml.dom.XmlElement
 
 /**
  * Exception thrown when an XForms Parsing error occurs.
@@ -29,7 +29,7 @@ import org.kxml2.kdom.Element
 class XFormParseException : RuntimeException {
 
     @JvmField
-    internal var element: Element? = null
+    internal var element: XmlElement? = null
 
     constructor()
 
@@ -37,7 +37,7 @@ class XFormParseException : RuntimeException {
         element = null
     }
 
-    constructor(msg: String?, e: Element?) : super(msg) {
+    constructor(msg: String?, e: XmlElement?) : super(msg) {
         element = e
     }
 

--- a/commcare-core/src/main/java/org/javarosa/xform/parse/XFormParser.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/parse/XFormParser.kt
@@ -35,24 +35,23 @@ import org.javarosa.core.util.Interner
 import org.javarosa.core.util.ShortestCycleAlgorithm
 import org.javarosa.core.util.externalizable.PrototypeFactory
 import org.javarosa.model.xform.XPathReference
-import org.javarosa.xform.util.InterningKXmlParser
 import org.javarosa.xform.util.XFormSerializer
+import org.javarosa.xml.dom.XmlDocumentHelper
 import org.javarosa.xform.util.XFormUtils
 import org.javarosa.xpath.XPathConditional
 import org.javarosa.xpath.XPathException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.XPathUnsupportedException
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
-import org.kxml2.kdom.Document
-import org.kxml2.kdom.Element
-import org.kxml2.kdom.Node
 import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.Reader
+import org.javarosa.xml.dom.XmlDocument
+import org.javarosa.xml.dom.XmlElement
+import org.javarosa.xml.dom.XmlNode
 
 /**
  * Provides conversion from xform to epihandy object model and vice vasa.
@@ -263,7 +262,7 @@ class XFormParser {
         }
 
         @JvmStatic
-        fun buildInstanceStructure(node: Element, parent: TreeElement?): TreeElement {
+        fun buildInstanceStructure(node: XmlElement, parent: TreeElement?): TreeElement {
             return buildInstanceStructure(node, parent, null, node.namespace)
         }
 
@@ -273,7 +272,7 @@ class XFormParser {
          */
         @JvmStatic
         fun buildInstanceStructure(
-            node: Element,
+            node: XmlElement,
             parent: TreeElement?,
             instanceName: String?,
             docnamespace: String?
@@ -284,8 +283,8 @@ class XFormParser {
             var hasElements = false
             for (i in 0 until numChildren) {
                 when (node.getType(i)) {
-                    Node.ELEMENT -> hasElements = true
-                    Node.TEXT -> if (node.getText(i).trim().isNotEmpty()) hasText = true
+                    XmlNode.ELEMENT -> hasElements = true
+                    XmlNode.TEXT -> if (node.getText(i).trim().isNotEmpty()) hasText = true
                 }
             }
             if (hasElements && hasText) {
@@ -327,7 +326,7 @@ class XFormParser {
 
             if (hasElements) {
                 for (i in 0 until numChildren) {
-                    if (node.getType(i) == Node.ELEMENT) {
+                    if (node.getType(i) == XmlNode.ELEMENT) {
                         element.addChild(
                             buildInstanceStructure(node.getElement(i), element, instanceName, docnamespace)
                         )
@@ -476,11 +475,11 @@ class XFormParser {
         /**
          * Traverse the node, copying data from it into the TreeElement argument.
          */
-        private fun loadInstanceData(node: Element, cur: TreeElement) {
+        private fun loadInstanceData(node: XmlElement, cur: TreeElement) {
             val numChildren = node.childCount
             var hasElements = false
             for (i in 0 until numChildren) {
-                if (node.getType(i) == Node.ELEMENT) {
+                if (node.getType(i) == XmlNode.ELEMENT) {
                     hasElements = true
                     break
                 }
@@ -489,7 +488,7 @@ class XFormParser {
             if (hasElements) {
                 val multiplicities = HashMap<String, Int>()
                 for (i in 0 until numChildren) {
-                    if (node.getType(i) == Node.ELEMENT) {
+                    if (node.getType(i) == XmlNode.ELEMENT) {
                         val child = node.getElement(i)
                         val cName = child.name
                         val index: Int
@@ -514,7 +513,7 @@ class XFormParser {
             }
         }
 
-        private fun loadNamespaces(e: Element, tree: FormInstance): HashMap<String, String> {
+        private fun loadNamespaces(e: XmlElement, tree: FormInstance): HashMap<String, String> {
             val prefixes = HashMap<String, String>()
             for (i in 0 until e.namespaceCount) {
                 val uri = e.getNamespaceUri(i)
@@ -537,7 +536,7 @@ class XFormParser {
          * call before f.initialize()!
          */
         @JvmStatic
-        fun loadXmlInstance(f: FormDef, xmlInst: Document): FormDef {
+        fun loadXmlInstance(f: FormDef, xmlInst: XmlDocument): FormDef {
             return loadXmlInstance(f, restoreDataModel(xmlInst, null))
         }
 
@@ -593,26 +592,18 @@ class XFormParser {
         }
 
         @JvmStatic
-        fun getXMLDocument(reader: Reader): Document {
+        fun getXMLDocument(reader: Reader): XmlDocument {
             return getXMLDocument(reader, null)
         }
 
         @JvmStatic
-        fun getXMLDocument(reader: Reader, stringCache: Interner<String>?): Document {
-            val doc = Document()
+        fun getXMLDocument(reader: Reader, stringCache: Interner<String>?): XmlDocument {
+            val doc: XmlDocument
 
             try {
-                val parser: KXmlParser = if (stringCache != null) {
-                    InterningKXmlParser(stringCache)
-                } else {
-                    KXmlParser()
-                }
-
-                parser.setInput(reader)
-                parser.setFeature(PlatformXmlParser.FEATURE_PROCESS_NAMESPACES, true)
-                doc.parse(parser)
+                doc = XmlDocumentHelper.parseDocument(reader, stringCache)
             } catch (e: PlatformXmlParserException) {
-                val errorMsg = "XML Syntax Error at Line: ${e.lineNumber}, Column: ${e.columnNumber}!"
+                val errorMsg = "XML Syntax Error!"
                 System.err.println(errorMsg)
                 e.printStackTrace()
                 throw XFormParseException(errorMsg)
@@ -637,7 +628,7 @@ class XFormParser {
             // so we really want to go through and convert the kxml parsed
             // text (which have lots of characters each as their own string)
             // into one single string
-            val q = ArrayDeque<Element>()
+            val q = ArrayDeque<XmlElement>()
 
             q.addLast(doc.rootElement)
             while (!q.isEmpty()) {
@@ -647,20 +638,20 @@ class XFormParser {
                 var i = 0
                 while (i < e.childCount) {
                     val type = e.getType(i)
-                    if (type == Element.TEXT) {
+                    if (type == XmlElement.TEXT) {
                         val text = e.getText(i)
                         accumulate += text
                         toRemove[i] = true
                     } else {
-                        if (type == Element.ELEMENT) {
+                        if (type == XmlElement.ELEMENT) {
                             q.add(e.getElement(i))
                         }
                         val accumulatedString = accumulate.trim()
                         if (accumulatedString.isNotEmpty()) {
                             if (stringCache == null) {
-                                e.addChild(i, Element.TEXT, accumulate)
+                                e.addChild(i, XmlElement.TEXT, accumulate)
                             } else {
-                                e.addChild(i, Element.TEXT, stringCache.intern(accumulate))
+                                e.addChild(i, XmlElement.TEXT, stringCache.intern(accumulate))
                             }
                             accumulate = ""
                             ++i
@@ -672,9 +663,9 @@ class XFormParser {
                 }
                 if (accumulate.trim().isNotEmpty()) {
                     if (stringCache == null) {
-                        e.addChild(Element.TEXT, accumulate)
+                        e.addChild(XmlElement.TEXT, accumulate)
                     } else {
-                        e.addChild(Element.TEXT, stringCache.intern(accumulate))
+                        e.addChild(XmlElement.TEXT, stringCache.intern(accumulate))
                     }
                 }
                 for (idx in e.childCount - 1 downTo 0) {
@@ -688,7 +679,7 @@ class XFormParser {
         }
 
         @JvmStatic
-        fun getXMLText(n: Node, trim: Boolean): String? {
+        fun getXMLText(n: XmlNode, trim: Boolean): String? {
             return if (n.childCount == 0) null else getXMLText(n, 0, trim)
         }
 
@@ -698,13 +689,13 @@ class XFormParser {
          * e.g. "abc&amp;123" --> (abc)(&)(123)
          */
         @JvmStatic
-        fun getXMLText(node: Node, startIndex: Int, trim: Boolean): String? {
+        fun getXMLText(node: XmlNode, startIndex: Int, trim: Boolean): String? {
             var strBuff: StringBuffer? = null
 
             var text: String? = node.getText(startIndex) ?: return null
 
             var i = startIndex + 1
-            while (i < node.childCount && node.getType(i) == Node.TEXT) {
+            while (i < node.childCount && node.getType(i) == XmlNode.TEXT) {
                 if (strBuff == null) strBuff = StringBuffer(text)
                 strBuff.append(node.getText(i))
                 i++
@@ -724,7 +715,7 @@ class XFormParser {
         }
 
         @JvmStatic
-        fun restoreDataModel(doc: Document, restorableType: Class<*>?): FormInstance {
+        fun restoreDataModel(doc: XmlDocument, restorableType: Class<*>?): FormInstance {
             val r = if (restorableType != null) PrototypeFactory.getInstance(restorableType) as? org.javarosa.core.model.util.restorable.Restorable else null
 
             val e = doc.rootElement
@@ -741,12 +732,12 @@ class XFormParser {
         }
 
         @JvmStatic
-        fun getVagueLocation(e: Element): String {
+        fun getVagueLocation(e: XmlElement): String {
             var path = e.name
-            var walker: Element? = e
+            var walker: XmlElement? = e
             while (walker != null) {
                 val n = walker.parent
-                if (n is Element) {
+                if (n is XmlElement) {
                     walker = n
                     var step = walker.name
                     for (i in 0 until walker.attributeCount) {
@@ -768,7 +759,7 @@ class XFormParser {
         }
 
         @JvmStatic
-        fun getVagueElementPrintout(e: Element, maxDepth: Int): String {
+        fun getVagueElementPrintout(e: XmlElement, maxDepth: Int): String {
             var elementString = "<" + e.name
             for (i in 0 until e.attributeCount) {
                 elementString += " " + e.getAttributeName(i) + "=\""
@@ -776,9 +767,9 @@ class XFormParser {
             }
             if (e.childCount > 0) {
                 elementString += ">"
-                if (e.getType(0) == Element.ELEMENT) {
+                if (e.getType(0) == XmlElement.ELEMENT) {
                     elementString += if (maxDepth > 0) {
-                        getVagueElementPrintout(e.getChild(0) as Element, maxDepth - 1)
+                        getVagueElementPrintout(e.getChild(0) as XmlElement, maxDepth - 1)
                     } else {
                         "..."
                     }
@@ -810,11 +801,11 @@ class XFormParser {
     private val extensionParsers: ArrayList<QuestionExtensionParser> = ArrayList()
 
     private var _reader: Reader? = null
-    private var _xmldoc: Document? = null
+    private var _xmldoc: XmlDocument? = null
     private var _f: FormDef? = null
 
     private var _instReader: Reader? = null
-    private var _instDoc: Document? = null
+    private var _instDoc: XmlDocument? = null
 
     private var modelFound = false
     private lateinit var bindingsByID: HashMap<String, DataBinding>
@@ -824,8 +815,8 @@ class XFormParser {
     private lateinit var itemsets: ArrayList<ItemsetBinding>
     private lateinit var selectOnes: ArrayList<TreeReference>
     private lateinit var selectMultis: ArrayList<TreeReference>
-    private var mainInstanceNode: Element? = null
-    private lateinit var instanceNodes: ArrayList<Element>
+    private var mainInstanceNode: XmlElement? = null
+    private lateinit var instanceNodes: ArrayList<XmlElement>
     private lateinit var instanceNodeIdStrs: ArrayList<String?>
     private var defaultNamespace: String? = null
     private lateinit var itextKnownForms: ArrayList<String>
@@ -845,7 +836,7 @@ class XFormParser {
         _reader = reader
     }
 
-    constructor(doc: Document) {
+    constructor(doc: XmlDocument) {
         _xmldoc = doc
     }
 
@@ -854,7 +845,7 @@ class XFormParser {
         _instReader = instance
     }
 
-    constructor(form: Document, instance: Document) {
+    constructor(form: XmlDocument, instance: XmlDocument) {
         _xmldoc = form
         _instDoc = instance
     }
@@ -920,7 +911,7 @@ class XFormParser {
     fun parseUnregisteredSpecExtension(
         namespace: String,
         name: String,
-        e: Element,
+        e: XmlElement,
         parent: Any,
         handlers: HashMap<String, IElementHandler>
     ) {
@@ -934,7 +925,7 @@ class XFormParser {
 
         if (parseSpecExtensionsInnerElements.contains(namespace)) {
             for (i in 0 until e.childCount) {
-                if (e.getType(i) == Element.ELEMENT) {
+                if (e.getType(i) == XmlElement.ELEMENT) {
                     parseElement(e.getElement(i), parent, handlers)
                 }
             }
@@ -986,14 +977,14 @@ class XFormParser {
                     if (e.childCount > 0) {
                         for (k in 0 until e.childCount) {
                             when (e.getType(k)) {
-                                Element.TEXT -> {
+                                XmlElement.TEXT -> {
                                     if ("" == e.getText(i).trim()) {
                                         continue
                                     }
                                     // fall through (no break in original Java)
                                 }
-                                Element.IGNORABLE_WHITESPACE -> continue
-                                Element.ELEMENT -> throw XFormParseException(
+                                XmlElement.IGNORABLE_WHITESPACE -> continue
+                                XmlElement.ELEMENT -> throw XFormParseException(
                                     "Instance declaration for instance $instanceid contains both a src and a body, only one is permitted",
                                     e
                                 )
@@ -1041,7 +1032,7 @@ class XFormParser {
         itextKnownForms.add("audio")
     }
 
-    private fun parseElement(e: Element, parent: Any, handlers: HashMap<String, IElementHandler>) {
+    private fun parseElement(e: XmlElement, parent: Any, handlers: HashMap<String, IElementHandler>) {
         val name = e.name
         val namespace = e.namespace
 
@@ -1073,7 +1064,7 @@ class XFormParser {
                     )
                 }
                 for (i in 0 until e.childCount) {
-                    if (e.getType(i) == Element.ELEMENT) {
+                    if (e.getType(i) == XmlElement.ELEMENT) {
                         parseElement(e.getElement(i), parent, handlers)
                     }
                 }
@@ -1081,7 +1072,7 @@ class XFormParser {
         }
     }
 
-    private fun parseTitle(e: Element) {
+    private fun parseTitle(e: XmlElement) {
         val usedAtts = ArrayList<String>()
         val title = getXMLText(e, true)
         _f!!.setTitle(title)
@@ -1094,7 +1085,7 @@ class XFormParser {
         }
     }
 
-    private fun parseMeta(e: Element) {
+    private fun parseMeta(e: XmlElement) {
         val usedAtts = ArrayList<String>()
         val attributes = e.attributeCount
         for (i in 0 until attributes) {
@@ -1111,9 +1102,9 @@ class XFormParser {
         }
     }
 
-    private fun parseModel(e: Element) {
+    private fun parseModel(e: XmlElement) {
         val usedAtts = ArrayList<String>()
-        val delayedParseElements = ArrayList<Element>()
+        val delayedParseElements = ArrayList<XmlElement>()
 
         if (modelFound) {
             reporter.warning(
@@ -1132,7 +1123,7 @@ class XFormParser {
         var i = 0
         while (i < e.childCount) {
             val type = e.getType(i)
-            val child: Element? = if (type == Node.ELEMENT) e.getElement(i) else null
+            val child: XmlElement? = if (type == XmlNode.ELEMENT) e.getElement(i) else null
             val childName: String? = child?.name
 
             if ("itext" == childName) {
@@ -1146,11 +1137,11 @@ class XFormParser {
             } else if (childName != null && actionHandlers.containsKey(childName)) {
                 delayedParseElements.add(child)
             } else {
-                if (type == Node.ELEMENT) {
+                if (type == XmlNode.ELEMENT) {
                     if (child!!.namespace == NAMESPACE_XFORMS) {
                         throw XFormParseException("Unrecognized top-level tag [$childName] found within <model>", child)
                     }
-                } else if (type == Node.TEXT && getXMLText(e, i, true)!!.isNotEmpty()) {
+                } else if (type == XmlNode.TEXT && getXMLText(e, i, true)!!.isNotEmpty()) {
                     throw XFormParseException(
                         "Unrecognized text content found within <model>: \"${getXMLText(e, i, true)}\"",
                         child ?: e
@@ -1179,7 +1170,7 @@ class XFormParser {
     /**
      * Generic parse method that all actions get passed through.
      */
-    private fun parseAction(e: Element, parent: Any, specificHandler: IElementHandler) {
+    private fun parseAction(e: XmlElement, parent: Any, specificHandler: IElementHandler) {
         val event = e.getAttributeValue(null, EVENT_ATTR)
         if (!Action.isValidEvent(event)) {
             throw XFormParseException("An action was registered for an unsupported event: $event")
@@ -1195,7 +1186,7 @@ class XFormParser {
         specificHandler.handle(this, e, parent)
     }
 
-    fun parseSetValueAction(source: ActionController, e: Element) {
+    fun parseSetValueAction(source: ActionController, e: XmlElement) {
         val ref = e.getAttributeValue(null, REF_ATTR)
         val bind = e.getAttributeValue(null, BIND_ATTR)
 
@@ -1245,7 +1236,7 @@ class XFormParser {
         source.registerEventListener(event, action)
     }
 
-    fun parseSendAction(source: ActionController, e: Element) {
+    fun parseSendAction(source: ActionController, e: XmlElement) {
         val event = getRequiredAttribute(e, "event")
         val id = getRequiredAttribute(e, "submission")
 
@@ -1253,7 +1244,7 @@ class XFormParser {
         source.registerEventListener(event, action)
     }
 
-    private fun getRequiredAttribute(e: Element, attrName: String): String {
+    private fun getRequiredAttribute(e: XmlElement, attrName: String): String {
         val value = e.getAttributeValue(null, attrName)
         if (value == null || value == "") {
             throw XFormParseException("Missing required attribute $attrName in element", e)
@@ -1261,7 +1252,7 @@ class XFormParser {
         return value
     }
 
-    private fun parseSubmission(submission: Element) {
+    private fun parseSubmission(submission: XmlElement) {
         val id = submission.getAttributeValue(null, ID_ATTR)
 
         val resource = getRequiredAttribute(submission, "resource")
@@ -1303,12 +1294,12 @@ class XFormParser {
         _f!!.addSubmissionProfile(id, profile)
     }
 
-    private fun saveInstanceNode(instance: Element) {
-        var instanceNode: Element? = null
+    private fun saveInstanceNode(instance: XmlElement) {
+        var instanceNode: XmlElement? = null
         val instanceId = instance.getAttributeValue("", "id")
 
         for (i in 0 until instance.childCount) {
-            if (instance.getType(i) == Node.ELEMENT) {
+            if (instance.getType(i) == XmlNode.ELEMENT) {
                 if (instanceNode != null) {
                     throw XFormParseException("XForm Parse: <instance> has more than one child element", instance)
                 } else {
@@ -1331,7 +1322,7 @@ class XFormParser {
         instanceNodeIdStrs.add(instanceId)
     }
 
-    protected fun parseUpload(parent: IFormElement, e: Element, controlUpload: Int): QuestionDef {
+    protected fun parseUpload(parent: IFormElement, e: XmlElement, controlUpload: Int): QuestionDef {
         val usedAtts = ArrayList<String>()
         usedAtts.add("mediatype")
 
@@ -1351,13 +1342,13 @@ class XFormParser {
         return question
     }
 
-    protected fun parseControl(parent: IFormElement, e: Element, controlType: Int): QuestionDef {
+    protected fun parseControl(parent: IFormElement, e: XmlElement, controlType: Int): QuestionDef {
         return parseControl(parent, e, controlType, ArrayList())
     }
 
     protected fun parseControl(
         parent: IFormElement,
-        e: Element,
+        e: XmlElement,
         controlType: Int,
         usedAtts: ArrayList<String>
     ): QuestionDef {
@@ -1461,14 +1452,14 @@ class XFormParser {
     }
 
     private fun parseControlChildren(
-        e: Element,
+        e: XmlElement,
         question: QuestionDef,
         parent: IFormElement,
         isSelect: Boolean
     ) {
         for (i in 0 until e.childCount) {
             val type = e.getType(i)
-            val child: Element? = if (type == Node.ELEMENT) e.getElement(i) else null
+            val child: XmlElement? = if (type == XmlNode.ELEMENT) e.getElement(i) else null
             if (child == null) continue
             val childName = child.name
 
@@ -1486,7 +1477,7 @@ class XFormParser {
         }
     }
 
-    private fun parseHelperText(q: QuestionDef, e: Element) {
+    private fun parseHelperText(q: QuestionDef, e: XmlElement) {
         val usedAtts = ArrayList<String>()
         usedAtts.add(REF_ATTR)
         val xmlText = getXMLText(e, true)
@@ -1515,7 +1506,7 @@ class XFormParser {
         }
     }
 
-    private fun parseGroupLabel(g: GroupDef, e: Element) {
+    private fun parseGroupLabel(g: GroupDef, e: XmlElement) {
         if (g.isRepeat()) return
 
         val usedAtts = ArrayList<String>()
@@ -1533,7 +1524,7 @@ class XFormParser {
         }
     }
 
-    private fun getItextReference(e: Element): String? {
+    private fun getItextReference(e: XmlElement): String? {
         val ref = e.getAttributeValue("", REF_ATTR)
         if (ref != null) {
             if (ref.startsWith(ITEXT_OPEN) && ref.endsWith(ITEXT_CLOSE)) {
@@ -1547,7 +1538,7 @@ class XFormParser {
         return null
     }
 
-    private fun getLabelOrTextId(element: Element): String? {
+    private fun getLabelOrTextId(element: XmlElement): String? {
         val labelItextId = getItextReference(element)
         if (!StringUtils.isEmpty(labelItextId)) {
             return labelItextId
@@ -1555,16 +1546,16 @@ class XFormParser {
         return getLabel(element)
     }
 
-    private fun getLabel(e: Element): String? {
+    private fun getLabel(e: XmlElement): String? {
         if (e.childCount == 0) return null
 
         recurseForOutput(e)
 
         val sb = StringBuffer()
         for (i in 0 until e.childCount) {
-            if (e.getType(i) != Node.TEXT && e.getChild(i) !is String) {
+            if (e.getType(i) != XmlNode.TEXT && e.getChild(i) !is String) {
                 val b = e.getChild(i)
-                val child = b as Element
+                val child = b as XmlElement
 
                 if (NAMESPACE_HTML == child.namespace) {
                     sb.append(XFormSerializer.elementToString(child))
@@ -1583,13 +1574,13 @@ class XFormParser {
         return sb.toString().trim()
     }
 
-    private fun recurseForOutput(e: Element) {
+    private fun recurseForOutput(e: XmlElement) {
         if (e.childCount == 0) return
 
         var i = 0
         while (i < e.childCount) {
             val kidType = e.getType(i)
-            if (kidType == Node.TEXT) {
+            if (kidType == XmlNode.TEXT) {
                 i++
                 continue
             }
@@ -1597,12 +1588,12 @@ class XFormParser {
                 i++
                 continue
             }
-            val kid = e.getChild(i) as Element
+            val kid = e.getChild(i) as XmlElement
 
-            if (kidType == Node.ELEMENT && XFormUtils.isOutput(kid)) {
+            if (kidType == XmlNode.ELEMENT && XFormUtils.isOutput(kid)) {
                 val s = "\${${parseOutput(kid)}}"
                 e.removeChild(i)
-                e.addChild(i, Node.TEXT, s)
+                e.addChild(i, XmlNode.TEXT, s)
             } else if (kid.childCount != 0) {
                 recurseForOutput(kid)
             } else {
@@ -1613,7 +1604,7 @@ class XFormParser {
         }
     }
 
-    private fun parseOutput(e: Element): String {
+    private fun parseOutput(e: XmlElement): String {
         var xpath = e.getAttributeValue(null, REF_ATTR)
         var attr = REF_ATTR
         if (xpath == null) {
@@ -1649,7 +1640,7 @@ class XFormParser {
         return index.toString()
     }
 
-    private fun parseItem(q: QuestionDef, e: Element) {
+    private fun parseItem(q: QuestionDef, e: XmlElement) {
         val MAX_VALUE_LEN = 256
 
         val usedAtts = ArrayList<String>()
@@ -1664,7 +1655,7 @@ class XFormParser {
 
         for (i in 0 until e.childCount) {
             val type = e.getType(i)
-            val child: Element? = if (type == Node.ELEMENT) e.getElement(i) else null
+            val child: XmlElement? = if (type == XmlNode.ELEMENT) e.getElement(i) else null
             val childName: String? = child?.name
 
             if (LABEL_ELEMENT == childName) {
@@ -1734,7 +1725,7 @@ class XFormParser {
         }
     }
 
-    private fun parseItemset(q: QuestionDef, e: Element) {
+    private fun parseItemset(q: QuestionDef, e: XmlElement) {
         val itemset = ItemsetBinding()
 
         val usedAtts = ArrayList<String>()
@@ -1753,7 +1744,7 @@ class XFormParser {
 
         for (i in 0 until e.childCount) {
             val type = e.getType(i)
-            val child: Element? = if (type == Node.ELEMENT) e.getElement(i) else null
+            val child: XmlElement? = if (type == XmlNode.ELEMENT) e.getElement(i) else null
             val childName: String? = child?.name
 
             if (LABEL_ELEMENT == childName) {
@@ -1793,7 +1784,7 @@ class XFormParser {
         }
     }
 
-    private fun parseItemsetLabelElement(child: Element, itemset: ItemsetBinding, labelUA: ArrayList<String>) {
+    private fun parseItemsetLabelElement(child: XmlElement, itemset: ItemsetBinding, labelUA: ArrayList<String>) {
         val labelXpath = child.getAttributeValue("", REF_ATTR)
 
         if (XFormUtils.showUnusedAttributeWarning(child, labelUA)) {
@@ -1803,7 +1794,7 @@ class XFormParser {
         ItemSetParsingUtils.setLabel(itemset, labelXpath)
     }
 
-    private fun parseItemsetCopyElement(child: Element, itemset: ItemsetBinding, copyUA: ArrayList<String>) {
+    private fun parseItemsetCopyElement(child: XmlElement, itemset: ItemsetBinding, copyUA: ArrayList<String>) {
         val copyRef = child.getAttributeValue("", REF_ATTR)
         if (XFormUtils.showUnusedAttributeWarning(child, copyUA)) {
             reporter.warning(XFormParserReporter.TYPE_UNKNOWN_MARKUP, XFormUtils.unusedAttWarning(child, copyUA), getVagueLocation(child))
@@ -1815,7 +1806,7 @@ class XFormParser {
         itemset.copyMode = true
     }
 
-    private fun parseItemsetValueElement(child: Element, itemset: ItemsetBinding, valueUA: ArrayList<String>) {
+    private fun parseItemsetValueElement(child: XmlElement, itemset: ItemsetBinding, valueUA: ArrayList<String>) {
         val valueXpath = child.getAttributeValue("", REF_ATTR)
 
         if (XFormUtils.showUnusedAttributeWarning(child, valueUA)) {
@@ -1824,12 +1815,12 @@ class XFormParser {
         ItemSetParsingUtils.setValue(itemset, valueXpath)
     }
 
-    private fun parseItemsetSortElement(child: Element, itemset: ItemsetBinding) {
+    private fun parseItemsetSortElement(child: XmlElement, itemset: ItemsetBinding) {
         val sortXpathString = child.getAttributeValue("", REF_ATTR)
         ItemSetParsingUtils.setSort(itemset, sortXpathString)
     }
 
-    private fun parseGroup(parent: IFormElement, e: Element, groupType: Int) {
+    private fun parseGroup(parent: IFormElement, e: XmlElement, groupType: Int) {
         val group = GroupDef()
         group.setID(serialQuestionID++)
         var dataRef: XPathReference? = null
@@ -1890,7 +1881,7 @@ class XFormParser {
 
         for (i in 0 until e.childCount) {
             val type = e.getType(i)
-            val child: Element? = if (type == Node.ELEMENT) e.getElement(i) else null
+            val child: XmlElement? = if (type == XmlNode.ELEMENT) e.getElement(i) else null
             val childName: String? = child?.name
             val childNamespace: String? = child?.namespace
 
@@ -1910,7 +1901,7 @@ class XFormParser {
         }
 
         for (i in 0 until e.childCount) {
-            if (e.getType(i) == Element.ELEMENT) {
+            if (e.getType(i) == XmlElement.ELEMENT) {
                 parseElement(e.getElement(i), group, groupLevelHandlers)
             }
         }
@@ -1951,7 +1942,7 @@ class XFormParser {
         this.stringCache = stringCache
     }
 
-    private fun parseIText(itext: Element) {
+    private fun parseIText(itext: XmlElement) {
         val l = Localizer(true, true)
         _f!!.setLocalizer(l)
 
@@ -1976,7 +1967,7 @@ class XFormParser {
         }
     }
 
-    private fun parseTranslation(l: Localizer, trans: Element) {
+    private fun parseTranslation(l: Localizer, trans: XmlElement) {
         val usedAtts = ArrayList<String>()
         usedAtts.add("lang")
         usedAtts.add("default")
@@ -2021,7 +2012,7 @@ class XFormParser {
         l.registerLocaleResource(lang, source)
     }
 
-    private fun parseTextHandle(l: TableLocaleSource, text: Element) {
+    private fun parseTextHandle(l: TableLocaleSource, text: XmlElement) {
         val id = text.getAttributeValue("", ID_ATTR)
 
         val usedAtts = ArrayList<String>()
@@ -2114,7 +2105,7 @@ class XFormParser {
         return false
     }
 
-    private fun processStandardBindAttributes(usedAtts: ArrayList<String>, e: Element): DataBinding {
+    private fun processStandardBindAttributes(usedAtts: ArrayList<String>, e: XmlElement): DataBinding {
         usedAtts.add(ID_ATTR)
         usedAtts.add(NODESET_ATTR)
         usedAtts.add("type")
@@ -2227,7 +2218,7 @@ class XFormParser {
         return binding
     }
 
-    private fun parseBind(e: Element) {
+    private fun parseBind(e: XmlElement) {
         val usedAtts = ArrayList<String>()
 
         val binding = processStandardBindAttributes(usedAtts, e)
@@ -2287,7 +2278,7 @@ class XFormParser {
         }
     }
 
-    private fun addMainInstanceToFormDef(e: Element, instanceModel: FormInstance) {
+    private fun addMainInstanceToFormDef(e: XmlElement, instanceModel: FormInstance) {
         loadInstanceData(e, instanceModel.getRoot())
 
         checkDependencyCycles()
@@ -2301,7 +2292,7 @@ class XFormParser {
         }
     }
 
-    private fun parseInstance(e: Element, isMainInstance: Boolean): FormInstance {
+    private fun parseInstance(e: XmlElement, isMainInstance: Boolean): FormInstance {
         val name: String? = instanceNodeIdStrs[instanceNodes.indexOf(e)]
 
         val root = buildInstanceStructure(e, null, if (!isMainInstance) name else null, e.namespace)

--- a/commcare-core/src/main/java/org/javarosa/xform/util/InterningKXmlParser.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/util/InterningKXmlParser.kt
@@ -1,47 +1,80 @@
 package org.javarosa.xform.util
 
 import org.javarosa.core.util.Interner
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 
 /**
+ * A PlatformXmlParser decorator that interns string results to reduce memory usage.
+ * Wraps a delegate parser and passes all results through a string interner.
+ *
  * @author ctsims
  */
-class InterningKXmlParser(private val stringCache: Interner<String>) : KXmlParser() {
+class InterningKXmlParser(
+    private val delegate: PlatformXmlParser,
+    private val stringCache: Interner<String>
+) : PlatformXmlParser {
 
     fun release() {
         //Anything?
     }
 
-    override fun getAttributeName(arg0: Int): String {
-        return stringCache.intern(super.getAttributeName(arg0))
+    override fun next(): Int = delegate.next()
+    override val eventType: Int get() = delegate.eventType
+    override val isWhitespace: Boolean get() = delegate.isWhitespace
+    override val depth: Int get() = delegate.depth
+    override val attributeCount: Int get() = delegate.attributeCount
+
+    override val namespace: String? get() {
+        val ns = delegate.namespace ?: return null
+        return stringCache.intern(ns)
     }
 
-    override fun getAttributeNamespace(arg0: Int): String {
-        return stringCache.intern(super.getAttributeNamespace(arg0))
-    }
-
-    override fun getAttributePrefix(arg0: Int): String? {
-        val value = super.getAttributePrefix(arg0) ?: return null
+    override fun getAttributeValue(namespace: String?, name: String): String? {
+        val value = delegate.getAttributeValue(namespace, name) ?: return null
         return stringCache.intern(value)
     }
 
-    override fun getAttributeValue(arg0: Int): String {
-        return stringCache.intern(super.getAttributeValue(arg0))
+    override fun getAttributeName(index: Int): String {
+        return stringCache.intern(delegate.getAttributeName(index))
     }
 
-    override fun getNamespace(arg0: String?): String {
-        return stringCache.intern(super.getNamespace(arg0))
+    override fun getAttributeNamespace(index: Int): String {
+        return stringCache.intern(delegate.getAttributeNamespace(index))
     }
 
-    override fun getNamespaceUri(arg0: Int): String {
-        return stringCache.intern(super.getNamespaceUri(arg0))
+    override fun getAttributePrefix(index: Int): String? {
+        val value = delegate.getAttributePrefix(index) ?: return null
+        return stringCache.intern(value)
     }
 
-    override fun getText(): String {
-        return stringCache.intern(super.getText())
+    override fun getAttributeValue(index: Int): String {
+        return stringCache.intern(delegate.getAttributeValue(index))
     }
 
-    override fun getName(): String {
-        return stringCache.intern(super.getName())
+    override fun getNamespace(prefix: String?): String {
+        return stringCache.intern(delegate.getNamespace(prefix))
+    }
+
+    override val text: String? get() {
+        val t = delegate.text ?: return null
+        return stringCache.intern(t)
+    }
+
+    override val name: String? get() {
+        val n = delegate.name ?: return null
+        return stringCache.intern(n)
+    }
+
+    override fun nextText(): String {
+        return stringCache.intern(delegate.nextText())
+    }
+
+    override fun nextTag(): Int = delegate.nextTag()
+
+    override val positionDescription: String get() = delegate.positionDescription
+
+    override val prefix: String? get() {
+        val p = delegate.prefix ?: return null
+        return stringCache.intern(p)
     }
 }

--- a/commcare-core/src/main/java/org/javarosa/xform/util/XFormSerializer.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/util/XFormSerializer.kt
@@ -1,69 +1,30 @@
 package org.javarosa.xform.util
 
-import org.kxml2.io.KXmlSerializer
-import org.kxml2.kdom.Document
-import org.kxml2.kdom.Element
-import org.xmlpull.v1.XmlSerializer
-
-import java.io.ByteArrayOutputStream
-import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
-import java.io.OutputStreamWriter
-import java.io.UnsupportedEncodingException
+import org.javarosa.xml.dom.XmlDocument
+import org.javarosa.xml.dom.XmlDomWriter
+import org.javarosa.xml.dom.XmlElement
 
 class XFormSerializer {
     companion object {
         @JvmStatic
-        fun elementToString(e: Element): String? {
-            val serializer = KXmlSerializer()
-
-            val bos = ByteArrayOutputStream()
-            val dos = DataOutputStream(bos)
-            try {
-                serializer.setOutput(dos, null)
-                e.write(serializer)
-                serializer.flush()
-                return String(bos.toByteArray(), Charsets.UTF_8)
-            } catch (uce: UnsupportedEncodingException) {
-                uce.printStackTrace()
-            } catch (ex: Exception) {
-                ex.printStackTrace()
-                return null
-            }
-
-            return null
+        fun elementToString(e: XmlElement): String? {
+            return XmlDomWriter.elementToString(e)
         }
 
         /**
          * Formats an XML document into a UTF-8 (no BOM) compatible format
          *
          * @return The raw bytes of the utf-8 encoded doc
-         * @throws PlatformIOException                           If there is an issue transferring
-         *                                               the bytes to a byte stream.
+         * @throws PlatformIOException If there is an issue transferring
+         *                             the bytes to a byte stream.
          * @throws UnsupportedUnicodeSurrogatesException If the document contains values
          *                                               that are not UTF-8 encoded.
          */
         @JvmStatic
         @Throws(PlatformIOException::class)
-        fun getUtfBytesFromDocument(doc: Document): ByteArray {
-            val serializer = object : KXmlSerializer() {
-                @Throws(PlatformIOException::class)
-                override fun text(text: String): XmlSerializer {
-                    try {
-                        return super.text(text)
-                    } catch (e: IllegalArgumentException) {
-                        // certain versions of Android have trouble encoding
-                        // unicode characters that require "surrogates".
-                        throw UnsupportedUnicodeSurrogatesException(text)
-                    }
-                }
-            }
-            val bos = ByteArrayOutputStream()
-            val osw = OutputStreamWriter(bos, "UTF-8")
-            serializer.setOutput(osw)
-            doc.write(serializer)
-            serializer.flush()
-            return bos.toByteArray()
+        fun getUtfBytesFromDocument(doc: XmlDocument): ByteArray {
+            return XmlDomWriter.getUtfBytesFromDocument(doc)
         }
     }
 

--- a/commcare-core/src/main/java/org/javarosa/xform/util/XFormUtils.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/util/XFormUtils.kt
@@ -5,12 +5,12 @@ import org.javarosa.core.model.FormDef
 import org.javarosa.xform.parse.QuestionExtensionParser
 import org.javarosa.xform.parse.XFormParseException
 import org.javarosa.xform.parse.XFormParserFactory
-import org.kxml2.kdom.Element
 
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.UnsupportedEncodingException
+import org.javarosa.xml.dom.XmlElement
 
 /**
  * Static Utility methods pertaining to XForms.
@@ -120,7 +120,7 @@ class XFormUtils {
          * Get the list of attributes in an element
          */
         @JvmStatic
-        fun getAttributeList(e: Element): ArrayList<String> {
+        fun getAttributeList(e: XmlElement): ArrayList<String> {
             val atts = ArrayList<String>()
 
             for (i in 0 until e.attributeCount) {
@@ -134,7 +134,7 @@ class XFormUtils {
          * @return ArrayList of attributes from 'e' that aren't in 'usedAtts'
          */
         @JvmStatic
-        fun getUnusedAttributes(e: Element, usedAtts: ArrayList<String>): ArrayList<String> {
+        fun getUnusedAttributes(e: XmlElement, usedAtts: ArrayList<String>): ArrayList<String> {
             val unusedAtts = getAttributeList(e)
             for (i in 0 until usedAtts.size) {
                 if (unusedAtts.contains(usedAtts[i])) {
@@ -148,11 +148,11 @@ class XFormUtils {
          * @return String warning about which attributes from 'e' aren't in 'usedAtts'
          */
         @JvmStatic
-        fun unusedAttWarning(e: Element, usedAtts: ArrayList<String>): String {
+        fun unusedAttWarning(e: XmlElement, usedAtts: ArrayList<String>): String {
             var warning = ""
             val unusedAtts = getUnusedAttributes(e, usedAtts)
 
-            warning += unusedAtts.size.toString() + " unrecognized attributes found in Element [" +
+            warning += unusedAtts.size.toString() + " unrecognized attributes found in XmlElement [" +
                     e.name + "] and will be ignored: "
             warning += "["
             for (i in 0 until unusedAtts.size) {
@@ -171,7 +171,7 @@ class XFormUtils {
          * in 'usedAtts'
          */
         @JvmStatic
-        fun showUnusedAttributeWarning(e: Element, usedAtts: ArrayList<String>): Boolean {
+        fun showUnusedAttributeWarning(e: XmlElement, usedAtts: ArrayList<String>): Boolean {
             return getUnusedAttributes(e, usedAtts).size > 0
         }
 
@@ -179,7 +179,7 @@ class XFormUtils {
          * Is this element an Output tag?
          */
         @JvmStatic
-        fun isOutput(e: Element): Boolean {
+        fun isOutput(e: XmlElement): Boolean {
             return e.name.lowercase() == "output"
         }
     }

--- a/commcare-core/src/main/java/org/javarosa/xml/ElementParser.java
+++ b/commcare-core/src/main/java/org/javarosa/xml/ElementParser.java
@@ -4,7 +4,6 @@ import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.services.Logger;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
-import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -27,7 +26,7 @@ import java.util.Date;
  * @author ctsims
  */
 public abstract class ElementParser<T> {
-    protected final KXmlParser parser;
+    protected final PlatformXmlParser parser;
 
     private int level = 0;
 
@@ -42,7 +41,7 @@ public abstract class ElementParser<T> {
      *               position of the top level element that represents this
      *               element's XML structure.
      */
-    public ElementParser(KXmlParser parser) {
+    public ElementParser(PlatformXmlParser parser) {
         this.parser = parser;
         level = parser.getDepth();
     }
@@ -56,22 +55,14 @@ public abstract class ElementParser<T> {
      * @throws IOException If the stream cannot be read for any reason
      *                     other than invalid XML Structures.
      */
-    public static KXmlParser instantiateParser(InputStream stream) throws IOException {
-        KXmlParser parser = new KXmlParser();
+    public static PlatformXmlParser instantiateParser(InputStream stream) throws IOException {
         try {
-            parser.setInput(stream, "UTF-8");
-            parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, true);
-
-            //Point to the first available tag.
-            parser.next();
-
-            return parser;
-        } catch (XmlPullParserException e) {
-            // TODO Auto-generated catch block
+            return JvmXmlParser.fromStream(stream);
+        } catch (Exception e) {
+            if (e instanceof IOException) {
+                throw (IOException) e;
+            }
             Logger.exception("Element Parser", e);
-            throw new IOException(e.getMessage());
-        } catch (IllegalArgumentException e) {
-            e.printStackTrace();
             throw new IOException(e.getMessage());
         }
     }
@@ -111,13 +102,8 @@ public abstract class ElementParser<T> {
             }
         }
         if (!checksOut) {
-            int eventType = -1;
-            try {
-                eventType = parser.getEventType();
-            } catch (XmlPullParserException xppe) {
-                //This event type is just here to help elaborate on the exception
-                //so don't crash on it
-            }
+            int eventType = parser.getEventType();
+
             String oneOf = null;
             if (names.length == 1) {
                 oneOf = "<" + names[0] + "> ";
@@ -130,11 +116,11 @@ public abstract class ElementParser<T> {
             }
 
             String foundInstead = "";
-            if (eventType == KXmlParser.END_TAG) {
+            if (eventType == PlatformXmlParser.END_TAG) {
                 foundInstead = "Closing tag </" + parser.getName() + ">";
-            } else if (eventType == KXmlParser.START_TAG) {
+            } else if (eventType == PlatformXmlParser.START_TAG) {
                 foundInstead = "Element <" + parser.getName() + ">";
-            } else if (eventType == KXmlParser.TEXT) {
+            } else if (eventType == PlatformXmlParser.TEXT) {
                 foundInstead = "Text \"" + parser.getText() + "\"";
             } else {
                 foundInstead = "Unknown";
@@ -183,17 +169,17 @@ public abstract class ElementParser<T> {
 
         //eventType = parser.nextTag();
         eventType = parser.next();
-        while (eventType == KXmlParser.TEXT && parser.isWhitespace()) {   // skip whitespace
+        while (eventType == PlatformXmlParser.TEXT && parser.isWhitespace()) {   // skip whitespace
             eventType = parser.next();
         }
 
-        if (eventType == KXmlParser.START_DOCUMENT) {
+        if (eventType == PlatformXmlParser.START_DOCUMENT) {
             //
-        } else if (eventType == KXmlParser.END_DOCUMENT) {
+        } else if (eventType == PlatformXmlParser.END_DOCUMENT) {
             return false;
-        } else if (eventType == KXmlParser.START_TAG) {
+        } else if (eventType == PlatformXmlParser.START_TAG) {
             return true;
-        } else if (eventType == KXmlParser.END_TAG) {
+        } else if (eventType == PlatformXmlParser.END_TAG) {
             //If we've reached the end of the current node path,
             //return false (signaling that the parsing action should end).
             if (isTagNamed(terminal)) {
@@ -207,7 +193,7 @@ public abstract class ElementParser<T> {
             else {
                 return false;
             }
-        } else if (eventType == KXmlParser.TEXT) {
+        } else if (eventType == PlatformXmlParser.TEXT) {
             return true;
         }
         return true;
@@ -325,21 +311,21 @@ public abstract class ElementParser<T> {
 
     public void skipBlock(String tag) throws XmlPullParserException, IOException {
 
-        while (parser.getEventType() != KXmlParser.END_DOCUMENT) {
+        while (parser.getEventType() != PlatformXmlParser.END_DOCUMENT) {
             int eventType;
             eventType = parser.next();
 
-            if (eventType == KXmlParser.START_DOCUMENT) {
+            if (eventType == PlatformXmlParser.START_DOCUMENT) {
 
-            } else if (eventType == KXmlParser.END_DOCUMENT) {
+            } else if (eventType == PlatformXmlParser.END_DOCUMENT) {
                 return;
-            } else if (eventType == KXmlParser.START_TAG) {
+            } else if (eventType == PlatformXmlParser.START_TAG) {
 
-            } else if (eventType == KXmlParser.END_TAG) {
+            } else if (eventType == PlatformXmlParser.END_TAG) {
                 if (parser.getName().equals(tag)) {
                     return;
                 }
-            } else if (eventType == KXmlParser.TEXT) {
+            } else if (eventType == PlatformXmlParser.TEXT) {
 
             }
         }
@@ -347,7 +333,7 @@ public abstract class ElementParser<T> {
 
     protected int nextNonWhitespace() throws XmlPullParserException, IOException {
         int ret = parser.next();
-        if (ret == KXmlParser.TEXT && parser.isWhitespace()) {
+        if (ret == PlatformXmlParser.TEXT && parser.isWhitespace()) {
             ret = parser.next();
         }
         return ret;

--- a/commcare-core/src/main/java/org/javarosa/xml/TreeElementParser.java
+++ b/commcare-core/src/main/java/org/javarosa/xml/TreeElementParser.java
@@ -4,7 +4,6 @@ import org.javarosa.core.model.data.UncastData;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
-import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -17,7 +16,7 @@ public class TreeElementParser extends ElementParser<TreeElement> {
     final int multiplicity;
     final String instanceId;
 
-    public TreeElementParser(KXmlParser parser, int multiplicity, String instanceId) {
+    public TreeElementParser(PlatformXmlParser parser, int multiplicity, String instanceId) {
         super(parser);
         this.multiplicity = multiplicity;
         this.instanceId = instanceId;
@@ -39,7 +38,7 @@ public class TreeElementParser extends ElementParser<TreeElement> {
         // loop parses all siblings at a given depth
         while (parser.getDepth() >= depth) {
             switch (this.nextNonWhitespace()) {
-                case KXmlParser.START_TAG:
+                case PlatformXmlParser.START_TAG:
                     String name = parser.getName();
                     int val;
                     if (multiplicities.containsKey(name)) {
@@ -52,9 +51,9 @@ public class TreeElementParser extends ElementParser<TreeElement> {
                     TreeElement kid = new TreeElementParser(parser, val, instanceId).parse();
                     element.addChild(kid);
                     break;
-                case KXmlParser.END_TAG:
+                case PlatformXmlParser.END_TAG:
                     return element;
-                case KXmlParser.TEXT:
+                case PlatformXmlParser.TEXT:
                     element.setValue(new UncastData(parser.getText().trim()));
                     break;
                 default:

--- a/commcare-core/src/main/java/org/javarosa/xml/util/InvalidStructureException.java
+++ b/commcare-core/src/main/java/org/javarosa/xml/util/InvalidStructureException.java
@@ -1,6 +1,6 @@
 package org.javarosa.xml.util;
 
-import org.kxml2.io.KXmlParser;
+import org.javarosa.xml.PlatformXmlParser;
 
 /**
  * Invalid Structure Exceptions are thrown when an invalid
@@ -14,7 +14,7 @@ public class InvalidStructureException extends Exception {
      * @param message A Message associated with the error.
      * @param parser  The parser in the position at which the error was detected.
      */
-    public InvalidStructureException(String message, KXmlParser parser) {
+    public InvalidStructureException(String message, PlatformXmlParser parser) {
         super("Invalid XML Structure(" + parser.getPositionDescription() + "): " + message);
     }
 
@@ -23,7 +23,7 @@ public class InvalidStructureException extends Exception {
      * @param parser  The parser in the position at which the error was detected.
      * @param file    The file being parsed
      */
-    public InvalidStructureException(String message, String file, KXmlParser parser) {
+    public InvalidStructureException(String message, String file, PlatformXmlParser parser) {
         super("Invalid XML Structure in document " + file + "(" + parser.getPositionDescription() + "): " + message);
     }
 
@@ -31,12 +31,12 @@ public class InvalidStructureException extends Exception {
         super(message);
     }
 
-    public static InvalidStructureException readableInvalidStructureException(String message, KXmlParser parser) {
+    public static InvalidStructureException readableInvalidStructureException(String message, PlatformXmlParser parser) {
         String humanReadableMessage = message + buildParserMessage(parser);
         return new InvalidStructureException(humanReadableMessage);
     }
 
-    private static String buildParserMessage(KXmlParser parser) {
+    private static String buildParserMessage(PlatformXmlParser parser) {
         String prefix = parser.getPrefix();
         if (prefix != null) {
             return ". Source: <" + prefix + ":" + parser.getName() + "> tag in namespace: " + parser.getNamespace();

--- a/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathExpression.kt
+++ b/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathExpression.kt
@@ -10,11 +10,12 @@ import org.javarosa.core.services.Logger
 import org.javarosa.core.util.externalizable.Externalizable
 import org.javarosa.model.xform.DataModelSerializer
 import org.javarosa.xpath.XPathNodeset
-import org.kxml2.io.KXmlSerializer
 
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.OutputStream
 import java.nio.charset.StandardCharsets
+import org.javarosa.xml.JvmXmlSerializer
+import org.javarosa.xml.PlatformXmlSerializer
 
 abstract class XPathExpression : InFormCacheableExpr(), Externalizable {
 
@@ -288,13 +289,7 @@ abstract class XPathExpression : InFormCacheableExpr(), Externalizable {
 
         @Throws(PlatformIOException::class)
         private fun serializeElements(nodeset: XPathNodeset, output: OutputStream) {
-            val serializer = KXmlSerializer()
-
-            try {
-                serializer.setOutput(output, "UTF-8")
-            } catch (e: PlatformIOException) {
-                throw RuntimeException(e)
-            }
+            val serializer = JvmXmlSerializer(output, "UTF-8")
 
             val s = DataModelSerializer(serializer)
 

--- a/commcare-core/src/test/java/org/commcare/cases/util/test/CaseParseReindexTests.java
+++ b/commcare-core/src/test/java/org/commcare/cases/util/test/CaseParseReindexTests.java
@@ -10,9 +10,9 @@ import org.commcare.data.xml.TransactionParserFactory;
 import org.commcare.util.mocks.MockDataUtils;
 import org.commcare.util.mocks.MockUserDataSandbox;
 import org.commcare.xml.CaseXmlParser;
+import org.javarosa.xml.PlatformXmlParser;
 import org.junit.Before;
 import org.junit.Test;
-import org.kxml2.io.KXmlParser;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -79,7 +79,7 @@ public class CaseParseReindexTests {
                     CaseXmlParser created = null;
 
                     @Override
-                    public TransactionParser<Case> getParser(KXmlParser parser) {
+                    public TransactionParser<Case> getParser(PlatformXmlParser parser) {
                         if (created == null) {
                             created = new CaseXmlParser(parser, sandbox.getCaseStorage()) {
                                 @Override

--- a/commcare-core/src/test/java/org/commcare/xml/ParserTestUtils.java
+++ b/commcare-core/src/test/java/org/commcare/xml/ParserTestUtils.java
@@ -1,7 +1,7 @@
 package org.commcare.xml;
 
 import org.javarosa.xml.ElementParser;
-import org.kxml2.io.KXmlParser;
+import org.javarosa.xml.PlatformXmlParser;
 
 import java.io.ByteArrayInputStream;
 import java.lang.reflect.Constructor;
@@ -15,7 +15,7 @@ public class ParserTestUtils {
     public static <T extends CommCareElementParser> T buildParser(String xml, Class<T> parserClass) {
         return buildParser(xml, (xmlParser) -> {
             try {
-                Constructor<T> constructor = parserClass.getConstructor(KXmlParser.class);
+                Constructor<T> constructor = parserClass.getConstructor(PlatformXmlParser.class);
                 return constructor.newInstance(xmlParser);
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -23,10 +23,10 @@ public class ParserTestUtils {
         });
     }
 
-    public static <T extends CommCareElementParser> T buildParser(String xml, Function<KXmlParser, T> builder) {
+    public static <T extends CommCareElementParser> T buildParser(String xml, Function<PlatformXmlParser, T> builder) {
         try {
             ByteArrayInputStream inputStream = new ByteArrayInputStream(xml.getBytes("UTF-8"));
-            KXmlParser parser = ElementParser.instantiateParser(inputStream);
+            PlatformXmlParser parser = ElementParser.instantiateParser(inputStream);
             return builder.apply(parser);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/commcare-core/src/translate/java/org/javarosa/engine/xml/ElementParser.java
+++ b/commcare-core/src/translate/java/org/javarosa/engine/xml/ElementParser.java
@@ -1,5 +1,7 @@
 package org.javarosa.engine.xml;
 
+import org.javarosa.xml.JvmXmlParser;
+import org.javarosa.xml.PlatformXmlParser;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
@@ -26,6 +28,7 @@ import java.io.InputStream;
  */
 public abstract class ElementParser<T> {
     protected final KXmlParser parser;
+    protected final PlatformXmlParser wrappedParser;
 
     int level = 0;
 
@@ -40,6 +43,7 @@ public abstract class ElementParser<T> {
      */
     public ElementParser(InputStream suiteStream) throws IOException{
         parser = new KXmlParser();
+        wrappedParser = JvmXmlParser.wrap(parser);
         try {
             parser.setInput(suiteStream,"UTF-8");
             parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, true);
@@ -62,6 +66,7 @@ public abstract class ElementParser<T> {
      */
     public ElementParser(KXmlParser parser) {
         this.parser = parser;
+        this.wrappedParser = JvmXmlParser.wrap(parser);
         level = parser.getDepth();
     }
 
@@ -76,7 +81,7 @@ public abstract class ElementParser<T> {
      */
     protected void checkNode(String name) throws InvalidStructureException {
         if(!parser.getName().toLowerCase().equals(name)) {
-            throw new InvalidStructureException("Expected <" + name + "> element <"+ parser.getName() + "> found instead",parser);
+            throw new InvalidStructureException("Expected <" + name + "> element <"+ parser.getName() + "> found instead",wrappedParser);
         }
     }
 
@@ -97,7 +102,7 @@ public abstract class ElementParser<T> {
      * XML.
      */
     protected void getNextTagInBlock(String terminal) throws InvalidStructureException, IOException, XmlPullParserException {
-        if(!nextTagInBlock(terminal)) {throw new InvalidStructureException("Expected another node inside of element <" + terminal + ">.",parser);}
+        if(!nextTagInBlock(terminal)) {throw new InvalidStructureException("Expected another node inside of element <" + terminal + ">.",wrappedParser);}
     }
 
     /**
@@ -162,12 +167,12 @@ public abstract class ElementParser<T> {
                 if(parser.getName().toLowerCase().equals(name.toLowerCase())) {
                     return;
                 }
-                throw new InvalidStructureException("Expected tag " + name + " but got tag: " + parser.getName(), parser);
+                throw new InvalidStructureException("Expected tag " + name + " but got tag: " + parser.getName(), wrappedParser);
             }
-            throw new InvalidStructureException("Expected tag " + name + " but reached end of block instead", parser);
+            throw new InvalidStructureException("Expected tag " + name + " but reached end of block instead", wrappedParser);
         }
 
-        throw new InvalidStructureException("Expected tag " + name + " but it wasn't found", parser);
+        throw new InvalidStructureException("Expected tag " + name + " but it wasn't found", wrappedParser);
 
     }
 
@@ -199,12 +204,12 @@ public abstract class ElementParser<T> {
      */
     protected int parseInt(String value) throws InvalidStructureException  {
         if(value == null) {
-            throw new InvalidStructureException("Expected an integer value, found null text instead",parser);
+            throw new InvalidStructureException("Expected an integer value, found null text instead",wrappedParser);
         }
         try  {
             return Integer.parseInt(value);
         } catch(NumberFormatException nfe) {
-            throw new InvalidStructureException("Expected an integer value, found " + value + " instead",parser);
+            throw new InvalidStructureException("Expected an integer value, found " + value + " instead",wrappedParser);
         }
     }
 

--- a/commcare-core/src/translate/java/org/javarosa/engine/xml/FormInstanceParser.java
+++ b/commcare-core/src/translate/java/org/javarosa/engine/xml/FormInstanceParser.java
@@ -32,7 +32,7 @@ public class FormInstanceParser extends ElementParser<FormInstance> {
 
         String instanceId = parser.getAttributeValue(null, "src");
         if(instanceId == null) {
-            throw new InvalidStructureException("Instance lacking src", parser);
+            throw new InvalidStructureException("Instance lacking src", wrappedParser);
         }
 
         //Get to the data root

--- a/commcare-core/src/translate/java/org/javarosa/engine/xml/MockupParser.java
+++ b/commcare-core/src/translate/java/org/javarosa/engine/xml/MockupParser.java
@@ -43,11 +43,11 @@ public class MockupParser extends ElementParser<Mockup> {
                             try {
                                 Date d = DateUtils.parseDate(dateText);
                                 if(d == null) {
-                                    throw new InvalidStructureException("Bad <date> in context: '" + dateText + "'", parser);
+                                    throw new InvalidStructureException("Bad <date> in context: '" + dateText + "'", wrappedParser);
                                 }
                                 editor.setDate(d);
                             } catch(Exception e){
-                                throw new InvalidStructureException("Bad <date> in context: '" + dateText + "'", parser);
+                                throw new InvalidStructureException("Bad <date> in context: '" + dateText + "'", wrappedParser);
                             }
                         }
                     }
@@ -58,7 +58,7 @@ public class MockupParser extends ElementParser<Mockup> {
                         editor.addInstance(instance);
                         //TODO: Somehow we need to make sure that there are no more siblings
                     } else {
-                        throw new InvalidStructureException("Unrecognized context element: <" + tag + ">", parser);
+                        throw new InvalidStructureException("Unrecognized context element: <" + tag + ">", wrappedParser);
                     }
                 }
 

--- a/commcare-core/src/translate/java/org/javarosa/engine/xml/TreeElementParser.java
+++ b/commcare-core/src/translate/java/org/javarosa/engine/xml/TreeElementParser.java
@@ -55,7 +55,7 @@ public class TreeElementParser extends ElementParser<TreeElement> {
                     element.setValue(new UncastData(parser.getText().trim()));
                     break;
                 default:
-                    throw new InvalidStructureException("Exception while trying to parse an XML Tree, got something other than tags and text", parser);
+                    throw new InvalidStructureException("Exception while trying to parse an XML Tree, got something other than tags and text", wrappedParser);
             }
         }
 

--- a/commcare-core/src/translate/java/org/javarosa/engine/xml/serializer/MockupSerializer.java
+++ b/commcare-core/src/translate/java/org/javarosa/engine/xml/serializer/MockupSerializer.java
@@ -8,6 +8,8 @@ import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.engine.models.Mockup;
 import org.javarosa.model.xform.DataModelSerializer;
+import org.javarosa.xml.JvmXmlSerializer;
+import org.javarosa.xml.PlatformXmlSerializer;
 import org.kxml2.io.KXmlSerializer;
 
 import java.io.IOException;
@@ -54,7 +56,7 @@ public class MockupSerializer {
 
                 s.attribute(null, "src", key);
 
-                DataModelSerializer dms = new DataModelSerializer(s);
+                DataModelSerializer dms = new DataModelSerializer(JvmXmlSerializer.wrap(s));
                 dms.serialize(theInstance, null);
 
                 s.endTag(XMLNS, "instance");


### PR DESCRIPTION
## Summary

- Migrate ~55 Kotlin files from direct `org.kxml2`/`org.xmlpull` imports to cross-platform `PlatformXmlParser` and `PlatformXmlSerializer` abstractions
- Create JVM-only DOM helpers (`jvmMain/xml/dom/`) with typealiases for kxml2 Document/Element/Node
- Rewrite `InterningKXmlParser` as a `PlatformXmlParser` decorator instead of `KXmlParser` subclass
- Update all Java interop points (`ElementParser`, `TransactionParser`, `InvalidStructureException`) to use `PlatformXmlParser`

## Changes

**PlatformXmlParser interface** — converted function-based getters to Kotlin properties (`name`, `text`, `namespace`, `depth`, `eventType`, etc.), added `nextText()`, `nextTag()`, `positionDescription`, `prefix`

**JVM implementations:**
- `JvmXmlParser`: added `wrap(KXmlParser)` and `fromStream(InputStream)` factory methods
- `JvmXmlSerializer`: added `OutputStream` constructor and `wrap(KXmlSerializer)` factory
- New `jvmMain/xml/dom/` package: `XmlDomTypealiases`, `XmlDocumentHelper`, `XmlDomExtensions`, `InterningKXmlParserJvm`

**iOS implementation** — `IosXmlParser` updated to property-based interface with `nextText()`, `nextTag()`, `positionDescription`, `prefix`

**~49 Kotlin parser files** — bulk-migrated constructor types, exception types, constant references, and nullable cascades (`parser.name!!` at ~93 call sites)

**8 DOM files** — kxml2.kdom imports replaced with `org.javarosa.xml.dom.Xml*` typealiases

**Java interop** — `ElementParser.java`, `TransactionParser.java`, `InvalidStructureException.java` updated; test/translate source sets use `JvmXmlParser.wrap()` for bridging

## Acceptance criteria

- [x] Zero `org.kxml2` or `org.xmlpull` imports in `src/main/java/**/*.kt` — confirmed via grep
- [x] All 769 JVM tests pass
- [x] Compilation succeeds across all source sets (jvm, test, translate, cli, ccapi)

## Notable technical decisions

1. **Property-based interface**: Changed PlatformXmlParser from `fun getName()` to `val name` to enable Kotlin property syntax (`parser.name` vs `parser.getName()`). This follows checklist item 19.
2. **JVM DOM typealiases**: kxml2 DOM types (`Document`, `Element`, `Node`) are JVM-only and can't be fully abstracted at this stage. Wrapped behind typealiases and helper classes in `jvmMain` to isolate them.
3. **Nullable cascades**: `parser.name` returns `String?` (was platform `String!`). Added `!!` at ~93 call sites where the parser is known to be at a START_TAG/END_TAG.
4. **Java typealias visibility**: Java can't see Kotlin `expect`/`actual` typealiases, so Java files continue using `XmlPullParserException` directly.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)