### PR TITLE
Phase 3 Wave 3: Replace java.util.Date and java.util.regex

### DIFF
--- a/commcare-core/src/commonMain/kotlin/org/javarosa/core/model/utils/PlatformDate.kt
+++ b/commcare-core/src/commonMain/kotlin/org/javarosa/core/model/utils/PlatformDate.kt
@@ -1,0 +1,26 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package org.javarosa.core.model.utils
+
+/**
+ * Cross-platform Date replacement.
+ * On JVM, this is a typealias to java.util.Date.
+ * On iOS, this is a simple wrapper around epoch milliseconds.
+ *
+ * Access `.time` (epoch millis) via platform-specific property:
+ * - JVM: synthesized from Date.getTime()/setTime()
+ * - iOS: declared directly as var
+ */
+expect open class PlatformDate {
+    /** Create a Date representing the current time. */
+    constructor()
+
+    /** Create a Date from milliseconds since Unix epoch. */
+    constructor(time: Long)
+
+    /** Get milliseconds since Unix epoch. */
+    fun getTime(): Long
+
+    /** Set milliseconds since Unix epoch. */
+    fun setTime(time: Long)
+}

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/core/model/utils/PlatformDate.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/core/model/utils/PlatformDate.kt
@@ -1,0 +1,34 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package org.javarosa.core.model.utils
+
+import platform.Foundation.NSDate
+import platform.Foundation.timeIntervalSince1970
+
+actual open class PlatformDate {
+    var time: Long
+
+    actual constructor() {
+        time = (NSDate().timeIntervalSince1970 * 1000).toLong()
+    }
+
+    actual constructor(time: Long) {
+        this.time = time
+    }
+
+    actual fun getTime(): Long = time
+
+    actual fun setTime(time: Long) {
+        this.time = time
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PlatformDate) return false
+        return time == other.time
+    }
+
+    override fun hashCode(): Int = time.hashCode()
+
+    override fun toString(): String = "PlatformDate(time=$time)"
+}

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/core/model/utils/PlatformDate.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/core/model/utils/PlatformDate.kt
@@ -1,0 +1,5 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package org.javarosa.core.model.utils
+
+actual typealias PlatformDate = java.util.Date

--- a/commcare-core/src/main/java/org/commcare/cases/instance/FixtureIndexSchema.kt
+++ b/commcare-core/src/main/java/org/commcare/cases/instance/FixtureIndexSchema.kt
@@ -5,7 +5,6 @@ import org.javarosa.core.model.instance.AbstractTreeElement
 import org.javarosa.core.model.instance.TreeElement
 import org.javarosa.xml.util.InvalidStructureException
 import java.util.HashSet
-import java.util.regex.Pattern
 
 /**
  * Tracks what attributes and elements are stored in indexed columns of an
@@ -67,7 +66,7 @@ class FixtureIndexSchema(schemaTree: TreeElement, @JvmField val fixtureName: Str
         @JvmStatic
         @Throws(InvalidStructureException::class)
         private fun validateIndexValue(index: String) {
-            if (!Pattern.matches("^[a-zA-Z0-9,@_\\.-]+$", index)) {
+            if (!Regex("^[a-zA-Z0-9,@_\\.-]+$").matches(index)) {
                 throw InvalidStructureException("Fixture schema contains an invalid index: '$index'")
             }
         }

--- a/commcare-core/src/main/java/org/commcare/cases/model/Case.kt
+++ b/commcare-core/src/main/java/org/commcare/cases/model/Case.kt
@@ -13,7 +13,7 @@ import org.javarosa.core.util.externalizable.PrototypeFactory
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 /**
  * NOTE: All new fields should be added to the case class using the "data" class,
@@ -37,7 +37,7 @@ open class Case : Persistable, IMetaData {
     protected var closed: Boolean = false
 
     @JvmField
-    protected var dateOpened: Date? = null
+    protected var dateOpened: PlatformDate? = null
 
     @JvmField
     protected var recordId: Int = 0
@@ -52,14 +52,14 @@ open class Case : Persistable, IMetaData {
      * NOTE: This constructor is for serialization only.
      */
     constructor() {
-        dateOpened = Date()
+        dateOpened = PlatformDate()
     }
 
     constructor(name: String?, typeId: String?) {
         setID(-1)
         this.name = name
         this.typeId = typeId
-        dateOpened = Date()
+        dateOpened = PlatformDate()
         setLastModified(dateOpened!!)
     }
 
@@ -137,9 +137,9 @@ open class Case : Persistable, IMetaData {
 
     fun getCaseId(): String? = id
 
-    fun getDateOpened(): Date? = dateOpened
+    fun getDateOpened(): PlatformDate? = dateOpened
 
-    fun setDateOpened(dateOpened: Date?) {
+    fun setDateOpened(dateOpened: PlatformDate?) {
         this.dateOpened = dateOpened
     }
 
@@ -149,7 +149,7 @@ open class Case : Persistable, IMetaData {
         id = ExtUtil.nullIfEmpty(ExtUtil.readString(`in`))
         name = ExtUtil.nullIfEmpty(ExtUtil.readString(`in`))
         closed = ExtUtil.readBool(`in`)
-        dateOpened = ExtUtil.read(`in`, ExtWrapNullable(Date::class.java), pf) as Date?
+        dateOpened = ExtUtil.read(`in`, ExtWrapNullable(PlatformDate::class.java), pf) as PlatformDate?
         recordId = ExtUtil.readInt(`in`)
         @Suppress("UNCHECKED_CAST")
         indices = ExtUtil.read(`in`, ExtWrapList(CaseIndex::class.java), pf) as ArrayList<CaseIndex>
@@ -291,15 +291,15 @@ open class Case : Persistable, IMetaData {
     // ugh, adding stuff to case models sucks. Need to code up a transition scheme in android so we
     // can stop having shitty models.
 
-    fun setLastModified(lastModified: Date) {
+    fun setLastModified(lastModified: PlatformDate) {
         data[LAST_MODIFIED] = lastModified
     }
 
-    fun getLastModified(): Date? {
+    fun getLastModified(): PlatformDate? {
         if (!data.containsKey(LAST_MODIFIED)) {
             return getDateOpened()
         }
-        return data[LAST_MODIFIED] as? Date
+        return data[LAST_MODIFIED] as? PlatformDate
     }
 
     /**

--- a/commcare-core/src/main/java/org/commcare/cases/util/StringUtils.kt
+++ b/commcare-core/src/main/java/org/commcare/cases/util/StringUtils.kt
@@ -2,14 +2,13 @@ package org.commcare.cases.util
 
 import org.commcare.modern.util.Pair
 import java.text.Normalizer
-import java.util.regex.Pattern
 
 /**
  * Created by willpride on 10/27/16.
  */
 object StringUtils {
 
-    private var diacritics: Pattern? = null
+    private var diacritics: Regex? = null
 
     // TODO: Really not sure about this size. Also, the LRU probably isn't really the best model here
     // since we'd _like_ for these caches to get cleaned up at _some_ point.
@@ -28,7 +27,7 @@ object StringUtils {
     fun normalize(input: String): String {
         if (normalizationCache == null) {
             normalizationCache = LruCache(cacheSize)
-            diacritics = Pattern.compile("\\p{InCombiningDiacriticalMarks}+")
+            diacritics = Regex("\\p{InCombiningDiacriticalMarks}+")
         }
         val cachedString = normalizationCache!!.get(input)
         if (cachedString != null) {
@@ -42,7 +41,7 @@ object StringUtils {
         // issues, but we can at least still eliminate diacritics.
         val normalized = Normalizer.normalize(input, Normalizer.Form.NFD)
 
-        val output = diacritics!!.matcher(normalized).replaceAll("").lowercase()
+        val output = diacritics!!.replace(normalized, "").lowercase()
 
         normalizationCache!!.put(input, output)
 

--- a/commcare-core/src/main/java/org/commcare/core/encryption/CryptUtil.kt
+++ b/commcare-core/src/main/java/org/commcare/core/encryption/CryptUtil.kt
@@ -13,7 +13,7 @@ import java.security.SecureRandom
 import java.security.interfaces.RSAPrivateKey
 import java.security.spec.InvalidKeySpecException
 import java.security.spec.PKCS8EncodedKeySpec
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 import javax.crypto.BadPaddingException
 import javax.crypto.Cipher
 import javax.crypto.CipherInputStream
@@ -127,7 +127,7 @@ object CryptUtil {
 
     @JvmStatic
     fun uniqueSeedFromSecureStatic(secureStatic: ByteArray): ByteArray? {
-        val uniqueBase = Date().time
+        val uniqueBase = PlatformDate().time
         val baseString = java.lang.Long.toHexString(uniqueBase)
         try {
             return append(

--- a/commcare-core/src/main/java/org/commcare/core/graph/c3/Configuration.kt
+++ b/commcare-core/src/main/java/org/commcare/core/graph/c3/Configuration.kt
@@ -5,7 +5,7 @@ import org.commcare.core.graph.util.GraphException
 import org.commcare.core.graph.util.GraphUtil
 import org.json.JSONObject
 import java.text.SimpleDateFormat
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 import java.util.SortedMap
 import java.util.TreeMap
 
@@ -50,7 +50,7 @@ open class Configuration(data: GraphData) {
             }
         } else {
             val daysSinceEpoch = parseDouble(v, description)
-            val d = Date((daysSinceEpoch * 86400000L).toLong())
+            val d = PlatformDate((daysSinceEpoch * 86400000L).toLong())
             v = mDateFormat.format(d)
         }
         return v

--- a/commcare-core/src/main/java/org/commcare/core/network/CommCareNetworkServiceGenerator.kt
+++ b/commcare-core/src/main/java/org/commcare/core/network/CommCareNetworkServiceGenerator.kt
@@ -11,7 +11,7 @@ import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.text.SimpleDateFormat
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
@@ -66,7 +66,7 @@ object CommCareNetworkServiceGenerator {
                 val serverTimeInMillis = SimpleDateFormat(
                     "EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH
                 ).parse(serverDate).time
-                val now = Date().time
+                val now = PlatformDate().time
                 var currentDrift = (now - serverTimeInMillis) / HOUR_IN_MS
                 commCarePreferenceManager.putLong(CURRENT_DRIFT, currentDrift)
                 val maxDriftSinceLastHeartbeat = commCarePreferenceManager.getLong(MAX_DRIFT_SINCE_LAST_HEARTBEAT, 0)

--- a/commcare-core/src/main/java/org/commcare/core/network/bitcache/FileBitCache.kt
+++ b/commcare-core/src/main/java/org/commcare/core/network/bitcache/FileBitCache.kt
@@ -11,7 +11,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.security.InvalidKeyException
 import java.security.NoSuchAlgorithmException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 import javax.crypto.Cipher
 import javax.crypto.CipherInputStream
 import javax.crypto.CipherOutputStream
@@ -33,7 +33,7 @@ internal class FileBitCache(
         val cacheLocation = cacheDirSetup!!.getCacheDir()
 
         // generate temp file
-        temp = File.createTempFile("commcare_pull_${Date().time}", "xml", cacheLocation)
+        temp = File.createTempFile("commcare_pull_${PlatformDate().time}", "xml", cacheLocation)
         key = CryptUtil.generateSemiRandomKey()
     }
 

--- a/commcare-core/src/main/java/org/commcare/modern/database/DatabaseHelper.kt
+++ b/commcare-core/src/main/java/org/commcare/modern/database/DatabaseHelper.kt
@@ -6,7 +6,7 @@ import org.javarosa.core.services.storage.IMetaData
 import org.javarosa.core.services.storage.Persistable
 import org.javarosa.core.util.externalizable.Externalizable
 
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 import java.util.HashMap
 import java.util.HashSet
 
@@ -152,7 +152,7 @@ object DatabaseHelper {
             for (key in (e as IMetaData).getMetaDataFields()) {
                 val o = e.getMetaData(key) ?: continue
                 val scrubbedKey = TableBuilder.scrubName(key)
-                if (o is Date) {
+                if (o is PlatformDate) {
                     // store date as seconds since epoch
                     values[scrubbedKey] = o.time
                 } else {

--- a/commcare-core/src/main/java/org/commcare/suite/model/Text.kt
+++ b/commcare-core/src/main/java/org/commcare/suite/model/Text.kt
@@ -24,7 +24,7 @@ import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.Calendar
 import java.util.Collections
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 /**
  * Text objects are a model for holding strings which
@@ -99,7 +99,7 @@ class Text : Externalizable, DetailTemplate, XPathAnalyzable {
                     temp.addFunctionHandler(object : IFunctionHandler {
                         override fun eval(args: Array<Any?>?, ec: EvaluationContext?): Any? {
                             val o = FunctionUtils.toDate(args!![0])
-                            if (o !is Date) {
+                            if (o !is PlatformDate) {
                                 // return null, date is null.
                                 return ""
                             }
@@ -119,7 +119,7 @@ class Text : Externalizable, DetailTemplate, XPathAnalyzable {
                         override fun getPrototypes(): ArrayList<Any> {
                             val format = ArrayList<Any>()
                             val prototypes = arrayOf<Class<*>>(
-                                Date::class.java,
+                                PlatformDate::class.java,
                                 String::class.java
                             )
                             format.add(prototypes)
@@ -132,7 +132,7 @@ class Text : Externalizable, DetailTemplate, XPathAnalyzable {
                     temp.addFunctionHandler(object : IFunctionHandler {
                         override fun eval(args: Array<Any?>?, ec: EvaluationContext?): Any? {
                             val c = Calendar.getInstance()
-                            c.time = Date()
+                            c.time = PlatformDate()
                             return c.get(Calendar.DAY_OF_WEEK).toString()
                         }
 

--- a/commcare-core/src/main/java/org/commcare/util/DateRangeUtils.kt
+++ b/commcare-core/src/main/java/org/commcare/util/DateRangeUtils.kt
@@ -3,7 +3,7 @@ package org.commcare.util
 import org.commcare.modern.util.Pair
 import java.text.ParseException
 import java.text.SimpleDateFormat
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 import java.util.Locale
 
 object DateRangeUtils {
@@ -40,7 +40,7 @@ object DateRangeUtils {
     }
 
     @Suppress("DEPRECATION")
-    private fun getTimeFromDateOffsettingTz(date: Date): Long {
+    private fun getTimeFromDateOffsettingTz(date: PlatformDate): Long {
         return date.time - date.timezoneOffset * 60 * 1000
     }
 
@@ -85,6 +85,6 @@ object DateRangeUtils {
     // Converts given time as yyyy-mm-dd
     @JvmStatic
     fun getDateFromTime(time: Long): String {
-        return SimpleDateFormat(DATE_FORMAT, Locale.US).format(Date(time))
+        return SimpleDateFormat(DATE_FORMAT, Locale.US).format(PlatformDate(time))
     }
 }

--- a/commcare-core/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.kt
@@ -30,7 +30,7 @@ import org.javarosa.core.util.externalizable.SerializationLimitationException
 import org.javarosa.xml.util.InvalidStructureException
 import org.kxml2.io.KXmlParser
 
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 import java.util.LinkedHashMap
 
 /**
@@ -130,7 +130,7 @@ abstract class BulkProcessingCaseXmlParser(parser: KXmlParser) :
         createElement: TreeElement,
         currentOperatingSet: MutableMap<String, Case>,
         caseId: String,
-        modified: Date?,
+        modified: PlatformDate?,
         userId: String?
     ): Case {
         val data = arrayOfNulls<String>(3)

--- a/commcare-core/src/main/java/org/javarosa/core/model/condition/Recalculate.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/condition/Recalculate.kt
@@ -17,7 +17,7 @@ import org.javarosa.core.model.data.UncastData
 import org.javarosa.core.model.instance.FormInstance
 import org.javarosa.core.model.instance.TreeReference
 import org.javarosa.xpath.XPathException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 import kotlin.math.abs
 
 class Recalculate : Triggerable {
@@ -123,7 +123,7 @@ class Recalculate : Triggerable {
                 return SelectMultiData().cast(UncastData(`val`.toString()))
             } else if (`val` is String) {
                 return StringData(`val`)
-            } else if (`val` is Date) {
+            } else if (`val` is PlatformDate) {
                 return if (dataType == Constants.DATATYPE_DATE_TIME) {
                     DateTimeData(`val`)
                 } else if (dataType == Constants.DATATYPE_TIME) {

--- a/commcare-core/src/main/java/org/javarosa/core/model/data/DateData.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/data/DateData.kt
@@ -8,7 +8,7 @@ import org.javarosa.core.util.externalizable.PrototypeFactory
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 /**
  * A response to a question requesting a Date Value
@@ -16,7 +16,7 @@ import java.util.Date
  * @author Drew Roos
  */
 class DateData : IAnswerData {
-    var d: Date? = null
+    var d: PlatformDate? = null
     private var mInit: Boolean = false
 
     /**
@@ -25,7 +25,7 @@ class DateData : IAnswerData {
      */
     constructor()
 
-    constructor(d: Date) {
+    constructor(d: PlatformDate) {
         setValue(d)
     }
 
@@ -38,7 +38,7 @@ class DateData : IAnswerData {
 
     override fun clone(): IAnswerData {
         init()
-        return DateData(Date(d!!.time))
+        return DateData(PlatformDate(d!!.time))
     }
 
     override fun setValue(o: Any?) {
@@ -46,13 +46,13 @@ class DateData : IAnswerData {
         if (o == null) {
             throw NullPointerException("Attempt to set an IAnswerData class to null.")
         }
-        d = o as Date
+        d = o as PlatformDate
         mInit = false
     }
 
     override fun getValue(): Any {
         init()
-        return Date(d!!.time)
+        return PlatformDate(d!!.time)
     }
 
     override fun getDisplayText(): String {

--- a/commcare-core/src/main/java/org/javarosa/core/model/data/DateTimeData.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/data/DateTimeData.kt
@@ -8,7 +8,7 @@ import org.javarosa.core.util.externalizable.PrototypeFactory
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 /**
  * A response to a question requesting a DateTime Value
@@ -16,7 +16,7 @@ import java.util.Date
  * @author Clayton Sims
  */
 class DateTimeData : IAnswerData {
-    var d: Date? = null
+    var d: PlatformDate? = null
 
     /**
      * Empty Constructor, necessary for dynamic construction during deserialization.
@@ -24,12 +24,12 @@ class DateTimeData : IAnswerData {
      */
     constructor()
 
-    constructor(d: Date) {
+    constructor(d: PlatformDate) {
         setValue(d)
     }
 
     override fun clone(): IAnswerData {
-        return DateTimeData(Date(d!!.time))
+        return DateTimeData(PlatformDate(d!!.time))
     }
 
     override fun setValue(o: Any?) {
@@ -37,11 +37,11 @@ class DateTimeData : IAnswerData {
         if (o == null) {
             throw NullPointerException("Attempt to set an IAnswerData class to null.")
         }
-        d = Date((o as Date).time)
+        d = PlatformDate((o as PlatformDate).time)
     }
 
     override fun getValue(): Any {
-        return Date(d!!.time)
+        return PlatformDate(d!!.time)
     }
 
     override fun getDisplayText(): String {

--- a/commcare-core/src/main/java/org/javarosa/core/model/data/TimeData.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/data/TimeData.kt
@@ -24,10 +24,10 @@ import org.javarosa.core.util.externalizable.PrototypeFactory
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 class TimeData : IAnswerData {
-    var d: Date? = null
+    var d: PlatformDate? = null
 
     /**
      * Empty Constructor, necessary for dynamic construction during deserialization.
@@ -35,23 +35,23 @@ class TimeData : IAnswerData {
      */
     constructor()
 
-    constructor(d: Date) {
+    constructor(d: PlatformDate) {
         setValue(d)
     }
 
     override fun clone(): IAnswerData {
-        return TimeData(Date(d!!.time))
+        return TimeData(PlatformDate(d!!.time))
     }
 
     override fun setValue(o: Any?) {
         if (o == null) {
             throw NullPointerException("Attempt to set an IAnswerData class to null.")
         }
-        d = Date((o as Date).time)
+        d = PlatformDate((o as PlatformDate).time)
     }
 
     override fun getValue(): Any {
-        return Date(d!!.time)
+        return PlatformDate(d!!.time)
     }
 
     override fun getDisplayText(): String {

--- a/commcare-core/src/main/java/org/javarosa/core/model/instance/FormInstance.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/instance/FormInstance.kt
@@ -13,7 +13,7 @@ import org.javarosa.core.util.externalizable.PrototypeFactory
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 /**
  * This class represents the xform model instance
@@ -23,7 +23,7 @@ open class FormInstance : DataInstance<TreeElement>, Persistable, IMetaData {
     /**
      * The date that this model was taken and recorded
      */
-    private var dateSaved: Date? = null
+    private var dateSaved: PlatformDate? = null
 
     @JvmField
     var schema: String? = null
@@ -163,7 +163,7 @@ open class FormInstance : DataInstance<TreeElement>, Persistable, IMetaData {
     override fun readExternal(`in`: DataInputStream, pf: PrototypeFactory) {
         super.readExternal(`in`, pf)
         schema = ExtUtil.read(`in`, ExtWrapNullable(String::class.java), pf) as String?
-        dateSaved = ExtUtil.read(`in`, ExtWrapNullable(Date::class.java), pf) as Date?
+        dateSaved = ExtUtil.read(`in`, ExtWrapNullable(PlatformDate::class.java), pf) as PlatformDate?
 
         @Suppress("UNCHECKED_CAST")
         namespaces = ExtUtil.read(`in`, ExtWrapMap(String::class.java, String::class.java), pf) as HashMap<String, String>
@@ -244,7 +244,7 @@ open class FormInstance : DataInstance<TreeElement>, Persistable, IMetaData {
     fun migrateSerialization(`in`: DataInputStream, pf: PrototypeFactory?) {
         super.readExternal(`in`, pf!!)
         schema = ExtUtil.read(`in`, ExtWrapNullable(String::class.java), pf) as String?
-        dateSaved = ExtUtil.read(`in`, ExtWrapNullable(Date::class.java), pf) as Date?
+        dateSaved = ExtUtil.read(`in`, ExtWrapNullable(PlatformDate::class.java), pf) as PlatformDate?
 
         @Suppress("UNCHECKED_CAST")
         namespaces = ExtUtil.read(`in`, ExtWrapMap(String::class.java, String::class.java), pf) as HashMap<String, String>

--- a/commcare-core/src/main/java/org/javarosa/core/model/util/restorable/RestoreUtils.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/util/restorable/RestoreUtils.kt
@@ -10,7 +10,7 @@ import org.javarosa.core.services.storage.Persistable
 import org.javarosa.model.xform.XPathReference
 import org.javarosa.xpath.XPathConditional
 import org.javarosa.xpath.expr.XPathPathExpr
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 object RestoreUtils {
     @JvmField
@@ -42,7 +42,7 @@ object RestoreUtils {
             java.lang.Long::class.java, Long::class.java -> Constants.DATATYPE_LONG
             java.lang.Float::class.java, Float::class.java,
             java.lang.Double::class.java, Double::class.java -> Constants.DATATYPE_DECIMAL
-            Date::class.java -> Constants.DATATYPE_DATE
+            PlatformDate::class.java -> Constants.DATATYPE_DATE
             java.lang.Boolean::class.java, Boolean::class.java -> Constants.DATATYPE_TEXT
             else -> throw RuntimeException("Can't handle data type ${c.name}")
         }
@@ -81,7 +81,7 @@ object RestoreUtils {
         var resolvedParent = parent
         if (resolvedParent == null) {
             resolvedParent = topRef(dm)
-            applyDataType(dm, "timestamp", resolvedParent, Date::class.java)
+            applyDataType(dm, "timestamp", resolvedParent, PlatformDate::class.java)
         }
 
         if (r is Persistable) {

--- a/commcare-core/src/main/java/org/javarosa/core/model/utils/DateUtils.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/utils/DateUtils.kt
@@ -7,7 +7,7 @@ import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.Arrays
 import java.util.Calendar
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 import java.util.TimeZone
 import java.util.concurrent.TimeUnit
 
@@ -35,7 +35,7 @@ object DateUtils {
     @JvmField
     val DAY_IN_MS: Long = TimeUnit.DAYS.toMillis(1)
 
-    private val EPOCH_DATE: Date = getDate(1970, 1, 1)!!
+    private val EPOCH_DATE: PlatformDate = getDate(1970, 1, 1)!!
 
     private val EPOCH_TIME: Long = roundDate(EPOCH_DATE).time
 
@@ -107,12 +107,12 @@ object DateUtils {
     }
 
     @JvmStatic
-    fun getFields(d: Date): DateFields {
+    fun getFields(d: PlatformDate): DateFields {
         return getFields(d, null as String?)
     }
 
     @JvmStatic
-    fun getFields(d: Date, timezone: String?): DateFields {
+    fun getFields(d: PlatformDate, timezone: String?): DateFields {
         val cd = Calendar.getInstance()
         cd.time = d
         if (timezone != null) {
@@ -125,7 +125,7 @@ object DateUtils {
         return getFields(cd, cd.timeZone.getOffset(d.time))
     }
 
-    private fun getFields(d: Date, timezoneOffset: Int): DateFields {
+    private fun getFields(d: PlatformDate, timezoneOffset: Int): DateFields {
         val cd = Calendar.getInstance()
         cd.timeZone = TimeZone.getTimeZone("UTC")
         cd.time = d
@@ -153,7 +153,7 @@ object DateUtils {
      * @return Date or null, depending if arguments are in the valid date range
      */
     @JvmStatic
-    fun getDate(year: Int, month: Int, day: Int): Date? {
+    fun getDate(year: Int, month: Int, day: Int): PlatformDate? {
         val f = DateFields()
         f.year = year
         f.month = month
@@ -166,7 +166,7 @@ object DateUtils {
      * timezone.
      */
     @JvmStatic
-    fun getDate(df: DateFields): Date {
+    fun getDate(df: DateFields): PlatformDate {
         return getDate(df, null)!!
     }
 
@@ -174,7 +174,7 @@ object DateUtils {
      * Turn DateField information into Date object, taking default or inputted
      * timezone into account.
      */
-    private fun getDate(df: DateFields, timezone: String?): Date? {
+    private fun getDate(df: DateFields, timezone: String?): PlatformDate? {
         val cd = Calendar.getInstance()
 
         if (timezone != null) {
@@ -196,7 +196,7 @@ object DateUtils {
         return cd.time
     }
 
-    private fun getDate(df: DateFields, timezoneOffset: Int): Date {
+    private fun getDate(df: DateFields, timezoneOffset: Int): PlatformDate {
         val cd = Calendar.getInstance()
         cd.timeZone = TimeZone.getTimeZone("UTC")
 
@@ -216,7 +216,7 @@ object DateUtils {
     /* ==== FORMATTING DATES/TIMES TO STANDARD STRINGS ==== */
 
     @JvmStatic
-    fun formatDateTime(d: Date?, format: Int): String {
+    fun formatDateTime(d: PlatformDate?, format: Int): String {
         if (d == null) {
             return ""
         }
@@ -234,12 +234,12 @@ object DateUtils {
     }
 
     @JvmStatic
-    fun formatDate(d: Date?, format: Int): String {
+    fun formatDate(d: PlatformDate?, format: Int): String {
         return if (d == null) "" else formatDate(getFields(d, if (format == FORMAT_TIMESTAMP_HTTP) "UTC" else null), format)!!
     }
 
     @JvmStatic
-    fun formatTime(d: Date?, format: Int): String {
+    fun formatTime(d: PlatformDate?, format: Int): String {
         return if (d == null) "" else formatTime(getFields(d, if (format == FORMAT_TIMESTAMP_HTTP) "UTC" else null), format)!!
     }
 
@@ -339,7 +339,7 @@ object DateUtils {
     }
 
     @JvmStatic
-    fun format(d: Date, format: String): String {
+    fun format(d: PlatformDate, format: String): String {
         return format(getFields(d), format)
     }
 
@@ -399,7 +399,7 @@ object DateUtils {
     /* ==== PARSING DATES/TIMES FROM STANDARD STRINGS ==== */
 
     @JvmStatic
-    fun parseDateTime(str: String): Date? {
+    fun parseDateTime(str: String): PlatformDate? {
         val fields = DateFields()
         val i = str.indexOf("T")
         if (i != -1) {
@@ -415,7 +415,7 @@ object DateUtils {
     }
 
     @JvmStatic
-    fun parseDate(str: String): Date? {
+    fun parseDate(str: String): PlatformDate? {
         val fields = DateFields()
         if (!parseDateAndStore(str, fields)) {
             return null
@@ -441,12 +441,12 @@ object DateUtils {
     }
 
     @JvmStatic
-    fun parseTime(str: String): Date? {
+    fun parseTime(str: String): PlatformDate? {
         return parseTime(str, false)
     }
 
     @JvmStatic
-    fun parseTime(str: String, ignoreTimezone: Boolean): Date? {
+    fun parseTime(str: String, ignoreTimezone: Boolean): PlatformDate? {
         var timeStr = str
         if (!ignoreTimezone && (timezoneOffset() != -1 && !timeStr.contains("+") && !timeStr.contains("-") && !timeStr.contains("Z"))) {
             timeStr = timeStr + getOffsetInStandardFormat(timezoneOffset())
@@ -533,7 +533,7 @@ object DateUtils {
         // Now apply any relevant offsets from the timezone.
         val c = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
 
-        c.time = Date(getDate(df, "UTC")!!.time + (((60 * timeOffset.hour) + timeOffset.minute) * 60 * 1000))
+        c.time = PlatformDate(getDate(df, "UTC")!!.time + (((60 * timeOffset.hour) + timeOffset.minute) * 60 * 1000))
 
         // c is now in the timezone of the parsed value, so put
         // it in the local timezone.
@@ -590,14 +590,14 @@ object DateUtils {
      * @return new Date object with same date but time set to midnight (in current timezone)
      */
     @JvmStatic
-    fun roundDate(d: Date): Date {
+    fun roundDate(d: PlatformDate): PlatformDate {
         val f = getFields(d)
         return getDate(f.year, f.month, f.day)!!
     }
 
     @JvmStatic
-    fun today(): Date {
-        return roundDate(Date())
+    fun today(): PlatformDate {
+        return roundDate(PlatformDate())
     }
 
     /* ==== CALENDAR FUNCTIONS ==== */
@@ -620,7 +620,7 @@ object DateUtils {
 
     private fun formatDaysFromToday(f: DateFields): String {
         val d = getDate(f)
-        val daysAgo = daysSinceEpoch(Date()) - daysSinceEpoch(d)
+        val daysAgo = daysSinceEpoch(PlatformDate()) - daysSinceEpoch(d)
 
         return when {
             daysAgo == 0 -> Localization.get("date.today")
@@ -637,10 +637,10 @@ object DateUtils {
 
     @JvmStatic
     fun getPastPeriodDate(
-        ref: Date, type: String, start: String, beginning: Boolean,
+        ref: PlatformDate, type: String, start: String, beginning: Boolean,
         includeToday: Boolean, nAgo: Int
-    ): Date? {
-        var d: Date? = null
+    ): PlatformDate? {
+        var d: PlatformDate? = null
 
         if (type == "week") {
             var target_dow = -1
@@ -676,7 +676,7 @@ object DateUtils {
             }
 
             val diff = (((current_dow - target_dow) + (7 + offset)) % 7 - offset) + (7 * nAgo) - (if (beginning) 0 else 6) //booyah
-            d = Date(ref.time - diff * DAY_IN_MS)
+            d = PlatformDate(ref.time - diff * DAY_IN_MS)
         } else if (type == "month") {
             //not supported
         } else {
@@ -687,9 +687,9 @@ object DateUtils {
     }
 
     @JvmStatic
-    fun getMonthsDifference(earlierDate: Date, laterDate: Date): Int {
-        val span = Date(laterDate.time - earlierDate.time)
-        val firstDate = Date(0)
+    fun getMonthsDifference(earlierDate: PlatformDate, laterDate: PlatformDate): Int {
+        val span = PlatformDate(laterDate.time - earlierDate.time)
+        val firstDate = PlatformDate(0)
         val calendar = Calendar.getInstance()
         calendar.time = firstDate
         val firstYear = calendar.get(Calendar.YEAR)
@@ -702,12 +702,12 @@ object DateUtils {
     }
 
     @JvmStatic
-    fun daysSinceEpoch(date: Date): Int {
+    fun daysSinceEpoch(date: PlatformDate): Int {
         return MathUtils.divLongNotSuck(roundDate(date).time - EPOCH_TIME + DAY_IN_MS / 2, DAY_IN_MS).toInt()
     }
 
     @JvmStatic
-    fun fractionalDaysSinceEpoch(a: Date): Double {
+    fun fractionalDaysSinceEpoch(a: PlatformDate): Double {
         @Suppress("DEPRECATION")
         val timeZoneAdjust = ((a.timezoneOffset - EPOCH_DATE.timezoneOffset) * 60 * 1000).toLong()
         return ((a.time - EPOCH_DATE.time) - timeZoneAdjust) / DAY_IN_MS.toDouble()
@@ -717,8 +717,8 @@ object DateUtils {
      * add n days to date d
      */
     @JvmStatic
-    fun dateAdd(d: Date, n: Int): Date {
-        return roundDate(Date(roundDate(d).time + DAY_IN_MS * n + DAY_IN_MS / 2))
+    fun dateAdd(d: PlatformDate, n: Int): PlatformDate {
+        return roundDate(PlatformDate(roundDate(d).time + DAY_IN_MS * n + DAY_IN_MS / 2))
         //half-day offset is needed to handle differing DST offsets!
     }
 
@@ -726,7 +726,7 @@ object DateUtils {
      * return the number of days between a and b, positive if b is later than a
      */
     @JvmStatic
-    fun dateDiff(a: Date, b: Date): Int {
+    fun dateDiff(a: PlatformDate, b: PlatformDate): Int {
         return MathUtils.divLongNotSuck(roundDate(b).time - roundDate(a).time + DAY_IN_MS / 2, DAY_IN_MS).toInt()
         //half-day offset is needed to handle differing DST offsets!
     }
@@ -748,32 +748,32 @@ object DateUtils {
     /* ==== GARBAGE (backward compatibility; too lazy to remove them now) ==== */
 
     @JvmStatic
-    fun formatDateToTimeStamp(date: Date?): String {
+    fun formatDateToTimeStamp(date: PlatformDate?): String {
         return formatDateTime(date, FORMAT_ISO8601)
     }
 
     @JvmStatic
-    fun getShortStringValue(`val`: Date?): String {
+    fun getShortStringValue(`val`: PlatformDate?): String {
         return formatDate(`val`, FORMAT_HUMAN_READABLE_SHORT)
     }
 
     @JvmStatic
-    fun getXMLStringValue(`val`: Date?): String {
+    fun getXMLStringValue(`val`: PlatformDate?): String {
         return formatDate(`val`, FORMAT_ISO8601)
     }
 
     @JvmStatic
-    fun get24HourTimeFromDate(d: Date?): String {
+    fun get24HourTimeFromDate(d: PlatformDate?): String {
         return formatTime(d, FORMAT_HUMAN_READABLE_SHORT)
     }
 
     @JvmStatic
-    fun getDateFromString(value: String): Date? {
+    fun getDateFromString(value: String): PlatformDate? {
         return parseDate(value)
     }
 
     @JvmStatic
-    fun getDateTimeFromString(value: String): Date? {
+    fun getDateTimeFromString(value: String): PlatformDate? {
         return parseDateTime(value)
     }
 

--- a/commcare-core/src/main/java/org/javarosa/core/model/utils/PreloadUtils.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/utils/PreloadUtils.kt
@@ -8,7 +8,7 @@ import org.javarosa.core.model.data.LongData
 import org.javarosa.core.model.data.SelectMultiData
 import org.javarosa.core.model.data.StringData
 import org.javarosa.core.model.data.helper.Selection
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 /**
  * @author Clayton Sims
@@ -30,7 +30,7 @@ object PreloadUtils {
         //TODO: Replace this all with an uncast data
         return when (o) {
             is String -> StringData(o)
-            is Date -> DateData(o)
+            is PlatformDate -> DateData(o)
             is Int -> IntegerData(o)
             is Long -> LongData(o)
             is Double -> DecimalData(o)

--- a/commcare-core/src/main/java/org/javarosa/core/services/Logger.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/services/Logger.kt
@@ -4,7 +4,7 @@ import org.commcare.util.LogTypes
 import org.javarosa.core.api.ILogger
 import org.javarosa.core.log.FatalException
 import org.javarosa.core.log.WrappedException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 object Logger {
     private const val MAX_MSG_LENGTH = 2048
@@ -47,7 +47,7 @@ object Logger {
         msg = msg.substring(0, Math.min(msg.length, MAX_MSG_LENGTH))
         if (logger != null) {
             try {
-                logger!!.log(type, msg, Date())
+                logger!!.log(type, msg, PlatformDate())
             } catch (e: RuntimeException) {
                 //do not catch exceptions here; if this fails, we want the exception to propogate
                 System.err.println("exception when trying to write log message! " + WrappedException.printException(e))

--- a/commcare-core/src/main/java/org/javarosa/core/util/externalizable/ExtUtil.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/util/externalizable/ExtUtil.kt
@@ -9,7 +9,7 @@ import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.UTFDataFormatException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 class ExtUtil {
     companion object {
@@ -53,7 +53,7 @@ class ExtUtil {
                 is Double -> writeDecimal(out, data)
                 is Boolean -> writeBool(out, data)
                 is String -> writeString(out, data)
-                is Date -> writeDate(out, data)
+                is PlatformDate -> writeDate(out, data)
                 is ByteArray -> writeBytes(out, data)
                 else -> throw ClassCastException("Not a serializable datatype: " + data.javaClass.name)
             }
@@ -108,7 +108,7 @@ class ExtUtil {
 
         @JvmStatic
         @Throws(PlatformIOException::class)
-        fun writeDate(out: DataOutputStream, `val`: Date) {
+        fun writeDate(out: DataOutputStream, `val`: PlatformDate) {
             writeNumeric(out, `val`.time)
             // time zone?
         }
@@ -143,7 +143,7 @@ class ExtUtil {
                 type == java.lang.Double::class.java -> readDecimal(`in`)
                 type == java.lang.Boolean::class.java -> readBool(`in`)
                 type == String::class.java -> readString(`in`)
-                type == Date::class.java -> readDate(`in`)
+                type == PlatformDate::class.java -> readDate(`in`)
                 type == ByteArray::class.java -> readBytes(`in`)
                 else -> throw ClassCastException("Not a deserializable datatype: " + type.name)
             }
@@ -227,8 +227,8 @@ class ExtUtil {
 
         @JvmStatic
         @Throws(PlatformIOException::class)
-        fun readDate(`in`: DataInputStream): Date {
-            return Date(readNumeric(`in`))
+        fun readDate(`in`: DataInputStream): PlatformDate {
+            return PlatformDate(readNumeric(`in`))
             // time zone?
         }
 

--- a/commcare-core/src/main/java/org/javarosa/core/util/externalizable/PrototypeFactory.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/util/externalizable/PrototypeFactory.kt
@@ -2,7 +2,7 @@ package org.javarosa.core.util.externalizable
 
 import org.javarosa.core.api.ClassNameHasher
 import org.javarosa.core.model.data.UncastData
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 import java.util.HashSet
 
 /**
@@ -85,7 +85,7 @@ open class PrototypeFactory {
             Float::class.javaObjectType,
             Double::class.javaObjectType,
             String::class.java,
-            Date::class.java,
+            PlatformDate::class.java,
             UncastData::class.java
         )
 

--- a/commcare-core/src/main/java/org/javarosa/xform/util/CalendarUtils.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/util/CalendarUtils.kt
@@ -6,7 +6,7 @@ import org.commcare.util.LocaleArrayDataSource
 import org.javarosa.core.model.utils.DateUtils
 
 import java.util.Calendar
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 import java.util.HashMap
 import java.util.TimeZone
 
@@ -215,7 +215,7 @@ class CalendarUtils {
         }
 
         @JvmStatic
-        fun ConvertToEthiopian(d: Date, format: String?): String {
+        fun ConvertToEthiopian(d: PlatformDate, format: String?): String {
             val fmt = format ?: "%e %B %Y"
 
             val fields = DateUtils.getFields(d)
@@ -271,7 +271,7 @@ class CalendarUtils {
          * @return Nepali date string in 'd MMMM yyyy' format
          */
         @JvmStatic
-        fun convertToNepaliString(date: Date, format: String?): String {
+        fun convertToNepaliString(date: PlatformDate, format: String?): String {
             var fmt = format
             if (fmt == null) {
                 fmt = "%e %B %Y"
@@ -383,7 +383,7 @@ class CalendarUtils {
         }
 
         @JvmStatic
-        fun fromMillis(date: Date, timezone: String?): UniversalDate {
+        fun fromMillis(date: PlatformDate, timezone: String?): UniversalDate {
             val cd = Calendar.getInstance()
             cd.time = date
             if (timezone != null) {
@@ -397,7 +397,7 @@ class CalendarUtils {
 
         @JvmStatic
         fun fromMillis(millisFromJavaEpoch: Long): UniversalDate {
-            val date = Date(millisFromJavaEpoch)
+            val date = PlatformDate(millisFromJavaEpoch)
             return fromMillis(date, null)
         }
 

--- a/commcare-core/src/main/java/org/javarosa/xform/util/XFormAnswerDataSerializer.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/util/XFormAnswerDataSerializer.kt
@@ -35,7 +35,7 @@ import org.javarosa.core.model.data.UncastData
 import org.javarosa.core.model.data.helper.Selection
 import org.javarosa.core.model.utils.DateUtils
 
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 /**
  * The XFormAnswerDataSerializer takes in AnswerData objects, and provides
@@ -81,7 +81,7 @@ class XFormAnswerDataSerializer : IAnswerDataSerializer {
      * formatting
      */
     fun serializeAnswerData(data: DateData): Any {
-        return DateUtils.formatDate(data.getValue() as Date, DateUtils.FORMAT_ISO8601)
+        return DateUtils.formatDate(data.getValue() as PlatformDate, DateUtils.FORMAT_ISO8601)
     }
 
     /**
@@ -90,7 +90,7 @@ class XFormAnswerDataSerializer : IAnswerDataSerializer {
      * formatting
      */
     fun serializeAnswerData(data: DateTimeData): Any {
-        return DateUtils.formatDateTime(data.getValue() as Date, DateUtils.FORMAT_ISO8601)
+        return DateUtils.formatDateTime(data.getValue() as PlatformDate, DateUtils.FORMAT_ISO8601)
     }
 
     /**
@@ -99,7 +99,7 @@ class XFormAnswerDataSerializer : IAnswerDataSerializer {
      * formatting
      */
     fun serializeAnswerData(data: TimeData): Any {
-        return DateUtils.formatTime(data.getValue() as Date, DateUtils.FORMAT_ISO8601_WALL_TIME)
+        return DateUtils.formatTime(data.getValue() as PlatformDate, DateUtils.FORMAT_ISO8601_WALL_TIME)
     }
 
     /**

--- a/commcare-core/src/main/java/org/javarosa/xpath/expr/FunctionUtils.kt
+++ b/commcare-core/src/main/java/org/javarosa/xpath/expr/FunctionUtils.kt
@@ -9,7 +9,7 @@ import org.javarosa.xpath.XPathNodeset
 import org.javarosa.xpath.XPathTypeMismatchException
 
 import java.util.ArrayList
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 import java.util.HashMap
 
 class FunctionUtils {
@@ -178,7 +178,7 @@ class FunctionUtils {
                 `val` = Math.abs(d) > 1.0e-12 && !java.lang.Double.isNaN(d)
             } else if (o is String) {
                 `val` = o.length > 0
-            } else if (o is Date) {
+            } else if (o is PlatformDate) {
                 `val` = true
             } else if (o is IExprDataType) {
                 `val` = o.toBoolean()
@@ -193,7 +193,7 @@ class FunctionUtils {
 
         @JvmStatic
         fun toDouble(o: Any?): Double {
-            return if (o is Date) {
+            return if (o is PlatformDate) {
                 DateUtils.fractionalDaysSinceEpoch(o)
             } else {
                 toNumeric(o)
@@ -227,7 +227,7 @@ class FunctionUtils {
                         `val` = java.lang.Double.valueOf(Double.NaN)
                     }
                 }
-            } else if (o is Date) {
+            } else if (o is PlatformDate) {
                 `val` = java.lang.Double.valueOf(DateUtils.daysSinceEpoch(o).toDouble())
             } else if (o is IExprDataType) {
                 `val` = o.toNumeric()
@@ -257,7 +257,7 @@ class FunctionUtils {
 
         private fun attemptDateConversion(s: String): Double {
             val o = toDate(s)
-            if (o is Date) {
+            if (o is PlatformDate) {
                 return toNumeric(o)
             } else {
                 throw XPathTypeMismatchException()
@@ -312,7 +312,7 @@ class FunctionUtils {
                 }
             } else if (o is String) {
                 `val` = o
-            } else if (o is Date) {
+            } else if (o is PlatformDate) {
                 `val` = DateUtils.formatDate(o, DateUtils.FORMAT_ISO8601)
             } else if (o is IExprDataType) {
                 `val` = o.toString()
@@ -337,7 +337,7 @@ class FunctionUtils {
          * string and int conversions are reversable, however:
          * * cannot convert bool to date
          * * empty string and NaN (xpath's 'null values') go unchanged, instead of being converted
-         * into a date (which would cause an error, since Date has no null value (other than java
+         * into a date (which would cause an error, since PlatformDate has no null value (other than java
          * null, which the xpath engine can't handle))
          * * note, however, than non-empty strings that aren't valid dates _will_ cause an error
          * during conversion
@@ -369,7 +369,7 @@ class FunctionUtils {
                 } else {
                     return d
                 }
-            } else if (o is Date) {
+            } else if (o is PlatformDate) {
                 return DateUtils.roundDate(o)
             } else {
                 val type = if (o == null) "null" else o.javaClass.name
@@ -378,13 +378,13 @@ class FunctionUtils {
         }
 
         @JvmStatic
-        internal fun expandDateSafe(dateObject: Any?): Date? {
+        internal fun expandDateSafe(dateObject: Any?): PlatformDate? {
             var dateObject = dateObject
-            if (dateObject !is Date) {
+            if (dateObject !is PlatformDate) {
                 // try to expand this out of a nodeset
                 dateObject = toDate(dateObject)
             }
-            return if (dateObject is Date) {
+            return if (dateObject is PlatformDate) {
                 dateObject
             } else {
                 null

--- a/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathCustomRuntimeFunc.kt
+++ b/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathCustomRuntimeFunc.kt
@@ -14,7 +14,7 @@ import org.javarosa.xpath.parser.XPathSyntaxException
 import java.io.DataInputStream
 import java.io.DataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 /**
  * Custom function that is dispatched at runtime
@@ -126,7 +126,7 @@ class XPathCustomRuntimeFunc : XPathFuncExpr {
                                 typed[i] = FunctionUtils.toNumeric(args[i])
                             } else if (prototype[i] == String::class.java) {
                                 typed[i] = FunctionUtils.toString(args[i])
-                            } else if (prototype[i] == Date::class.java) {
+                            } else if (prototype[i] == PlatformDate::class.java) {
                                 typed[i] = FunctionUtils.toDate(args[i])
                             }
                         } catch (xptme: XPathTypeMismatchException) {

--- a/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathFormatDateForCalendarFunc.kt
+++ b/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathFormatDateForCalendarFunc.kt
@@ -6,7 +6,7 @@ import org.javarosa.xform.util.CalendarUtils
 import org.javarosa.xpath.XPathArityException
 import org.javarosa.xpath.XPathUnsupportedException
 import org.javarosa.xpath.parser.XPathSyntaxException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 open class XPathFormatDateForCalendarFunc : XPathFuncExpr {
     constructor() {
@@ -40,12 +40,12 @@ open class XPathFormatDateForCalendarFunc : XPathFuncExpr {
          * Given a date and format, return that date as a string formatted for that calendar
          * Accepted calendars are Ethiopian and Nepali
          *
-         * @param dateObject The Object (String, Date, or XPath) to be evaluated into a date
+         * @param dateObject The Object (String, PlatformDate, or XPath) to be evaluated into a date
          * @param calendar     The calendar system to use (nepali or ethiopian)
          * @param format     An optional format string as used in format-date()
          */
         private fun formatDateForCalendar(dateObject: Any?, calendar: Any?, format: String?): String {
-            val date: Date? = FunctionUtils.expandDateSafe(dateObject)
+            val date: PlatformDate? = FunctionUtils.expandDateSafe(dateObject)
             if (date == null) {
                 return ""
             }

--- a/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathFormatDateFunc.kt
+++ b/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathFormatDateFunc.kt
@@ -4,7 +4,7 @@ import org.javarosa.core.model.condition.EvaluationContext
 import org.javarosa.core.model.instance.DataInstance
 import org.javarosa.core.model.utils.DateUtils
 import org.javarosa.xpath.parser.XPathSyntaxException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 open class XPathFormatDateFunc : XPathFuncExpr {
     constructor() {
@@ -24,7 +24,7 @@ open class XPathFormatDateFunc : XPathFuncExpr {
         private const val EXPECTED_ARG_COUNT: Int = 2
 
         private fun dateStr(od: Any?, of: Any?): String {
-            val expandedDate: Date? = FunctionUtils.expandDateSafe(od)
+            val expandedDate: PlatformDate? = FunctionUtils.expandDateSafe(od)
             if (expandedDate == null) {
                 return ""
             }

--- a/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathNowFunc.kt
+++ b/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathNowFunc.kt
@@ -3,7 +3,7 @@ package org.javarosa.xpath.expr
 import org.javarosa.core.model.condition.EvaluationContext
 import org.javarosa.core.model.instance.DataInstance
 import org.javarosa.xpath.parser.XPathSyntaxException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 open class XPathNowFunc : XPathFuncExpr, VolatileXPathFuncExpr {
     constructor() {
@@ -15,7 +15,7 @@ open class XPathNowFunc : XPathFuncExpr, VolatileXPathFuncExpr {
     constructor(args: Array<XPathExpression>) : super(NAME, args, EXPECTED_ARG_COUNT, false)
 
     override fun evalBody(model: DataInstance<*>?, evalContext: EvaluationContext, evaluatedArgs: Array<Any?>): Any {
-        return Date()
+        return PlatformDate()
     }
 
     override fun rootExpressionTypeIsCacheable(): Boolean {

--- a/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathRegexFunc.kt
+++ b/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathRegexFunc.kt
@@ -4,8 +4,6 @@ import org.javarosa.core.model.condition.EvaluationContext
 import org.javarosa.core.model.instance.DataInstance
 import org.javarosa.xpath.XPathException
 import org.javarosa.xpath.parser.XPathSyntaxException
-import java.util.regex.Pattern
-import java.util.regex.PatternSyntaxException
 
 open class XPathRegexFunc : XPathFuncExpr {
     constructor() {
@@ -35,8 +33,8 @@ open class XPathRegexFunc : XPathFuncExpr {
             val re = FunctionUtils.toString(o2)
 
             try {
-                return Pattern.compile(re).matcher(str).find()
-            } catch (e: PatternSyntaxException) {
+                return Regex(re).containsMatchIn(str)
+            } catch (e: IllegalArgumentException) {
                 throw XPathException("The regular expression '$re' is invalid.")
             }
         }

--- a/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathReplaceFunc.kt
+++ b/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathReplaceFunc.kt
@@ -4,8 +4,6 @@ import org.javarosa.core.model.condition.EvaluationContext
 import org.javarosa.core.model.instance.DataInstance
 import org.javarosa.xpath.XPathException
 import org.javarosa.xpath.parser.XPathSyntaxException
-import java.util.regex.Matcher
-import java.util.regex.PatternSyntaxException
 
 open class XPathReplaceFunc : XPathFuncExpr {
     constructor() {
@@ -38,8 +36,8 @@ open class XPathReplaceFunc : XPathFuncExpr {
             val regexString = FunctionUtils.toString(o2)
             val replacement = FunctionUtils.toString(o3)
             try {
-                return source.replace(Regex(regexString), Matcher.quoteReplacement(replacement))
-            } catch (e: PatternSyntaxException) {
+                return source.replace(Regex(regexString), Regex.escapeReplacement(replacement))
+            } catch (e: IllegalArgumentException) {
                 throw XPathException("The regular expression '$regexString' is invalid.")
             }
         }

--- a/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathTodayFunc.kt
+++ b/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathTodayFunc.kt
@@ -4,7 +4,7 @@ import org.javarosa.core.model.condition.EvaluationContext
 import org.javarosa.core.model.instance.DataInstance
 import org.javarosa.core.model.utils.DateUtils
 import org.javarosa.xpath.parser.XPathSyntaxException
-import java.util.Date
+import org.javarosa.core.model.utils.PlatformDate
 
 open class XPathTodayFunc : XPathFuncExpr, VolatileXPathFuncExpr {
     constructor() {
@@ -16,7 +16,7 @@ open class XPathTodayFunc : XPathFuncExpr, VolatileXPathFuncExpr {
     constructor(args: Array<XPathExpression>) : super(NAME, args, EXPECTED_ARG_COUNT, false)
 
     override fun evalBody(model: DataInstance<*>?, evalContext: EvaluationContext, evaluatedArgs: Array<Any?>): Any {
-        return DateUtils.roundDate(Date())
+        return DateUtils.roundDate(PlatformDate())
     }
 
     override fun rootExpressionTypeIsCacheable(): Boolean {


### PR DESCRIPTION
## Summary

- Create cross-platform `PlatformDate` (expect/actual) to replace `java.util.Date` in 28 Kotlin files
- Replace `java.util.regex.Pattern`/`Matcher` with Kotlin `Regex` in 4 files
- 35 files changed, 3 new files (PlatformDate in commonMain/jvmMain/iosMain)

## Changes

**PlatformDate expect/actual:**
- `commonMain`: expect class with `constructor()`, `constructor(Long)`, `getTime()`, `setTime()`
- `jvmMain`: `actual typealias PlatformDate = java.util.Date` — zero runtime overhead
- `iosMain`: actual class wrapping epoch millis via `NSDate.timeIntervalSince1970`
- 28 files: `import java.util.Date` → `import org.javarosa.core.model.utils.PlatformDate`, all `Date` references → `PlatformDate`

**Regex migration (4 files):**
- `FixtureIndexSchema.kt`: `Pattern.matches()` → `Regex().matches()`
- `StringUtils.kt`: `Pattern.compile()` → `Regex()`, `.matcher().replaceAll()` → `.replace()`
- `XPathRegexFunc.kt`: `Pattern.compile().matcher().find()` → `Regex().containsMatchIn()`
- `XPathReplaceFunc.kt`: `Matcher.quoteReplacement()` → `Regex.escapeReplacement()`, `PatternSyntaxException` → `IllegalArgumentException`

## Acceptance criteria

- [x] Zero imports of `java.util.Date` in Kotlin source (`src/main/java/**/*.kt`)
- [x] Zero imports of `java.util.regex.Pattern`/`Matcher` in Kotlin source
- [x] All 769 JVM tests pass
- [x] Compilation succeeds across all source sets

## Notable technical decisions

1. **Typealias for JVM**: `PlatformDate` = `java.util.Date` on JVM means zero runtime overhead. Java callers continue using `java.util.Date` unmodified.
2. **No `var time` in expect class**: `java.util.Date.getTime()/setTime()` are Java methods that Kotlin synthesizes as property access, but expect/actual matching doesn't resolve them as `var time`. Declared `getTime()/setTime()` functions instead — Kotlin callers can still use `.time` property syntax via the JVM typealias.
3. **`IllegalArgumentException` catch**: Kotlin `Regex(badPattern)` throws platform-specific exception. On JVM it's `PatternSyntaxException extends IllegalArgumentException`. Catching `IllegalArgumentException` works cross-platform.

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)