### PR TITLE
Wave 8: Real iOS platform implementations

### DIFF
--- a/commcare-core/src/commonTest/kotlin/org/commcare/core/interfaces/PlatformCryptoTest.kt
+++ b/commcare-core/src/commonTest/kotlin/org/commcare/core/interfaces/PlatformCryptoTest.kt
@@ -1,0 +1,120 @@
+package org.commcare.core.interfaces
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Cross-platform tests for PlatformCrypto.
+ * These run on both JVM and iOS to verify crypto operations work correctly.
+ */
+class PlatformCryptoTest {
+
+    @Test
+    fun testSha256ProducesCorrectLength() {
+        val hash = PlatformCrypto.sha256("hello".encodeToByteArray())
+        assertEquals(32, hash.size)
+    }
+
+    @Test
+    fun testSha256Deterministic() {
+        val data = "CommCare test data".encodeToByteArray()
+        val hash1 = PlatformCrypto.sha256(data)
+        val hash2 = PlatformCrypto.sha256(data)
+        assertEquals(hash1.toList(), hash2.toList())
+    }
+
+    @Test
+    fun testSha256DifferentInputsDifferentOutputs() {
+        val hash1 = PlatformCrypto.sha256("hello".encodeToByteArray())
+        val hash2 = PlatformCrypto.sha256("world".encodeToByteArray())
+        assertNotEquals(hash1.toList(), hash2.toList())
+    }
+
+    @Test
+    fun testMd5ProducesCorrectLength() {
+        val hash = PlatformCrypto.md5("hello".encodeToByteArray())
+        assertEquals(16, hash.size)
+    }
+
+    @Test
+    fun testMd5Deterministic() {
+        val data = "CommCare test data".encodeToByteArray()
+        val hash1 = PlatformCrypto.md5(data)
+        val hash2 = PlatformCrypto.md5(data)
+        assertEquals(hash1.toList(), hash2.toList())
+    }
+
+    @Test
+    fun testRandomBytesCorrectLength() {
+        val bytes16 = PlatformCrypto.randomBytes(16)
+        assertEquals(16, bytes16.size)
+        val bytes32 = PlatformCrypto.randomBytes(32)
+        assertEquals(32, bytes32.size)
+    }
+
+    @Test
+    fun testRandomBytesNotAllZeros() {
+        val bytes = PlatformCrypto.randomBytes(32)
+        // Extremely unlikely to be all zeros from a good RNG
+        assertTrue(bytes.any { it != 0.toByte() })
+    }
+
+    @Test
+    fun testGenerateAesKey256() {
+        val key = PlatformCrypto.generateAesKey(256)
+        assertEquals(32, key.size)
+    }
+
+    @Test
+    fun testGenerateAesKey128() {
+        val key = PlatformCrypto.generateAesKey(128)
+        assertEquals(16, key.size)
+    }
+
+    @Test
+    fun testAesEncryptDecryptRoundTrip() {
+        val key = PlatformCrypto.generateAesKey(256)
+        val plaintext = "Hello CommCare!".encodeToByteArray()
+
+        val encrypted = PlatformCrypto.aesEncrypt(plaintext, key)
+        val decrypted = PlatformCrypto.aesDecrypt(encrypted, key)
+
+        assertEquals(plaintext.toList(), decrypted.toList())
+    }
+
+    @Test
+    fun testAesEncryptProducesDifferentCiphertexts() {
+        val key = PlatformCrypto.generateAesKey(256)
+        val plaintext = "Hello CommCare!".encodeToByteArray()
+
+        val encrypted1 = PlatformCrypto.aesEncrypt(plaintext, key)
+        val encrypted2 = PlatformCrypto.aesEncrypt(plaintext, key)
+
+        // Different IVs should produce different ciphertexts
+        assertNotEquals(encrypted1.toList(), encrypted2.toList())
+    }
+
+    @Test
+    fun testAesEncryptDecryptEmptyData() {
+        val key = PlatformCrypto.generateAesKey(256)
+        val plaintext = ByteArray(0)
+
+        val encrypted = PlatformCrypto.aesEncrypt(plaintext, key)
+        val decrypted = PlatformCrypto.aesDecrypt(encrypted, key)
+
+        assertEquals(plaintext.toList(), decrypted.toList())
+    }
+
+    @Test
+    fun testAesEncryptDecryptLargeData() {
+        val key = PlatformCrypto.generateAesKey(256)
+        val plaintext = ByteArray(10000) { (it % 256).toByte() }
+
+        val encrypted = PlatformCrypto.aesEncrypt(plaintext, key)
+        val decrypted = PlatformCrypto.aesDecrypt(encrypted, key)
+
+        assertEquals(plaintext.toList(), decrypted.toList())
+    }
+}

--- a/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformCrypto.kt
+++ b/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformCrypto.kt
@@ -1,38 +1,190 @@
 package org.commcare.core.interfaces
 
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
+import platform.CommonCrypto.CC_MD5
+import platform.CommonCrypto.CC_MD5_DIGEST_LENGTH
+import platform.CommonCrypto.CC_SHA256
+import platform.CommonCrypto.CC_SHA256_DIGEST_LENGTH
+import platform.CommonCrypto.CCCrypt
+import platform.CommonCrypto.kCCAlgorithmAES
+import platform.CommonCrypto.kCCBlockSizeAES128
+import platform.CommonCrypto.kCCDecrypt
+import platform.CommonCrypto.kCCEncrypt
+import platform.CommonCrypto.kCCOptionPKCS7Padding
+import platform.CommonCrypto.kCCSuccess
+import platform.CoreFoundation.CFIndex
+import platform.Security.SecRandomCopyBytes
+import platform.Security.errSecSuccess
+import platform.Security.kSecRandomDefault
+import platform.posix.size_tVar
+
 /**
- * iOS cryptography implementation.
- * Uses CommonCrypto via Kotlin/Native interop.
+ * iOS cryptography implementation using CommonCrypto and Security frameworks.
  *
- * Note: Full CommonCrypto interop requires cinterop configuration.
- * This implementation provides the structure; the actual interop calls
- * will be wired up when building on macOS with Xcode.
+ * Uses AES/CBC/PKCS7 (CommonCrypto's native mode) rather than AES/GCM
+ * since CommonCrypto doesn't directly support GCM. The encrypt/decrypt
+ * format is IV (16 bytes) prepended to ciphertext, matching the interface
+ * contract.
  */
+@OptIn(ExperimentalForeignApi::class)
 actual object PlatformCrypto {
+    private const val AES_IV_LENGTH = kCCBlockSizeAES128
 
     actual fun sha256(data: ByteArray): ByteArray {
-        // Will use CC_SHA256 via cinterop
-        TODO("iOS SHA-256 implementation requires CommonCrypto cinterop")
+        val digest = ByteArray(CC_SHA256_DIGEST_LENGTH)
+        digest.usePinned { digestPinned ->
+            if (data.isEmpty()) {
+                CC_SHA256(null, 0u, digestPinned.addressOf(0).reinterpret())
+            } else {
+                data.usePinned { dataPinned ->
+                    CC_SHA256(
+                        dataPinned.addressOf(0),
+                        data.size.toUInt(),
+                        digestPinned.addressOf(0).reinterpret()
+                    )
+                }
+            }
+        }
+        return digest
     }
 
     actual fun md5(data: ByteArray): ByteArray {
-        // Will use CC_MD5 via cinterop
-        TODO("iOS MD5 implementation requires CommonCrypto cinterop")
+        val digest = ByteArray(CC_MD5_DIGEST_LENGTH)
+        digest.usePinned { digestPinned ->
+            if (data.isEmpty()) {
+                CC_MD5(null, 0u, digestPinned.addressOf(0).reinterpret())
+            } else {
+                data.usePinned { dataPinned ->
+                    CC_MD5(
+                        dataPinned.addressOf(0),
+                        data.size.toUInt(),
+                        digestPinned.addressOf(0).reinterpret()
+                    )
+                }
+            }
+        }
+        return digest
     }
 
     actual fun randomBytes(size: Int): ByteArray {
-        // Will use SecRandomCopyBytes via cinterop
-        TODO("iOS randomBytes implementation requires Security framework cinterop")
+        val bytes = ByteArray(size)
+        bytes.usePinned { pinned ->
+            val status = SecRandomCopyBytes(kSecRandomDefault, size.toULong(), pinned.addressOf(0))
+            if (status != errSecSuccess) {
+                throw RuntimeException("SecRandomCopyBytes failed with status: $status")
+            }
+        }
+        return bytes
     }
 
     actual fun aesEncrypt(data: ByteArray, key: ByteArray): ByteArray {
-        // Will use CCCrypt with kCCAlgorithmAES via cinterop
-        TODO("iOS AES encrypt implementation requires CommonCrypto cinterop")
+        val iv = randomBytes(AES_IV_LENGTH)
+        val bufferSize = data.size + AES_IV_LENGTH // room for PKCS7 padding
+        val ciphertext = ByteArray(bufferSize)
+
+        memScoped {
+            val dataOutMoved = alloc<size_tVar>()
+            val status = ciphertext.usePinned { ciphertextPinned ->
+                iv.usePinned { ivPinned ->
+                    key.usePinned { keyPinned ->
+                        if (data.isEmpty()) {
+                            CCCrypt(
+                                kCCEncrypt,
+                                kCCAlgorithmAES,
+                                kCCOptionPKCS7Padding.toUInt(),
+                                keyPinned.addressOf(0),
+                                key.size.toULong(),
+                                ivPinned.addressOf(0),
+                                null,
+                                0u,
+                                ciphertextPinned.addressOf(0),
+                                bufferSize.toULong(),
+                                dataOutMoved.ptr
+                            )
+                        } else {
+                            data.usePinned { dataPinned ->
+                                CCCrypt(
+                                    kCCEncrypt,
+                                    kCCAlgorithmAES,
+                                    kCCOptionPKCS7Padding.toUInt(),
+                                    keyPinned.addressOf(0),
+                                    key.size.toULong(),
+                                    ivPinned.addressOf(0),
+                                    dataPinned.addressOf(0),
+                                    data.size.toULong(),
+                                    ciphertextPinned.addressOf(0),
+                                    bufferSize.toULong(),
+                                    dataOutMoved.ptr
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+            if (status != kCCSuccess) {
+                throw RuntimeException("AES encrypt failed with status: $status")
+            }
+            val actualSize = dataOutMoved.value.toInt()
+            return iv + ciphertext.copyOfRange(0, actualSize)
+        }
     }
 
     actual fun aesDecrypt(data: ByteArray, key: ByteArray): ByteArray {
-        // Will use CCCrypt with kCCAlgorithmAES via cinterop
-        TODO("iOS AES decrypt implementation requires CommonCrypto cinterop")
+        val iv = data.copyOfRange(0, AES_IV_LENGTH)
+        val ciphertext = data.copyOfRange(AES_IV_LENGTH, data.size)
+        val plaintext = ByteArray(ciphertext.size)
+
+        memScoped {
+            val dataOutMoved = alloc<size_tVar>()
+            val status = plaintext.usePinned { plaintextPinned ->
+                iv.usePinned { ivPinned ->
+                    key.usePinned { keyPinned ->
+                        if (ciphertext.isEmpty()) {
+                            CCCrypt(
+                                kCCDecrypt,
+                                kCCAlgorithmAES,
+                                kCCOptionPKCS7Padding.toUInt(),
+                                keyPinned.addressOf(0),
+                                key.size.toULong(),
+                                ivPinned.addressOf(0),
+                                null,
+                                0u,
+                                plaintextPinned.addressOf(0),
+                                plaintext.size.toULong(),
+                                dataOutMoved.ptr
+                            )
+                        } else {
+                            ciphertext.usePinned { ciphertextPinned ->
+                                CCCrypt(
+                                    kCCDecrypt,
+                                    kCCAlgorithmAES,
+                                    kCCOptionPKCS7Padding.toUInt(),
+                                    keyPinned.addressOf(0),
+                                    key.size.toULong(),
+                                    ivPinned.addressOf(0),
+                                    ciphertextPinned.addressOf(0),
+                                    ciphertext.size.toULong(),
+                                    plaintextPinned.addressOf(0),
+                                    plaintext.size.toULong(),
+                                    dataOutMoved.ptr
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+            if (status != kCCSuccess) {
+                throw RuntimeException("AES decrypt failed with status: $status")
+            }
+            val actualSize = dataOutMoved.value.toInt()
+            return plaintext.copyOfRange(0, actualSize)
+        }
     }
 
     actual fun generateAesKey(bits: Int): ByteArray {

--- a/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformFiles.kt
+++ b/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformFiles.kt
@@ -1,39 +1,102 @@
 package org.commcare.core.interfaces
 
+import kotlinx.cinterop.BooleanVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
+import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSFileSize
+import platform.Foundation.NSNumber
+import platform.Foundation.NSProcessInfo
+import platform.Foundation.NSString
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.create
+import platform.Foundation.dataWithContentsOfFile
+import platform.Foundation.stringByAppendingPathComponent
+import platform.Foundation.writeToFile
+import platform.posix.memcpy
+
 /**
- * iOS file system operations.
- * Will use NSFileManager via Kotlin/Native interop.
+ * iOS file system operations using NSFileManager.
  */
+@OptIn(ExperimentalForeignApi::class)
 actual object PlatformFiles {
+
+    private val fileManager: NSFileManager
+        get() = NSFileManager.defaultManager
+
     actual fun readBytes(path: String): ByteArray {
-        TODO("iOS readBytes requires NSFileManager cinterop")
+        val data = NSData.dataWithContentsOfFile(path)
+            ?: throw RuntimeException("Cannot read file: $path")
+        val size = data.length.toInt()
+        if (size == 0) return ByteArray(0)
+        val bytes = ByteArray(size)
+        bytes.usePinned { pinned ->
+            memcpy(pinned.addressOf(0), data.bytes, data.length)
+        }
+        return bytes
     }
 
     actual fun writeBytes(path: String, data: ByteArray) {
-        TODO("iOS writeBytes requires NSFileManager cinterop")
+        val nsData = if (data.isEmpty()) {
+            NSData()
+        } else {
+            data.usePinned { pinned ->
+                NSData.create(bytes = pinned.addressOf(0), length = data.size.toULong())
+            }
+        }
+        val success = nsData.writeToFile(path, atomically = true)
+        if (!success) {
+            throw RuntimeException("Cannot write file: $path")
+        }
     }
 
     actual fun exists(path: String): Boolean {
-        TODO("iOS exists requires NSFileManager cinterop")
+        return fileManager.fileExistsAtPath(path)
     }
 
     actual fun delete(path: String): Boolean {
-        TODO("iOS delete requires NSFileManager cinterop")
+        return try {
+            fileManager.removeItemAtPath(path, error = null)
+            true
+        } catch (_: Exception) {
+            false
+        }
     }
 
     actual fun isDirectory(path: String): Boolean {
-        TODO("iOS isDirectory requires NSFileManager cinterop")
+        memScoped {
+            val isDir = alloc<BooleanVar>()
+            val exists = fileManager.fileExistsAtPath(path, isDirectory = isDir.ptr)
+            return exists && isDir.value
+        }
     }
 
     actual fun listDir(path: String): List<String> {
-        TODO("iOS listDir requires NSFileManager cinterop")
+        return fileManager.contentsOfDirectoryAtPath(path, error = null)
+            ?.mapNotNull { it as? String }
+            ?: emptyList()
     }
 
     actual fun fileSize(path: String): Long {
-        TODO("iOS fileSize requires NSFileManager cinterop")
+        val attrs = fileManager.attributesOfItemAtPath(path, error = null)
+            ?: return 0L
+        val size = attrs[NSFileSize] as? NSNumber
+        return size?.longLongValue ?: 0L
     }
 
     actual fun createTempFile(prefix: String, suffix: String): String {
-        TODO("iOS createTempFile requires NSTemporaryDirectory cinterop")
+        val tempDir = NSTemporaryDirectory()
+        val uniqueId = NSProcessInfo.processInfo.globallyUniqueString
+        val fileName = "$prefix$uniqueId$suffix"
+        @Suppress("CAST_NEVER_SUCCEEDS")
+        val path = (tempDir as NSString).stringByAppendingPathComponent(fileName)
+        fileManager.createFileAtPath(path, contents = null, attributes = null)
+        return path
     }
 }

--- a/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformHttpClient.kt
+++ b/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformHttpClient.kt
@@ -1,12 +1,105 @@
 package org.commcare.core.interfaces
 
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.NSHTTPURLResponse
+import platform.Foundation.NSMutableURLRequest
+import platform.Foundation.NSURL
+import platform.Foundation.NSURLConnection
+import platform.Foundation.NSURLResponse
+import platform.Foundation.create
+import platform.Foundation.sendSynchronousRequest
+import platform.Foundation.setHTTPBody
+import platform.Foundation.setHTTPMethod
+import platform.Foundation.setValue
+import platform.posix.memcpy
+import kotlinx.cinterop.ObjCObjectVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import platform.Foundation.NSError
+
 /**
- * iOS HTTP client.
- * Will use NSURLSession via Kotlin/Native interop.
+ * iOS HTTP client using NSURLConnection (synchronous).
  */
 class IosHttpClient : PlatformHttpClient {
+
+    @OptIn(ExperimentalForeignApi::class)
     override fun execute(request: HttpRequest): HttpResponse {
-        TODO("iOS HTTP client requires Foundation NSURLSession cinterop")
+        val url = NSURL.URLWithString(request.url)
+            ?: throw RuntimeException("Invalid URL: ${request.url}")
+
+        val nsRequest = NSMutableURLRequest.requestWithURL(url)
+        nsRequest.setHTTPMethod(request.method.uppercase())
+
+        for ((name, value) in request.headers) {
+            nsRequest.setValue(value, forHTTPHeaderField = name)
+        }
+
+        if (request.body != null && request.body.isNotEmpty()) {
+            val nsData = request.body.usePinned { pinned ->
+                NSData.create(bytes = pinned.addressOf(0), length = request.body.size.toULong())
+            }
+            nsRequest.setHTTPBody(nsData)
+        }
+
+        if (request.contentType != null) {
+            nsRequest.setValue(request.contentType, forHTTPHeaderField = "Content-Type")
+        }
+
+        memScoped {
+            val responsePtr = alloc<ObjCObjectVar<NSURLResponse?>>()
+            val errorPtr = alloc<ObjCObjectVar<NSError?>>()
+
+            @Suppress("DEPRECATION")
+            val responseData = NSURLConnection.sendSynchronousRequest(
+                nsRequest,
+                returningResponse = responsePtr.ptr,
+                error = errorPtr.ptr
+            )
+
+            val error = errorPtr.value
+            if (error != null) {
+                return HttpResponse(
+                    code = error.code.toInt(),
+                    headers = emptyMap(),
+                    body = null,
+                    errorBody = error.localizedDescription.encodeToByteArray()
+                )
+            }
+
+            val httpResponse = responsePtr.value as? NSHTTPURLResponse
+            val statusCode = httpResponse?.statusCode?.toInt() ?: 0
+
+            val headers = mutableMapOf<String, String>()
+            httpResponse?.allHeaderFields?.forEach { (key, value) ->
+                if (key is String && value is String) {
+                    headers[key] = value
+                }
+            }
+
+            val bodyBytes = responseData?.let { data ->
+                val size = data.length.toInt()
+                if (size == 0) ByteArray(0)
+                else {
+                    val bytes = ByteArray(size)
+                    bytes.usePinned { pinned ->
+                        memcpy(pinned.addressOf(0), data.bytes, data.length)
+                    }
+                    bytes
+                }
+            }
+
+            return HttpResponse(
+                code = statusCode,
+                headers = headers,
+                body = if (statusCode in 200..299) bodyBytes else null,
+                errorBody = if (statusCode !in 200..299) bodyBytes else null
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- **PlatformCrypto**: Replace TODO stubs with real CommonCrypto implementations
  - `sha256()` / `md5()` via `CC_SHA256` / `CC_MD5`
  - `randomBytes()` via `SecRandomCopyBytes`
  - `aesEncrypt()` / `aesDecrypt()` via `CCCrypt` with AES/CBC/PKCS7
  - `generateAesKey()` via secure random bytes
- **PlatformFiles**: Replace TODO stubs with NSFileManager implementations
  - `readBytes()` / `writeBytes()` via NSData
  - `exists()` / `delete()` / `isDirectory()` / `listDir()` / `fileSize()` via NSFileManager
  - `createTempFile()` via NSTemporaryDirectory + NSProcessInfo.globallyUniqueString
- **PlatformHttpClient**: Replace TODO stub with NSURLConnection synchronous requests
  - Full HTTP method support (GET, POST, PUT, DELETE)
  - Header handling, request body, content type
  - Error response handling
- **Cross-platform tests**: 13 new PlatformCryptoTest cases validating SHA-256, MD5, random bytes, AES key generation, and AES encrypt/decrypt round-trips

### Notable decisions

- **AES/CBC vs AES/GCM**: iOS uses AES/CBC/PKCS7 (CommonCrypto's native mode) since CommonCrypto doesn't directly support GCM. JVM uses AES/GCM. The formats are platform-specific — data encrypted on one platform is decrypted on the same platform.
- **NSURLConnection**: Used synchronous `sendSynchronousRequest` (deprecated but functional) for simplicity, since the PlatformHttpClient interface is synchronous. Can be migrated to NSURLSession with semaphore if needed.
- **PlatformUrl and PlatformDate**: Already had real implementations (pure Kotlin URL parser and NSDate-based), no changes needed.

Files changed: 4 (3 modified, 1 new test)

Closes #71

## Test plan

- [x] JVM compilation passes (`compileKotlinJvm compileJava`)
- [x] commonMain metadata compilation passes (`compileCommonMainKotlinMetadata`)
- [x] JVM test suite passes (710+ tests)
- [x] New PlatformCryptoTest passes on JVM (13 tests)
- [ ] iOS compilation verified by CI (macOS runner)
- [ ] PlatformCryptoTest passes on iOS simulator (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)