### PR TITLE
Phase 3 Wave 2: Migrate XML consumers to PlatformXmlParser

### DIFF
--- a/commcare-core/src/commonMain/kotlin/org/javarosa/xml/PlatformXmlParser.kt
+++ b/commcare-core/src/commonMain/kotlin/org/javarosa/xml/PlatformXmlParser.kt
@@ -4,22 +4,66 @@ package org.javarosa.xml
  * Cross-platform XML pull parser interface mirroring XmlPullParser/KXmlParser API.
  * On JVM, implemented by wrapping kxml2's KXmlParser.
  * On iOS, implemented with a pure Kotlin state-machine parser.
+ *
+ * Uses Kotlin properties for simple getters to enable property-syntax access
+ * (e.g., parser.name, parser.depth) which matches KXmlParser's Java-to-Kotlin usage.
  */
 interface PlatformXmlParser {
     fun next(): Int
-    fun getEventType(): Int
-    fun getName(): String?
-    fun getNamespace(): String?
-    fun getText(): String?
+
+    val eventType: Int
+    val name: String?
+    val namespace: String?
+    val text: String?
+    val depth: Int
+    val attributeCount: Int
+    val prefix: String?
+    val positionDescription: String
+
     fun isWhitespace(): Boolean
-    fun getDepth(): Int
     fun getAttributeValue(namespace: String?, name: String): String?
-    fun getAttributeCount(): Int
     fun getAttributeName(index: Int): String
     fun getAttributeNamespace(index: Int): String
     fun getAttributePrefix(index: Int): String?
     fun getAttributeValue(index: Int): String
     fun getNamespace(prefix: String?): String
+
+    /**
+     * Skip whitespace and advance to the next START_TAG or END_TAG.
+     * Throws if the next non-whitespace event is not a tag.
+     */
+    fun nextTag(): Int {
+        var event = next()
+        if (event == TEXT && isWhitespace()) {
+            event = next()
+        }
+        if (event != START_TAG && event != END_TAG) {
+            throw PlatformXmlParserException("Expected START_TAG or END_TAG, got $event")
+        }
+        return event
+    }
+
+    /**
+     * Read the text content of the current element.
+     * Must be on START_TAG. Returns the text and leaves parser on END_TAG.
+     */
+    fun nextText(): String {
+        if (eventType != START_TAG) {
+            throw PlatformXmlParserException("Parser must be on START_TAG to read next text, was $eventType")
+        }
+        var event = next()
+        val result: String
+        if (event == TEXT) {
+            result = text ?: ""
+            event = next()
+        } else {
+            result = ""
+        }
+        if (event != END_TAG) {
+            throw PlatformXmlParserException("Expected END_TAG after text, got $event")
+        }
+        return result
+    }
 
     companion object {
         const val START_DOCUMENT = 0

--- a/commcare-core/src/commonTest/kotlin/org/javarosa/xml/XmlParserTest.kt
+++ b/commcare-core/src/commonTest/kotlin/org/javarosa/xml/XmlParserTest.kt
@@ -15,16 +15,16 @@ class XmlParserTest {
         val xml = "<root>hello</root>"
         val parser = createXmlParser(xml.encodeToByteArray())
 
-        assertEquals(PlatformXmlParser.START_DOCUMENT, parser.getEventType())
+        assertEquals(PlatformXmlParser.START_DOCUMENT, parser.eventType)
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next())
-        assertEquals("root", parser.getName())
+        assertEquals("root", parser.name)
 
         assertEquals(PlatformXmlParser.TEXT, parser.next())
-        assertEquals("hello", parser.getText())
+        assertEquals("hello", parser.text)
 
         assertEquals(PlatformXmlParser.END_TAG, parser.next())
-        assertEquals("root", parser.getName())
+        assertEquals("root", parser.name)
 
         assertEquals(PlatformXmlParser.END_DOCUMENT, parser.next())
     }
@@ -35,8 +35,8 @@ class XmlParserTest {
         val parser = createXmlParser(xml.encodeToByteArray())
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next())
-        assertEquals("item", parser.getName())
-        assertEquals(2, parser.getAttributeCount())
+        assertEquals("item", parser.name)
+        assertEquals(2, parser.attributeCount)
         assertEquals("123", parser.getAttributeValue(null, "id"))
         assertEquals("case", parser.getAttributeValue(null, "type"))
     }
@@ -58,9 +58,9 @@ class XmlParserTest {
         var foundCaseName = false
         var caseNameText: String? = null
         while (parser.next() != PlatformXmlParser.END_DOCUMENT) {
-            if (parser.getEventType() == PlatformXmlParser.START_TAG && parser.getName() == "case_name") {
+            if (parser.eventType == PlatformXmlParser.START_TAG && parser.name == "case_name") {
                 parser.next() // TEXT
-                caseNameText = parser.getText()
+                caseNameText = parser.text
                 foundCaseName = true
                 break
             }
@@ -76,19 +76,19 @@ class XmlParserTest {
         val parser = createXmlParser(xml.encodeToByteArray())
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next()) // data
-        assertEquals("data", parser.getName())
+        assertEquals("data", parser.name)
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next()) // empty
-        assertEquals("empty", parser.getName())
+        assertEquals("empty", parser.name)
 
         assertEquals(PlatformXmlParser.END_TAG, parser.next()) // /empty
-        assertEquals("empty", parser.getName())
+        assertEquals("empty", parser.name)
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next()) // next
-        assertEquals("next", parser.getName())
+        assertEquals("next", parser.name)
 
         assertEquals(PlatformXmlParser.TEXT, parser.next())
-        assertEquals("ok", parser.getText())
+        assertEquals("ok", parser.text)
     }
 
     @Test
@@ -97,12 +97,12 @@ class XmlParserTest {
         val parser = createXmlParser(xml.encodeToByteArray())
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next())
-        assertEquals("html", parser.getName())
-        assertEquals("http://www.w3.org/1999/xhtml", parser.getNamespace())
+        assertEquals("html", parser.name)
+        assertEquals("http://www.w3.org/1999/xhtml", parser.namespace)
 
         assertEquals(PlatformXmlParser.START_TAG, parser.next())
-        assertEquals("body", parser.getName())
-        assertEquals("http://www.w3.org/1999/xhtml", parser.getNamespace())
+        assertEquals("body", parser.name)
+        assertEquals("http://www.w3.org/1999/xhtml", parser.namespace)
     }
 
     @Test
@@ -112,7 +112,7 @@ class XmlParserTest {
 
         parser.next() // START_TAG
         parser.next() // TEXT
-        assertEquals("1 < 2 & 3 > 0", parser.getText())
+        assertEquals("1 < 2 & 3 > 0", parser.text)
     }
 
     @Test
@@ -122,7 +122,7 @@ class XmlParserTest {
 
         parser.next() // START_TAG
         parser.next() // TEXT (CDATA content)
-        assertEquals("<not>xml</not>", parser.getText())
+        assertEquals("<not>xml</not>", parser.text)
     }
 
     @Test
@@ -153,8 +153,8 @@ class XmlParserTest {
         // Verify we can walk the entire XForm without errors
         val elementNames = mutableListOf<String>()
         while (parser.next() != PlatformXmlParser.END_DOCUMENT) {
-            if (parser.getEventType() == PlatformXmlParser.START_TAG) {
-                elementNames.add(parser.getName()!!)
+            if (parser.eventType == PlatformXmlParser.START_TAG) {
+                elementNames.add(parser.name!!)
             }
         }
 
@@ -178,7 +178,7 @@ class XmlParserTest {
         // Verify correct event sequence regardless of depth reporting details
         val events = mutableListOf<Pair<Int, String?>>()
         while (parser.next() != PlatformXmlParser.END_DOCUMENT) {
-            events.add(Pair(parser.getEventType(), parser.getName()))
+            events.add(Pair(parser.eventType, parser.name))
         }
 
         assertEquals(PlatformXmlParser.START_TAG, events[0].first)

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/xml/PlatformXmlParserIos.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/xml/PlatformXmlParserIos.kt
@@ -11,14 +11,14 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
 
     private val input: String = data.decodeToString()
     private var pos = 0
-    private var eventType = PlatformXmlParser.START_DOCUMENT
-    private var depth = 0
+    private var __eventType = PlatformXmlParser.START_DOCUMENT
+    private var _depth = 0
 
     // Current event state
-    private var currentName: String? = null
-    private var currentNamespace: String? = null
-    private var currentText: String? = null
-    private var currentPrefix: String? = null
+    private var _name: String? = null
+    private var _namespace: String? = null
+    private var _text: String? = null
+    private var _prefix: String? = null
     private var attributes = mutableListOf<Attribute>()
     private var isEmptyElement = false
     private var pendingEndTag = false
@@ -33,19 +33,28 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
         val value: String
     )
 
+    override val eventType: Int get() = _eventType
+    override val name: String? get() = _name
+    override val namespace: String? get() = _namespace
+    override val text: String? get() = _text
+    override val depth: Int get() = _depth
+    override val attributeCount: Int get() = attributes.size
+    override val prefix: String? get() = _prefix
+    override val positionDescription: String get() = "@position $pos in document (depth $_depth)"
+
     override fun next(): Int {
         if (pendingEndTag) {
             pendingEndTag = false
-            depth--
-            eventType = PlatformXmlParser.END_TAG
-            return eventType
+            _depth--
+            _eventType = PlatformXmlParser.END_TAG
+            return _eventType
         }
 
         skipWhitespaceAndComments()
 
         if (pos >= input.length) {
-            eventType = PlatformXmlParser.END_DOCUMENT
-            return eventType
+            _eventType = PlatformXmlParser.END_DOCUMENT
+            return _eventType
         }
 
         if (input[pos] == '<') {
@@ -72,18 +81,13 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
             parseText()
         }
 
-        return eventType
+        return _eventType
     }
 
-    override fun getEventType(): Int = eventType
-    override fun getName(): String? = currentName
-    override fun getNamespace(): String? = currentNamespace
-    override fun getText(): String? = currentText
-    override fun getDepth(): Int = depth
 
     override fun isWhitespace(): Boolean {
-        val text = currentText ?: return true
-        return text.all { it == ' ' || it == '\t' || it == '\n' || it == '\r' }
+        val t = _text ?: return true
+        return t.all { it == ' ' || it == '\t' || it == '\n' || it == '\r' }
     }
 
     override fun getAttributeValue(namespace: String?, name: String): String? {
@@ -92,7 +96,6 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
         }?.value
     }
 
-    override fun getAttributeCount(): Int = attributes.size
 
     override fun getAttributeName(index: Int): String = attributes[index].name
     override fun getAttributeNamespace(index: Int): String = attributes[index].namespace
@@ -106,6 +109,8 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
         }
         return ""
     }
+
+
 
     // --- Parsing Methods ---
 
@@ -144,20 +149,20 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
         }
         expect('>')
 
-        depth++
+        _depth++
 
         // Push namespace scope
-        while (namespaceStack.size < depth) {
+        while (namespaceStack.size < _depth) {
             namespaceStack.add(mutableMapOf())
         }
-        namespaceStack[depth - 1] = nsDeclarations.toMutableMap()
+        namespaceStack[_depth - 1] = nsDeclarations.toMutableMap()
 
         // Resolve element namespace
         val (prefix, localName) = splitQName(qname)
-        currentPrefix = prefix
-        currentName = localName
-        currentNamespace = resolveNamespace(prefix)
-        currentText = null
+        _prefix = prefix
+        _name = localName
+        _namespace = resolveNamespace(prefix)
+        _text = null
 
         // Resolve attribute namespaces
         attributes = attributes.map { attr ->
@@ -168,7 +173,7 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
             }
         }.toMutableList()
 
-        eventType = PlatformXmlParser.START_TAG
+        _eventType = PlatformXmlParser.START_TAG
 
         if (isEmptyElement) {
             pendingEndTag = true
@@ -182,18 +187,18 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
         expect('>')
 
         val (prefix, localName) = splitQName(qname)
-        currentName = localName
-        currentNamespace = resolveNamespace(prefix)
-        currentText = null
+        _name = localName
+        _namespace = resolveNamespace(prefix)
+        _text = null
         attributes.clear()
 
         // Pop namespace scope
-        if (depth > 0 && depth <= namespaceStack.size) {
-            namespaceStack[depth - 1].clear()
+        if (_depth > 0 && _depth <= namespaceStack.size) {
+            namespaceStack[_depth - 1].clear()
         }
-        depth--
+        _depth--
 
-        eventType = PlatformXmlParser.END_TAG
+        _eventType = PlatformXmlParser.END_TAG
     }
 
     private fun parseText() {
@@ -201,23 +206,23 @@ class IosXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
         while (pos < input.length && input[pos] != '<') {
             pos++
         }
-        currentText = decodeEntities(input.substring(start, pos))
-        currentName = null
-        currentNamespace = null
+        _text = decodeEntities(input.substring(start, pos))
+        _name = null
+        _namespace = null
         attributes.clear()
-        eventType = PlatformXmlParser.TEXT
+        _eventType = PlatformXmlParser.TEXT
     }
 
     private fun parseCData() {
         pos += 9 // skip "<![CDATA["
         val end = input.indexOf("]]>", pos)
         if (end == -1) throw RuntimeException("Unclosed CDATA section")
-        currentText = input.substring(pos, end)
+        _text = input.substring(pos, end)
         pos = end + 3
-        currentName = null
-        currentNamespace = null
+        _name = null
+        _namespace = null
         attributes.clear()
-        eventType = PlatformXmlParser.TEXT
+        _eventType = PlatformXmlParser.TEXT
     }
 
     private fun parseProcessingInstruction() {

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/PlatformXmlParserJvm.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/xml/PlatformXmlParserJvm.kt
@@ -2,33 +2,56 @@ package org.javarosa.xml
 
 import org.kxml2.io.KXmlParser
 import java.io.ByteArrayInputStream
+import java.io.InputStream
 
 /**
  * JVM implementation of PlatformXmlParser wrapping kxml2's KXmlParser.
  */
-class JvmXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
-    private val parser = KXmlParser()
+class JvmXmlParser : PlatformXmlParser {
+    val kxmlParser: KXmlParser
 
-    init {
-        parser.setInput(ByteArrayInputStream(data), encoding)
-        parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, true)
+    constructor(data: ByteArray, encoding: String) {
+        kxmlParser = KXmlParser()
+        kxmlParser.setInput(ByteArrayInputStream(data), encoding)
+        kxmlParser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, true)
     }
 
-    override fun next(): Int = mapEventType(parser.next())
-    override fun getEventType(): Int = mapEventType(parser.eventType)
-    override fun getName(): String? = parser.name
-    override fun getNamespace(): String? = parser.namespace
-    override fun getText(): String? = parser.text
-    override fun isWhitespace(): Boolean = parser.isWhitespace
-    override fun getDepth(): Int = parser.depth
+    /**
+     * Wrap an existing KXmlParser. Used by ElementParser.instantiateParser
+     * and other JVM code that creates parsers from InputStreams.
+     */
+    constructor(parser: KXmlParser) {
+        this.kxmlParser = parser
+    }
+
+    override fun next(): Int = mapEventType(kxmlParser.next())
+    override val eventType: Int get() = mapEventType(kxmlParser.eventType)
+    override val name: String? get() = kxmlParser.name
+    override val namespace: String? get() = kxmlParser.namespace
+    override val text: String? get() = kxmlParser.text
+    override val depth: Int get() = kxmlParser.depth
+    override val attributeCount: Int get() = kxmlParser.attributeCount
+    override val prefix: String? get() = kxmlParser.prefix
+    override val positionDescription: String get() = kxmlParser.positionDescription
+
+    override fun isWhitespace(): Boolean = kxmlParser.isWhitespace
     override fun getAttributeValue(namespace: String?, name: String): String? =
-        parser.getAttributeValue(namespace, name)
-    override fun getAttributeCount(): Int = parser.attributeCount
-    override fun getAttributeName(index: Int): String = parser.getAttributeName(index)
-    override fun getAttributeNamespace(index: Int): String = parser.getAttributeNamespace(index)
-    override fun getAttributePrefix(index: Int): String? = parser.getAttributePrefix(index)
-    override fun getAttributeValue(index: Int): String = parser.getAttributeValue(index)
-    override fun getNamespace(prefix: String?): String = parser.getNamespace(prefix)
+        kxmlParser.getAttributeValue(namespace, name)
+    override fun getAttributeName(index: Int): String = kxmlParser.getAttributeName(index)
+    override fun getAttributeNamespace(index: Int): String = kxmlParser.getAttributeNamespace(index)
+    override fun getAttributePrefix(index: Int): String? = kxmlParser.getAttributePrefix(index)
+    override fun getAttributeValue(index: Int): String = kxmlParser.getAttributeValue(index)
+    override fun getNamespace(prefix: String?): String = kxmlParser.getNamespace(prefix)
+
+    /**
+     * Delegates to KXmlParser.nextTag() for JVM compatibility.
+     */
+    override fun nextTag(): Int = mapEventType(kxmlParser.nextTag())
+
+    /**
+     * Delegates to KXmlParser.nextText() for JVM compatibility.
+     */
+    override fun nextText(): String = kxmlParser.nextText()
 
     private fun mapEventType(kxmlType: Int): Int {
         return when (kxmlType) {
@@ -40,6 +63,18 @@ class JvmXmlParser(data: ByteArray, encoding: String) : PlatformXmlParser {
             else -> kxmlType
         }
     }
+}
+
+/**
+ * Create a PlatformXmlParser from an InputStream (JVM-only).
+ * Configures namespace processing and advances past START_DOCUMENT.
+ */
+fun createXmlParser(stream: InputStream, encoding: String = "UTF-8"): PlatformXmlParser {
+    val parser = KXmlParser()
+    parser.setInput(stream, encoding)
+    parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, true)
+    parser.next()
+    return JvmXmlParser(parser)
 }
 
 actual fun createXmlParser(data: ByteArray, encoding: String): PlatformXmlParser =

--- a/commcare-core/src/main/java/org/commcare/core/parse/CaseInstanceXmlTransactionParserFactory.kt
+++ b/commcare-core/src/main/java/org/commcare/core/parse/CaseInstanceXmlTransactionParserFactory.kt
@@ -5,7 +5,7 @@ import org.commcare.data.xml.TransactionParser
 import org.commcare.data.xml.TransactionParserFactory
 import org.commcare.modern.engine.cases.CaseIndexTable
 import org.commcare.xml.bulk.BulkCaseInstanceXmlParser
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 
 /**
  * Transaction factory for parsing the case instance xml as defined in
@@ -28,7 +28,7 @@ class CaseInstanceXmlTransactionParserFactory(
         return object : TransactionParserFactory {
             var created: BulkCaseInstanceXmlParser? = null
 
-            override fun getParser(parser: KXmlParser): TransactionParser<*> {
+            override fun getParser(parser: PlatformXmlParser): TransactionParser<*> {
                 if (created == null) {
                     created = BulkCaseInstanceXmlParser(parser, sandbox.getCaseStorage(), caseIndexTable)
                 }
@@ -37,7 +37,7 @@ class CaseInstanceXmlTransactionParserFactory(
         }
     }
 
-    override fun getParser(parser: KXmlParser): TransactionParser<*>? {
+    override fun getParser(parser: PlatformXmlParser): TransactionParser<*>? {
         val name = parser.name
         if ("case".equals(name, ignoreCase = true)) {
             return caseParser.getParser(parser)

--- a/commcare-core/src/main/java/org/commcare/core/parse/CommCareTransactionParserFactory.kt
+++ b/commcare-core/src/main/java/org/commcare/core/parse/CommCareTransactionParserFactory.kt
@@ -12,7 +12,7 @@ import org.commcare.xml.LedgerXmlParsers
 import org.commcare.xml.bulk.LinearBulkProcessingCaseXmlParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
@@ -64,7 +64,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
         this.initStockParser()
     }
 
-    override fun getParser(parser: KXmlParser): TransactionParser<*>? {
+    override fun getParser(parser: PlatformXmlParser): TransactionParser<*>? {
         val namespace = parser.namespace
         val name = parser.name
         if (LedgerXmlParsers.STOCK_XML_NAMESPACE == namespace) {
@@ -92,7 +92,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
             val isIndexedAttr = parser.getAttributeValue(null, "indexed")
             val isIndexed = "true" == isIndexedAttr
             req()
-            processedFixtures.add(id)
+            processedFixtures.add(id!!)
             if (isIndexed) {
                 val schema = fixtureSchemas[id]
                 return IndexedFixtureXmlParser(parser, id, schema, sandbox)
@@ -141,7 +141,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
         userParser = object : TransactionParserFactory {
             var created: UserXmlParser? = null
 
-            override fun getParser(parser: KXmlParser): TransactionParser<*> {
+            override fun getParser(parser: PlatformXmlParser): TransactionParser<*> {
                 if (created == null) {
                     created = UserXmlParser(parser, sandbox.getUserStorage())
                 }
@@ -154,7 +154,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
         fixtureParser = object : TransactionParserFactory {
             var created: FixtureXmlParser? = null
 
-            override fun getParser(parser: KXmlParser): TransactionParser<*> {
+            override fun getParser(parser: PlatformXmlParser): TransactionParser<*> {
                 if (created == null) {
                     created = FixtureXmlParser(parser, true, sandbox.getUserFixtureStorage())
                 }
@@ -185,7 +185,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
         return object : TransactionParserFactory {
             var created: CaseXmlParser? = null
 
-            override fun getParser(parser: KXmlParser): TransactionParser<*> {
+            override fun getParser(parser: PlatformXmlParser): TransactionParser<*> {
                 if (created == null) {
                     created = CaseXmlParser(parser, sandbox.getCaseStorage())
                 }
@@ -198,7 +198,7 @@ open class CommCareTransactionParserFactory @JvmOverloads constructor(
         return object : TransactionParserFactory {
             var created: LinearBulkProcessingCaseXmlParser? = null
 
-            override fun getParser(parser: KXmlParser): TransactionParser<*> {
+            override fun getParser(parser: PlatformXmlParser): TransactionParser<*> {
                 if (created == null) {
                     created = LinearBulkProcessingCaseXmlParser(parser, sandbox.getCaseStorage())
                 }

--- a/commcare-core/src/main/java/org/commcare/core/parse/UserXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/core/parse/UserXmlParser.kt
@@ -6,7 +6,7 @@ import org.javarosa.core.model.utils.DateUtils
 import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
@@ -17,9 +17,9 @@ open class UserXmlParser : TransactionParser<User> {
 
     private var storage: IStorageUtilityIndexed<User>? = null
 
-    constructor(parser: KXmlParser) : super(parser)
+    constructor(parser: PlatformXmlParser) : super(parser)
 
-    constructor(parser: KXmlParser, storage: IStorageUtilityIndexed<User>) : super(parser) {
+    constructor(parser: PlatformXmlParser, storage: IStorageUtilityIndexed<User>) : super(parser) {
         this.storage = storage
     }
 
@@ -58,7 +58,7 @@ open class UserXmlParser : TransactionParser<User> {
 
         // Now look for optional components
         while (this.nextTagInBlock("registration")) {
-            val tag = parser.name.lowercase()
+            val tag = parser.name!!.lowercase()
 
             if (tag == "registering_phone_id") {
                 parser.nextText()
@@ -71,7 +71,7 @@ open class UserXmlParser : TransactionParser<User> {
                     val key = this.parser.getAttributeValue(null, "key")
                     val value = this.parser.nextText()
 
-                    u.setProperty(key, value)
+                    u.setProperty(key!!, value!!)
                 }
 
                 // This should be the last block in the registration stuff...

--- a/commcare-core/src/main/java/org/commcare/data/xml/TransactionParser.java
+++ b/commcare-core/src/main/java/org/commcare/data/xml/TransactionParser.java
@@ -1,8 +1,8 @@
 package org.commcare.data.xml;
 
 import org.javarosa.xml.ElementParser;
+import org.javarosa.xml.PlatformXmlParser;
 import org.javarosa.xml.util.InvalidStructureException;
-import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -11,7 +11,7 @@ import java.io.IOException;
  * @author ctsims
  */
 public abstract class TransactionParser<T> extends ElementParser<T> {
-    public TransactionParser(KXmlParser parser) {
+    public TransactionParser(PlatformXmlParser parser) {
         super(parser);
     }
 

--- a/commcare-core/src/main/java/org/commcare/data/xml/TransactionParserFactory.java
+++ b/commcare-core/src/main/java/org/commcare/data/xml/TransactionParserFactory.java
@@ -1,7 +1,7 @@
 package org.commcare.data.xml;
 
-import org.kxml2.io.KXmlParser;
+import org.javarosa.xml.PlatformXmlParser;
 
 public interface TransactionParserFactory {
-    TransactionParser getParser(KXmlParser parser);
+    TransactionParser getParser(PlatformXmlParser parser);
 }

--- a/commcare-core/src/main/java/org/commcare/suite/model/OfflineUserRestore.kt
+++ b/commcare-core/src/main/java/org/commcare/suite/model/OfflineUserRestore.kt
@@ -14,7 +14,7 @@ import org.javarosa.core.util.externalizable.ExtUtil
 import org.javarosa.core.util.externalizable.PrototypeFactory
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 
 import java.io.ByteArrayInputStream
@@ -106,7 +106,7 @@ class OfflineUserRestore : Persistable {
     private fun checkThatRestoreIsValidAndSetUsername() {
         val factory = TransactionParserFactory { parser ->
             val name = parser.name
-            if ("registration" == name.lowercase()) {
+            if ("registration" == name!!.lowercase()) {
                 return@TransactionParserFactory buildUserParser(parser)
             }
             null
@@ -116,7 +116,7 @@ class OfflineUserRestore : Persistable {
         parser.parse()
     }
 
-    private fun buildUserParser(parser: KXmlParser): TransactionParser<*> {
+    private fun buildUserParser(parser: PlatformXmlParser): TransactionParser<*> {
         return object : UserXmlParser(parser) {
             @Throws(PlatformIOException::class, InvalidStructureException::class)
             override fun commit(parsed: User) {

--- a/commcare-core/src/main/java/org/commcare/xml/ActionParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/ActionParser.kt
@@ -7,7 +7,7 @@ import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
@@ -16,7 +16,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  *
  * @author ctsims
  */
-class ActionParser(parser: KXmlParser) : CommCareElementParser<Action>(parser) {
+class ActionParser(parser: PlatformXmlParser) : CommCareElementParser<Action>(parser) {
 
     companion object {
         const val NAME_ACTION: String = "action"

--- a/commcare-core/src/main/java/org/commcare/xml/AssertionSetParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/AssertionSetParser.kt
@@ -6,14 +6,14 @@ import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
  * @author ctsims
  */
-class AssertionSetParser(parser: KXmlParser) : ElementParser<AssertionSet>(parser) {
+class AssertionSetParser(parser: PlatformXmlParser) : ElementParser<AssertionSet>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): AssertionSet {

--- a/commcare-core/src/main/java/org/commcare/xml/BestEffortBlockParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/BestEffortBlockParser.kt
@@ -3,7 +3,7 @@ package org.commcare.xml
 import org.commcare.data.xml.TransactionParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
@@ -16,7 +16,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * @author ctsims
  */
 abstract class BestEffortBlockParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val elements: Array<String>
 ) : TransactionParser<HashMap<String, String>>(parser) {
 
@@ -28,15 +28,15 @@ abstract class BestEffortBlockParser(
         PlatformXmlParserException::class, UnfullfilledRequirementsException::class
     )
     override fun parse(): HashMap<String, String> {
-        val name = parser.name
+        val name = parser.name!!
         val ret = HashMap<String, String>()
 
         var expecting = false
         var expected: String? = null
         while (this.nextTagInBlock(name)) {
             if (expecting) {
-                if (parser.eventType == KXmlParser.TEXT) {
-                    ret[expected!!] = parser.text
+                if (parser.eventType == PlatformXmlParser.TEXT) {
+                    ret[expected!!] = parser.text!!
                 }
                 expecting = false
             }

--- a/commcare-core/src/main/java/org/commcare/xml/CalloutParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/CalloutParser.kt
@@ -4,7 +4,7 @@ import org.commcare.suite.model.Callout
 import org.commcare.suite.model.DetailField
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
@@ -14,7 +14,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  *
  * @author wspride
  */
-class CalloutParser(parser: KXmlParser) : ElementParser<Callout>(parser) {
+class CalloutParser(parser: PlatformXmlParser) : ElementParser<Callout>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Callout {
@@ -29,11 +29,11 @@ class CalloutParser(parser: KXmlParser) : ElementParser<Callout>(parser) {
         var responseDetailField: DetailField? = null
 
         while (nextTagInBlock("lookup")) {
-            val tagName = parser.name
+            val tagName = parser.name!!
             if ("extra" == tagName) {
-                extras[parser.getAttributeValue(null, "key")] = parser.getAttributeValue(null, "value")
+                extras[parser.getAttributeValue(null, "key")!!] = parser.getAttributeValue(null, "value")!!
             } else if ("response" == tagName) {
-                responses.add(parser.getAttributeValue(null, "key"))
+                responses.add(parser.getAttributeValue(null, "key")!!)
             } else if ("field" == tagName) {
                 responseDetailField = DetailFieldParser(parser, null, "'lookup callout detail field'").parse()
             }

--- a/commcare-core/src/main/java/org/commcare/xml/CaseXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/CaseXmlParser.kt
@@ -31,7 +31,7 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.core.util.externalizable.SerializationLimitationException
 import org.javarosa.xml.util.ActionableInvalidStructureException
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.NoSuchElementException
@@ -54,7 +54,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
     private val storage: IStorageUtilityIndexed<*>
     private val acceptCreateOverwrites: Boolean
 
-    constructor(parser: KXmlParser, storage: IStorageUtilityIndexed<*>) : this(parser, true, storage)
+    constructor(parser: PlatformXmlParser, storage: IStorageUtilityIndexed<*>) : this(parser, true, storage)
 
     /**
      * Creates a Parser for case blocks in the XML stream provided.
@@ -64,7 +64,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
      *                               contains create actions for cases which already exist.
      */
     constructor(
-        parser: KXmlParser, acceptCreateOverwrites: Boolean,
+        parser: PlatformXmlParser, acceptCreateOverwrites: Boolean,
         storage: IStorageUtilityIndexed<*>
     ) : super(parser) {
         this.acceptCreateOverwrites = acceptCreateOverwrites
@@ -75,10 +75,10 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
     override fun parse(): Case? {
         checkNode(CASE_NODE)
 
-        val caseId = parser.getAttributeValue(null, CASE_PROPERTY_CASE_ID)
+        val caseId = parser.getAttributeValue(null, CASE_PROPERTY_CASE_ID)!!
         validateMandatoryProperty(CASE_PROPERTY_CASE_ID, caseId, "", parser)
 
-        val dateModified = parser.getAttributeValue(null, CASE_PROPERTY_DATE_MODIFIED)
+        val dateModified = parser.getAttributeValue(null, CASE_PROPERTY_DATE_MODIFIED)!!
         validateMandatoryProperty(CASE_PROPERTY_DATE_MODIFIED, dateModified, caseId, parser)
 
         val modified = DateUtils.parseDateTime(dateModified)
@@ -89,7 +89,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
         var isCreateOrUpdate = false
 
         while (nextTagInBlock(CASE_NODE)) {
-            val action = parser.name.lowercase()
+            val action = parser.name!!.lowercase()
             when (action) {
                 CASE_CREATE_NODE -> {
                     caseForBlock = createCase(caseId, modified!!, userId)
@@ -142,13 +142,13 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
         var caseForBlock: Case? = null
 
         while (nextTagInBlock(CASE_CREATE_NODE)) {
-            val tag = parser.name
+            val tag = parser.name!!
             when (tag) {
-                CASE_PROPERTY_CASE_TYPE -> data[0] = parser.nextText().trim()
-                CASE_PROPERTY_OWNER_ID -> data[1] = parser.nextText().trim()
-                CASE_PROPERTY_CASE_NAME -> data[2] = parser.nextText().trim()
+                CASE_PROPERTY_CASE_TYPE -> data[0] = parser.nextText()!!.trim()
+                CASE_PROPERTY_OWNER_ID -> data[1] = parser.nextText()!!.trim()
+                CASE_PROPERTY_CASE_NAME -> data[2] = parser.nextText()!!.trim()
                 else -> throw InvalidStructureException(
-                    "Expected one of [case_type, owner_id, case_name], found ${parser.name}", parser
+                    "Expected one of [case_type, owner_id, case_name], found ${parser.name!!}", parser
                 )
             }
         }
@@ -195,8 +195,8 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun updateCase(caseForBlock: Case, caseId: String) {
         while (nextTagInBlock(CASE_UPDATE_NODE)) {
-            val key = parser.name
-            val value = parser.nextText().trim()
+            val key = parser.name!!
+            val value = parser.nextText()!!.trim()
 
             when (key) {
                 CASE_PROPERTY_CASE_TYPE -> caseForBlock.setTypeId(value)
@@ -242,7 +242,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun indexCase(caseForBlock: Case, caseId: String) {
         while (nextTagInBlock(CASE_INDEX_NODE)) {
-            val indexName = parser.name
+            val indexName = parser.name!!
             val caseType = parser.getAttributeValue(null, CASE_PROPERTY_INDEX_CASE_TYPE)
 
             var relationship = parser.getAttributeValue(null, CASE_PROPERTY_INDEX_RELATIONSHIP)
@@ -254,7 +254,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
                 )
             }
 
-            var value: String? = parser.nextText().trim()
+            var value: String? = parser.nextText()!!.trim()
 
             if (value == caseId) {
                 throw ActionableInvalidStructureException(
@@ -282,7 +282,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun processCaseAttachment(caseForBlock: Case) {
         while (nextTagInBlock(CASE_ATTACHMENT_NODE)) {
-            val attachmentName = parser.name
+            val attachmentName = parser.name!!
             val src = parser.getAttributeValue(null, CASE_PROPERTY_ATTACHMENT_SRC)
             val from = parser.getAttributeValue(null, CASE_PROPERTY_ATTACHMENT_FROM)
             val fileName = parser.getAttributeValue(null, CASE_PROPERTY_ATTACHMENT_NAME)
@@ -304,7 +304,7 @@ open class CaseXmlParser : TransactionParser<Case>, CaseIndexChangeListener {
     protected open fun removeAttachment(caseForBlock: Case, attachmentName: String) {
     }
 
-    protected open fun processAttachment(src: String?, from: String?, name: String?, parser: KXmlParser): String? {
+    protected open fun processAttachment(src: String?, from: String?, name: String?, parser: PlatformXmlParser): String? {
         return null
     }
 

--- a/commcare-core/src/main/java/org/commcare/xml/CaseXmlParserUtil.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/CaseXmlParserUtil.kt
@@ -6,7 +6,7 @@ import org.javarosa.core.model.instance.TreeElement
 import org.javarosa.xml.util.ActionableInvalidStructureException
 import org.javarosa.xml.util.InvalidCasePropertyLengthException
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 
 class CaseXmlParserUtil {
     companion object {
@@ -40,7 +40,7 @@ class CaseXmlParserUtil {
 
         @JvmStatic
         @Throws(InvalidStructureException::class)
-        fun validateMandatoryProperty(key: String, value: Any?, caseId: String, parser: KXmlParser) {
+        fun validateMandatoryProperty(key: String, value: Any?, caseId: String, parser: PlatformXmlParser) {
             if (value == null || value == "") {
                 val error = String.format("The %s attribute of a <case> %s wasn't set", key, caseId)
                 throw InvalidStructureException.readableInvalidStructureException(error, parser)

--- a/commcare-core/src/main/java/org/commcare/xml/CommCareElementParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/CommCareElementParser.kt
@@ -4,7 +4,7 @@ import org.commcare.suite.model.DisplayUnit
 import org.commcare.suite.model.Text
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
@@ -14,7 +14,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  *
  * @author Phillip Mates
  */
-abstract class CommCareElementParser<T>(parser: KXmlParser) : ElementParser<T>(parser) {
+abstract class CommCareElementParser<T>(parser: PlatformXmlParser) : ElementParser<T>(parser) {
 
     /**
      * Build a DisplayUnit object by parsing the contents of a display tag.

--- a/commcare-core/src/main/java/org/commcare/xml/DetailFieldParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/DetailFieldParser.kt
@@ -8,7 +8,7 @@ import org.javarosa.core.model.Constants
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
@@ -17,7 +17,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * Contains text templates, as well as layout and sorting options
  */
 class DetailFieldParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val graphParser: GraphParser?,
     private val id: String?
 ) : CommCareElementParser<DetailField>(parser) {
@@ -75,7 +75,7 @@ class DetailFieldParser(
             //sort details
             checkNode(arrayOf("sort", "background", "endpoint_action", "alt_text"))
 
-            val name = parser.name.lowercase()
+            val name = parser.name!!.lowercase()
 
             if (name == "sort") {
                 parseSort(builder)
@@ -109,7 +109,7 @@ class DetailFieldParser(
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     private fun parseStyle(builder: DetailField.Builder) {
         //style
-        if (parser.name.lowercase() == "style") {
+        if (parser.name!!.lowercase() == "style") {
             val styleParser = StyleParser(builder, parser)
             styleParser.parse()
             //Header

--- a/commcare-core/src/main/java/org/commcare/xml/DetailGroupParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/DetailGroupParser.kt
@@ -5,11 +5,11 @@ import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
-class DetailGroupParser(parser: KXmlParser) : CommCareElementParser<DetailGroup>(parser) {
+class DetailGroupParser(parser: PlatformXmlParser) : CommCareElementParser<DetailGroup>(parser) {
 
     companion object {
         const val NAME_GROUP: String = "group"

--- a/commcare-core/src/main/java/org/commcare/xml/DetailParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/DetailParser.kt
@@ -12,14 +12,14 @@ import org.javarosa.core.util.OrderedHashtable
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
  * @author ctsims
  */
-open class DetailParser(parser: KXmlParser) : CommCareElementParser<Detail>(parser) {
+open class DetailParser(parser: PlatformXmlParser) : CommCareElementParser<Detail>(parser) {
 
     companion object {
         private const val NAME_NO_ITEMS_TEXT = "no_items_text"
@@ -46,7 +46,7 @@ open class DetailParser(parser: KXmlParser) : CommCareElementParser<Detail>(pars
         getNextTagInBlock("title")
         val title: DisplayUnit
 
-        if ("text" == parser.name.lowercase()) {
+        if ("text" == parser.name!!.lowercase()) {
             title = DisplayUnit(TextParser(parser).parse())
         } else {
             title = parseDisplayBlock()
@@ -66,37 +66,37 @@ open class DetailParser(parser: KXmlParser) : CommCareElementParser<Detail>(pars
         var detailGroup: DetailGroup? = null
 
         while (nextTagInBlock("detail")) {
-            if (GlobalParser.NAME_GLOBAL == parser.name.lowercase()) {
+            if (GlobalParser.NAME_GLOBAL == parser.name!!.lowercase()) {
                 checkNode(GlobalParser.NAME_GLOBAL)
                 global = GlobalParser(parser).parse()
                 parser.nextTag()
             }
-            if ("lookup" == parser.name.lowercase()) {
+            if ("lookup" == parser.name!!.lowercase()) {
                 checkNode("lookup")
                 callout = CalloutParser(parser).parse()
                 parser.nextTag()
             }
-            if (NAME_NO_ITEMS_TEXT == parser.name.lowercase()) {
+            if (NAME_NO_ITEMS_TEXT == parser.name!!.lowercase()) {
                 checkNode("no_items_text")
                 getNextTagInBlock("no_items_text")
-                if ("text" == parser.name.lowercase()) {
+                if ("text" == parser.name!!.lowercase()) {
                     noItemsText = TextParser(parser).parse()
                 }
                 continue
             }
-            if ("select_text" == parser.name.lowercase()) {
+            if ("select_text" == parser.name!!.lowercase()) {
                 checkNode("select_text")
                 getNextTagInBlock("select_text")
-                if ("text" == parser.name.lowercase()) {
+                if ("text" == parser.name!!.lowercase()) {
                     selectText = TextParser(parser).parse()
                 }
                 continue
             }
-            if ("variables" == parser.name.lowercase()) {
+            if ("variables" == parser.name!!.lowercase()) {
                 while (nextTagInBlock("variables")) {
                     val function = parser.getAttributeValue(null, "function")
                         ?: throw InvalidStructureException(
-                            "No function in variable declaration for variable ${parser.name}", parser
+                            "No function in variable declaration for variable ${parser.name!!}", parser
                         )
                     try {
                         XPathParseTool.parseXPath(function)
@@ -106,15 +106,15 @@ open class DetailParser(parser: KXmlParser) : CommCareElementParser<Detail>(pars
                             "Invalid XPath function $function. ${e.message}", parser
                         )
                     }
-                    variables[parser.name] = function
+                    variables[parser.name!!] = function
                 }
                 continue
             }
-            if ("focus" == parser.name.lowercase()) {
+            if ("focus" == parser.name!!.lowercase()) {
                 focusFunction = parser.getAttributeValue(null, "function")
                 if (focusFunction == null) {
                     throw InvalidStructureException(
-                        "No function in focus declaration ${parser.name}", parser
+                        "No function in focus declaration ${parser.name!!}", parser
                     )
                 }
                 try {
@@ -127,15 +127,15 @@ open class DetailParser(parser: KXmlParser) : CommCareElementParser<Detail>(pars
                 }
                 continue
             }
-            if (ActionParser.NAME_ACTION.equals(parser.name, ignoreCase = true)) {
+            if (ActionParser.NAME_ACTION.equals(parser.name!!, ignoreCase = true)) {
                 actions.add(ActionParser(parser).parse())
                 continue
             }
-            if (DetailGroupParser.NAME_GROUP.equals(parser.name, ignoreCase = true)) {
+            if (DetailGroupParser.NAME_GROUP.equals(parser.name!!, ignoreCase = true)) {
                 detailGroup = DetailGroupParser(parser).parse()
                 continue
             }
-            if (parser.name == "detail") {
+            if (parser.name!! == "detail") {
                 subdetails.add(getDetailParser().parse())
             } else {
                 val detailField = DetailFieldParser(parser, getGraphParser(), id).parse()

--- a/commcare-core/src/main/java/org/commcare/xml/EndpointParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/EndpointParser.kt
@@ -7,11 +7,11 @@ import org.javarosa.core.model.instance.ExternalDataInstance.Companion.JR_SELECT
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
-class EndpointParser(parser: KXmlParser) : ElementParser<Endpoint>(parser) {
+class EndpointParser(parser: PlatformXmlParser) : ElementParser<Endpoint>(parser) {
 
     companion object {
         @JvmField
@@ -42,7 +42,7 @@ class EndpointParser(parser: KXmlParser) : ElementParser<Endpoint>(parser) {
         val arguments = ArrayList<EndpointArgument>()
 
         while (nextTagInBlock(NAME_ENDPOINT)) {
-            val tagName = parser.name.lowercase()
+            val tagName = parser.name!!.lowercase()
             if (tagName.contentEquals(NAME_ARGUMENT)) {
                 val argumentID = parser.getAttributeValue(null, ATTR_ARGUMENT_ID)
                 if (argumentID == null || argumentID.isEmpty()) {

--- a/commcare-core/src/main/java/org/commcare/xml/EntryParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/EntryParser.kt
@@ -18,7 +18,7 @@ import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.net.MalformedURLException
@@ -28,7 +28,7 @@ import java.net.URL
  * @author ctsims
  */
 class EntryParser private constructor(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val parserBlockTag: String
 ) : CommCareElementParser<Entry>(parser) {
 
@@ -38,17 +38,17 @@ class EntryParser private constructor(
         const val REMOTE_REQUEST_TAG: String = "remote-request"
 
         @JvmStatic
-        fun buildViewParser(parser: KXmlParser): EntryParser {
+        fun buildViewParser(parser: PlatformXmlParser): EntryParser {
             return EntryParser(parser, VIEW_ENTRY_TAG)
         }
 
         @JvmStatic
-        fun buildEntryParser(parser: KXmlParser): EntryParser {
+        fun buildEntryParser(parser: PlatformXmlParser): EntryParser {
             return EntryParser(parser, FORM_ENTRY_TAG)
         }
 
         @JvmStatic
-        fun buildRemoteSyncParser(parser: KXmlParser): EntryParser {
+        fun buildRemoteSyncParser(parser: PlatformXmlParser): EntryParser {
             return EntryParser(parser, REMOTE_REQUEST_TAG)
         }
     }
@@ -71,14 +71,14 @@ class EntryParser private constructor(
         var post: PostRequest? = null
 
         while (nextTagInBlock(parserBlockTag)) {
-            val tagName = parser.name
+            val tagName = parser.name!!
             if ("form" == tagName) {
                 if (parserBlockTag == VIEW_ENTRY_TAG) {
                     throw InvalidStructureException("<$parserBlockTag>'s cannot specify XForms!!", parser)
                 }
                 xFormNamespace = parser.nextText()
             } else if ("command" == tagName) {
-                commandId = parser.getAttributeValue(null, "id")
+                commandId = parser.getAttributeValue(null, "id")!!
                 display = parseCommandDisplay()
             } else if ("instance" == tagName.lowercase()) {
                 ParseInstance.parseInstance(instances, parser)
@@ -128,7 +128,7 @@ class EntryParser private constructor(
     private fun parseCommandDisplay(): DisplayUnit? {
         parser.nextTag()
         var display: DisplayUnit? = null
-        val tagName = parser.name
+        val tagName = parser.name!!
         if ("text" == tagName) {
             display = DisplayUnit(TextParser(parser).parse())
         } else if ("display" == tagName) {

--- a/commcare-core/src/main/java/org/commcare/xml/FixtureIndexSchemaParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/FixtureIndexSchemaParser.kt
@@ -5,7 +5,7 @@ import org.commcare.data.xml.TransactionParser
 import org.javarosa.xml.TreeElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
@@ -22,7 +22,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * @author Phillip Mates (pmates@dimagi.com)
  */
 class FixtureIndexSchemaParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val fixtureSchemas: MutableMap<String, FixtureIndexSchema>,
     private val processedFixtures: Set<String>
 ) : TransactionParser<FixtureIndexSchema>(parser) {

--- a/commcare-core/src/main/java/org/commcare/xml/FixtureXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/FixtureXmlParser.kt
@@ -9,7 +9,7 @@ import org.javarosa.core.util.externalizable.ExtUtil
 import org.javarosa.xml.TreeElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
@@ -20,7 +20,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * @author ctsims
  */
 open class FixtureXmlParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val overwrite: Boolean,
     @JvmField var storage: IStorageUtilityIndexed<FormInstance>
 ) : TransactionParser<FormInstance>(parser) {

--- a/commcare-core/src/main/java/org/commcare/xml/GeoOverlayParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/GeoOverlayParser.kt
@@ -4,14 +4,14 @@ import org.commcare.suite.model.DisplayUnit
 import org.commcare.suite.model.GeoOverlay
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
  * Parses the defintion for a [GeoOverlay] element
  */
-internal class GeoOverlayParser(parser: KXmlParser) : ElementParser<GeoOverlay>(parser) {
+internal class GeoOverlayParser(parser: PlatformXmlParser) : ElementParser<GeoOverlay>(parser) {
 
     companion object {
         @JvmField
@@ -25,7 +25,7 @@ internal class GeoOverlayParser(parser: KXmlParser) : ElementParser<GeoOverlay>(
         var title: DisplayUnit? = null
         var coordinates: DisplayUnit? = null
         while (nextTagInBlock(NAME_GEO_OVERLAY)) {
-            val tagName = parser.name.lowercase()
+            val tagName = parser.name!!.lowercase()
             if (NAME_COORDINATES.contentEquals(tagName)) {
                 nextTagInBlock(NAME_COORDINATES)
                 coordinates = DisplayUnit(TextParser(parser).parse())

--- a/commcare-core/src/main/java/org/commcare/xml/GlobalParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/GlobalParser.kt
@@ -4,14 +4,14 @@ import org.commcare.suite.model.GeoOverlay
 import org.commcare.suite.model.Global
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
  * Parser used in DetailParser to parse the defintion of Global element used in case-select and case-detail views
  */
-internal class GlobalParser(parser: KXmlParser) : ElementParser<Global>(parser) {
+internal class GlobalParser(parser: PlatformXmlParser) : ElementParser<Global>(parser) {
 
     companion object {
         @JvmField
@@ -22,7 +22,7 @@ internal class GlobalParser(parser: KXmlParser) : ElementParser<Global>(parser) 
     override fun parse(): Global {
         val geoOverlays = ArrayList<GeoOverlay>()
         while (nextTagInBlock(NAME_GLOBAL)) {
-            if (GeoOverlayParser.NAME_GEO_OVERLAY == parser.name.lowercase()) {
+            if (GeoOverlayParser.NAME_GEO_OVERLAY == parser.name!!.lowercase()) {
                 val geoOverlay = GeoOverlayParser(parser).parse()
                 geoOverlays.add(geoOverlay)
             }

--- a/commcare-core/src/main/java/org/commcare/xml/GraphParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/GraphParser.kt
@@ -12,14 +12,14 @@ import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
  * Created by jschweers on 1/28/2016.
  */
-open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parser) {
+open class GraphParser(parser: PlatformXmlParser) : ElementParser<DetailTemplate>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Graph {
@@ -91,9 +91,9 @@ open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parse
             if (parser.name == "text") {
                 val id = parser.getAttributeValue(null, "id")
                 val t = textParser.parse()
-                data.setConfiguration(id, t)
+                data.setConfiguration(id!!, t)
             }
-        } while (parser.eventType != KXmlParser.END_TAG || parser.name != "configuration")
+        } while (parser.eventType != PlatformXmlParser.END_TAG || parser.name != "configuration")
     }
 
     /*
@@ -124,7 +124,7 @@ open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parse
             (series as BubbleSeries).setRadius(parseFunction("radius"))
         }
 
-        while (parser.eventType != KXmlParser.END_TAG || parser.name != "series") {
+        while (parser.eventType != PlatformXmlParser.END_TAG || parser.name != "series") {
             parser.nextTag()
         }
 
@@ -141,7 +141,7 @@ open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parse
     @Throws(InvalidStructureException::class)
     private fun parseFunction(name: String): String {
         checkNode(name)
-        val function = parser.getAttributeValue(null, "function")
+        val function = parser.getAttributeValue(null, "function")!!
         try {
             XPathParseTool.parseXPath(function)
         } catch (e: XPathSyntaxException) {
@@ -159,6 +159,6 @@ open class GraphParser(parser: KXmlParser) : ElementParser<DetailTemplate>(parse
     private fun nextStartTag() {
         do {
             parser.nextTag()
-        } while (parser.eventType != KXmlParser.START_TAG)
+        } while (parser.eventType != PlatformXmlParser.START_TAG)
     }
 }

--- a/commcare-core/src/main/java/org/commcare/xml/GridParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/GridParser.kt
@@ -3,7 +3,7 @@ package org.commcare.xml
 import org.commcare.suite.model.DetailField.Builder
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
@@ -14,7 +14,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  */
 class GridParser(
     val builder: Builder,
-    parser: KXmlParser
+    parser: PlatformXmlParser
 ) : ElementParser<Int>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)

--- a/commcare-core/src/main/java/org/commcare/xml/IndexedFixtureXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/IndexedFixtureXmlParser.kt
@@ -11,7 +11,7 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.xml.TreeElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
@@ -28,7 +28,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * @author Phillip Mates (pmates@dimagi.com)
  */
 class IndexedFixtureXmlParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val fixtureName: String?,
     schema: FixtureIndexSchema?,
     private val sandbox: UserSandbox

--- a/commcare-core/src/main/java/org/commcare/xml/LedgerXmlParsers.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/LedgerXmlParsers.kt
@@ -6,7 +6,7 @@ import org.javarosa.core.model.utils.DateUtils
 import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.NoSuchElementException
@@ -18,7 +18,7 @@ import java.util.NoSuchElementException
  * @author ctsims
  */
 class LedgerXmlParsers(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     val storage: IStorageUtilityIndexed<Ledger>
 ) : TransactionParser<Array<Ledger>>(parser) {
 
@@ -40,7 +40,7 @@ class LedgerXmlParsers(
     override fun parse(): Array<Ledger> {
         this.checkNode(arrayOf(TAG_BALANCE, TRANSFER))
 
-        val name = parser.name.lowercase()
+        val name = parser.name!!.lowercase()
 
         val toWrite = ArrayList<Ledger>()
 
@@ -84,7 +84,7 @@ class LedgerXmlParsers(
                                 }
                                 val quantity = this.parseInt(quantityString)
 
-                                ledger.setEntry(sectionId, productId, quantity)
+                                ledger.setEntry(sectionId, productId!!, quantity)
                             }
                             return null
                         }
@@ -146,11 +146,11 @@ class LedgerXmlParsers(
                                 val quantity = this.parseInt(quantityString)
 
                                 sourceLeger?.setEntry(
-                                    sectionId, productId,
+                                    sectionId, productId!!,
                                     sourceLeger.getEntry(sectionId, productId) - quantity
                                 )
                                 destinationLedger?.setEntry(
-                                    sectionId, productId,
+                                    sectionId, productId!!,
                                     destinationLedger.getEntry(sectionId, productId) + quantity
                                 )
                             }

--- a/commcare-core/src/main/java/org/commcare/xml/MarkupParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/MarkupParser.kt
@@ -3,13 +3,13 @@ package org.commcare.xml
 import org.commcare.suite.model.DetailField.Builder
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 class MarkupParser(
     val builder: Builder,
-    parser: KXmlParser
+    parser: PlatformXmlParser
 ) : ElementParser<Int>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)

--- a/commcare-core/src/main/java/org/commcare/xml/MenuParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/MenuParser.kt
@@ -8,14 +8,14 @@ import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
  * @author ctsims
  */
-class MenuParser(parser: KXmlParser) : CommCareElementParser<Menu>(parser) {
+class MenuParser(parser: PlatformXmlParser) : CommCareElementParser<Menu>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Menu {
@@ -58,9 +58,9 @@ class MenuParser(parser: KXmlParser) : CommCareElementParser<Menu>(parser) {
         val commandIds = ArrayList<String>()
         val relevantExprs = ArrayList<String?>()
         while (nextTagInBlock("menu")) {
-            val tagName = parser.name
+            val tagName = parser.name!!
             if (tagName == "command") {
-                commandIds.add(parser.getAttributeValue(null, "id"))
+                commandIds.add(parser.getAttributeValue(null, "id")!!)
                 val relevantExpr = parser.getAttributeValue(null, "relevant")
                 if (relevantExpr == null) {
                     relevantExprs.add(null)

--- a/commcare-core/src/main/java/org/commcare/xml/ParseInstance.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/ParseInstance.kt
@@ -2,14 +2,14 @@ package org.commcare.xml
 
 import org.javarosa.core.model.instance.DataInstance
 import org.javarosa.core.model.instance.ExternalDataInstance
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 
 class ParseInstance {
     companion object {
         @JvmStatic
-        fun parseInstance(instances: HashMap<String, DataInstance<*>>, parser: KXmlParser) {
-            val instanceId = parser.getAttributeValue(null, "id")
-            val location = parser.getAttributeValue(null, "src")
+        fun parseInstance(instances: HashMap<String, DataInstance<*>>, parser: PlatformXmlParser) {
+            val instanceId = parser.getAttributeValue(null, "id")!!
+            val location = parser.getAttributeValue(null, "src")!!
             instances[instanceId] = ExternalDataInstance(location, instanceId)
         }
     }

--- a/commcare-core/src/main/java/org/commcare/xml/ProfileParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/ProfileParser.kt
@@ -12,7 +12,7 @@ import org.javarosa.core.util.PropertyUtils
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
@@ -54,8 +54,8 @@ class ProfileParser(
             var eventType: Int
             eventType = parser.eventType
             do {
-                if (eventType == KXmlParser.START_TAG) {
-                    when (parser.name.lowercase()) {
+                if (eventType == PlatformXmlParser.START_TAG) {
+                    when (parser.name!!.lowercase()) {
                         "property" -> parseProperty(profile)
                         "root" -> {
                             val root = RootParser(this.parser).parse()
@@ -68,7 +68,7 @@ class ProfileParser(
                     }
                 }
                 eventType = parser.next()
-            } while (eventType != KXmlParser.END_DOCUMENT)
+            } while (eventType != PlatformXmlParser.END_DOCUMENT)
 
             return profile
         } catch (e: PlatformXmlParserException) {
@@ -168,8 +168,8 @@ class ProfileParser(
     }
 
     private fun parseProperty(profile: Profile) {
-        val key = parser.getAttributeValue(null, "key")
-        val value = parser.getAttributeValue(null, "value")
+        val key = parser.getAttributeValue(null, "key")!!
+        val value = parser.getAttributeValue(null, "value")!!
         val force = parser.getAttributeValue(null, "force")
         addPropertySetter(profile, key, value, force)
     }
@@ -197,7 +197,7 @@ class ProfileParser(
     @Throws(PlatformXmlParserException::class, PlatformIOException::class, InvalidStructureException::class)
     private fun parseFeatures(profile: Profile) {
         while (nextTagInBlock("features")) {
-            val tag = parser.name.lowercase()
+            val tag = parser.name!!.lowercase()
             val active = parser.getAttributeValue(null, "active")
             var isActive = false
             if (active != null && active.lowercase() == "true") {
@@ -214,10 +214,10 @@ class ProfileParser(
                 //nothing (yet)
             } else if (tag == "users") {
                 while (nextTagInBlock("users")) {
-                    if (parser.name.lowercase() == "registration") {
-                        profile.addPropertySetter("user_reg_namespace", parser.nextText(), true)
-                    } else if (parser.name.lowercase() == "logo") {
-                        val logo = parser.nextText()
+                    if (parser.name!!.lowercase() == "registration") {
+                        profile.addPropertySetter("user_reg_namespace", parser.nextText()!!, true)
+                    } else if (parser.name!!.lowercase() == "logo") {
+                        val logo = parser.nextText()!!
                         profile.addPropertySetter("cc_login_image", logo, true)
                     } else {
                         throw InvalidStructureException(
@@ -241,7 +241,7 @@ class ProfileParser(
     private fun parseCredentials(): ArrayList<Credential> {
         val appCredentials = ArrayList<Credential>()
         while (nextTagInBlock(NAME_CREDENTIALS)) {
-            val tag = parser.name.lowercase()
+            val tag = parser.name!!.lowercase()
             if (tag == NAME_CREDENTIAL) {
                 val level = parser.getAttributeValue(null, ATTR_CREDENTIAL_LEVEL)
                 val type = parser.getAttributeValue(null, ATTR_CREDENTIAL_TYPE)
@@ -261,7 +261,7 @@ class ProfileParser(
     private fun parseDependencies(): ArrayList<AndroidPackageDependency> {
         val appDependencies = ArrayList<AndroidPackageDependency>()
         while (nextTagInBlock(NAME_DEPENDENCIES)) {
-            val tag = parser.name.lowercase()
+            val tag = parser.name!!.lowercase()
             if (tag == NAME_ANDROID_PACKAGE) {
                 val appId = parser.getAttributeValue(null, ATTR_ID)
                     ?: throw InvalidStructureException("No id defined for app dependency")

--- a/commcare-core/src/main/java/org/commcare/xml/QueryDataParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/QueryDataParser.kt
@@ -8,14 +8,14 @@ import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
  * Parser for parsing `<data>` elements
  */
-class QueryDataParser(parser: KXmlParser) : CommCareElementParser<QueryData>(parser) {
+class QueryDataParser(parser: PlatformXmlParser) : CommCareElementParser<QueryData>(parser) {
 
     companion object {
         @JvmStatic

--- a/commcare-core/src/main/java/org/commcare/xml/QueryGroupParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/QueryGroupParser.kt
@@ -4,11 +4,11 @@ import org.commcare.suite.model.DisplayUnit
 import org.commcare.suite.model.QueryGroup
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
-class QueryGroupParser(parser: KXmlParser) : CommCareElementParser<QueryGroup>(parser) {
+class QueryGroupParser(parser: PlatformXmlParser) : CommCareElementParser<QueryGroup>(parser) {
 
     companion object {
         const val NAME_GROUP: String = "group"

--- a/commcare-core/src/main/java/org/commcare/xml/QueryPromptParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/QueryPromptParser.kt
@@ -12,11 +12,11 @@ import org.javarosa.xml.util.UnfullfilledRequirementsException
 import org.javarosa.xpath.XPathParseTool
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
-class QueryPromptParser(parser: KXmlParser) : CommCareElementParser<QueryPrompt>(parser) {
+class QueryPromptParser(parser: PlatformXmlParser) : CommCareElementParser<QueryPrompt>(parser) {
 
     companion object {
         private const val NAME_PROMPT = "prompt"

--- a/commcare-core/src/main/java/org/commcare/xml/ResourceParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/ResourceParser.kt
@@ -5,12 +5,12 @@ import org.commcare.resources.model.Resource.Companion.LAZY_VAL_FALSE
 import org.commcare.resources.model.ResourceLocation
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 class ResourceParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     val maximumAuthority: Int
 ) : ElementParser<Resource>(parser) {
 
@@ -18,7 +18,7 @@ class ResourceParser(
     override fun parse(): Resource {
         checkNode("resource")
 
-        val id = parser.getAttributeValue(null, "id")
+        val id = parser.getAttributeValue(null, "id")!!
         val version = parseInt(parser.getAttributeValue(null, "version"))
 
         val descriptor = parser.getAttributeValue(null, "descriptor")
@@ -28,8 +28,8 @@ class ResourceParser(
 
         while (nextTagInBlock("resource")) {
             //New Location
-            val sAuthority = parser.getAttributeValue(null, "authority")
-            val location = parser.nextText()
+            val sAuthority = parser.getAttributeValue(null, "authority")!!
+            val location = parser.nextText()!!
             var authority = Resource.RESOURCE_AUTHORITY_REMOTE
             if (sAuthority.lowercase() == "local") {
                 authority = Resource.RESOURCE_AUTHORITY_LOCAL

--- a/commcare-core/src/main/java/org/commcare/xml/RootParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/RootParser.kt
@@ -3,14 +3,14 @@ package org.commcare.xml
 import org.javarosa.core.reference.RootTranslator
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
  * @author ctsims
  */
-class RootParser(parser: KXmlParser) : ElementParser<RootTranslator>(parser) {
+class RootParser(parser: PlatformXmlParser) : ElementParser<RootTranslator>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): RootTranslator {
@@ -22,7 +22,7 @@ class RootParser(parser: KXmlParser) : ElementParser<RootTranslator>(parser) {
         //Get the child or error out if none exists
         getNextTagInBlock("root")
 
-        val referenceType = parser.name.lowercase()
+        val referenceType = parser.name!!.lowercase()
         val path = parser.getAttributeValue(null, "path")
         return when (referenceType) {
             "filesystem" -> RootTranslator("jr://$id/", "jr://file$path")

--- a/commcare-core/src/main/java/org/commcare/xml/SessionDatumParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/SessionDatumParser.kt
@@ -14,7 +14,7 @@ import org.commcare.suite.model.Text
 import org.javarosa.core.util.OrderedHashtable
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.net.MalformedURLException
@@ -23,7 +23,7 @@ import java.net.URL
 /**
  * @author ctsims
  */
-class SessionDatumParser(parser: KXmlParser) : CommCareElementParser<SessionDatum>(parser) {
+class SessionDatumParser(parser: PlatformXmlParser) : CommCareElementParser<SessionDatum>(parser) {
 
     companion object {
         const val DEFAULT_MAX_SELECT_VAL: Int = 100
@@ -98,7 +98,7 @@ class SessionDatumParser(parser: KXmlParser) : CommCareElementParser<SessionDatu
             }
         }
 
-        while (parser.next() == KXmlParser.TEXT) {
+        while (parser.next() == PlatformXmlParser.TEXT) {
             // consume text nodes
         }
 
@@ -142,7 +142,7 @@ class SessionDatumParser(parser: KXmlParser) : CommCareElementParser<SessionDatu
             if ("data" == tagName) {
                 hiddenQueryValues.add(QueryDataParser(parser).parse())
             } else if ("prompt" == tagName) {
-                val key = parser.getAttributeValue(null, "key")
+                val key = parser.getAttributeValue(null, "key")!!
                 userQueryPrompts[key] = QueryPromptParser(parser).parse()
             } else if ("title" == tagName) {
                 nextTagInBlock("title")

--- a/commcare-core/src/main/java/org/commcare/xml/StackFrameStepParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/StackFrameStepParser.kt
@@ -6,7 +6,7 @@ import org.commcare.suite.model.StackFrameStep
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.net.MalformedURLException
@@ -15,7 +15,7 @@ import java.net.URL
 /**
  * @author ctsims
  */
-internal class StackFrameStepParser(parser: KXmlParser) : ElementParser<StackFrameStep>(parser) {
+internal class StackFrameStepParser(parser: PlatformXmlParser) : ElementParser<StackFrameStep>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): StackFrameStep {

--- a/commcare-core/src/main/java/org/commcare/xml/StackOpParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/StackOpParser.kt
@@ -5,14 +5,14 @@ import org.commcare.suite.model.StackOperation
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
 /**
  * @author ctsims
  */
-class StackOpParser(parser: KXmlParser) : ElementParser<StackOperation>(parser) {
+class StackOpParser(parser: PlatformXmlParser) : ElementParser<StackOperation>(parser) {
 
     companion object {
         const val NAME_STACK: String = "stack"

--- a/commcare-core/src/main/java/org/commcare/xml/StyleParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/StyleParser.kt
@@ -3,7 +3,7 @@ package org.commcare.xml
 import org.commcare.suite.model.DetailField.Builder
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
@@ -15,7 +15,7 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  */
 class StyleParser(
     val builder: Builder,
-    parser: KXmlParser
+    parser: PlatformXmlParser
 ) : ElementParser<Int>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)

--- a/commcare-core/src/main/java/org/commcare/xml/SuiteParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/SuiteParser.kt
@@ -13,7 +13,7 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
@@ -94,8 +94,8 @@ open class SuiteParser : ElementParser<Suite> {
 
             var eventType = parser.eventType
             do {
-                if (eventType == KXmlParser.START_TAG) {
-                    val tagName = parser.name.lowercase()
+                if (eventType == PlatformXmlParser.START_TAG) {
+                    val tagName = parser.name!!.lowercase()
                     when (tagName) {
                         "entry" -> {
                             val entry = EntryParser.buildEntryParser(parser).parse()
@@ -110,7 +110,7 @@ open class SuiteParser : ElementParser<Suite> {
                             entries[remoteRequestEntry.commandId!!] = remoteRequestEntry
                         }
                         "locale" -> {
-                            val localeKey = parser.getAttributeValue(null, "language")
+                            val localeKey = parser.getAttributeValue(null, "language")!!
                             parser.nextTag()
                             val localeResource = ResourceParser(parser, maximumResourceAuthority).parse()
                             if (!skipResources) {
@@ -122,7 +122,7 @@ open class SuiteParser : ElementParser<Suite> {
                             }
                         }
                         "media" -> {
-                            val path = parser.getAttributeValue(null, "path")
+                            val path = parser.getAttributeValue(null, "path")!!
                             while (this.nextTagInBlock("media")) {
                                 val mediaResource = ResourceParser(parser, maximumResourceAuthority).parse()
                                 if (!skipResources) {
@@ -178,7 +178,7 @@ open class SuiteParser : ElementParser<Suite> {
                     }
                 }
                 eventType = parser.next()
-            } while (eventType != KXmlParser.END_DOCUMENT)
+            } while (eventType != PlatformXmlParser.END_DOCUMENT)
 
             return Suite(version, details, entries, menus, endpoints)
         } catch (e: PlatformXmlParserException) {

--- a/commcare-core/src/main/java/org/commcare/xml/TextParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/TextParser.kt
@@ -4,11 +4,11 @@ import org.commcare.suite.model.Text
 import org.javarosa.xml.ElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xpath.parser.XPathSyntaxException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 
-class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
+class TextParser(parser: PlatformXmlParser) : ElementParser<Text>(parser) {
 
     @Throws(InvalidStructureException::class, PlatformIOException::class, PlatformXmlParserException::class)
     override fun parse(): Text {
@@ -26,7 +26,7 @@ class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
             e.printStackTrace()
         }
 
-        while (parser.depth > entryLevel || parser.eventType == KXmlParser.TEXT) {
+        while (parser.depth > entryLevel || parser.eventType == PlatformXmlParser.TEXT) {
             val t = parseBody()
             if (t != null) {
                 texts.add(t)
@@ -47,7 +47,7 @@ class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
         var eventType = parser.eventType
         var text = ""
         do {
-            if (eventType == KXmlParser.START_TAG) {
+            if (eventType == PlatformXmlParser.START_TAG) {
                 //If we were parsing text, commit that up first.
                 if (text.trim() != "") {
                     val t = Text.PlainText(text)
@@ -56,21 +56,21 @@ class TextParser(parser: KXmlParser) : ElementParser<Text>(parser) {
                 }
 
                 //now parse out the next tag.
-                if (parser.name.lowercase() == "xpath") {
+                if (parser.name!!.lowercase() == "xpath") {
                     val xpathText = parseXPath()
                     texts.add(xpathText)
-                } else if (parser.name.lowercase() == "locale") {
+                } else if (parser.name!!.lowercase() == "locale") {
                     val localeText = parseLocale()
                     texts.add(localeText)
                 }
-            } else if (eventType == KXmlParser.TEXT) {
-                text += parser.text.trim()
+            } else if (eventType == PlatformXmlParser.TEXT) {
+                text += parser.text!!.trim()
             }
 
             //We shouldn't really ever get here as far as things are currently set up
             eventType = parser.next()
             //How do we get out of here? Depth?
-        } while (eventType != KXmlParser.END_TAG)
+        } while (eventType != PlatformXmlParser.END_TAG)
 
         if (text.trim() != "") {
             val t = Text.PlainText(text)

--- a/commcare-core/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/bulk/BulkCaseInstanceXmlParser.kt
@@ -23,7 +23,7 @@ import org.javarosa.core.model.utils.DateUtils
 import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.javarosa.core.util.externalizable.SerializationLimitationException
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.LinkedHashMap
@@ -34,7 +34,7 @@ import java.util.LinkedHashMap
  */
 // todo this and other case parsers duplicates a bunch of logic today that can be unified
 open class BulkCaseInstanceXmlParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val storage: IStorageUtilityIndexed<Case>,
     private val mCaseIndexTable: CaseIndexTable?
 ) : BulkElementParser<Case>(parser), CaseIndexChangeListener {

--- a/commcare-core/src/main/java/org/commcare/xml/bulk/BulkElementParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/bulk/BulkElementParser.kt
@@ -5,7 +5,7 @@ import org.javarosa.core.model.instance.TreeElement
 import org.javarosa.xml.TreeElementParser
 import org.javarosa.xml.util.InvalidStructureException
 import org.javarosa.xml.util.UnfullfilledRequirementsException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 
 import org.javarosa.core.util.externalizable.PlatformIOException
@@ -33,7 +33,7 @@ import java.util.LinkedHashMap
  *
  * Created by ctsims on 3/14/2017.
  */
-abstract class BulkElementParser<T>(parser: KXmlParser) : TransactionParser<TreeElement>(parser) {
+abstract class BulkElementParser<T>(parser: PlatformXmlParser) : TransactionParser<TreeElement>(parser) {
 
     @JvmField
     protected var bulkTrigger = 500

--- a/commcare-core/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/bulk/BulkProcessingCaseXmlParser.kt
@@ -28,7 +28,7 @@ import org.javarosa.core.model.instance.TreeElement
 import org.javarosa.core.model.utils.DateUtils
 import org.javarosa.core.util.externalizable.SerializationLimitationException
 import org.javarosa.xml.util.InvalidStructureException
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 
 import java.util.Date
 import java.util.LinkedHashMap
@@ -43,7 +43,7 @@ import java.util.LinkedHashMap
  *
  * Created by ctsims on 3/14/2017.
  */
-abstract class BulkProcessingCaseXmlParser(parser: KXmlParser) :
+abstract class BulkProcessingCaseXmlParser(parser: PlatformXmlParser) :
     BulkElementParser<Case>(parser), CaseIndexChangeListener {
 
     override fun requestModelReadsForElement(

--- a/commcare-core/src/main/java/org/commcare/xml/bulk/LinearBulkProcessingCaseXmlParser.kt
+++ b/commcare-core/src/main/java/org/commcare/xml/bulk/LinearBulkProcessingCaseXmlParser.kt
@@ -2,7 +2,7 @@ package org.commcare.xml.bulk
 
 import org.commcare.cases.model.Case
 import org.javarosa.core.services.storage.IStorageUtilityIndexed
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.util.LinkedHashMap
@@ -19,7 +19,7 @@ import java.util.LinkedHashMap
  * Created by ctsims on 3/14/2017.
  */
 open class LinearBulkProcessingCaseXmlParser(
-    parser: KXmlParser,
+    parser: PlatformXmlParser,
     private val storage: IStorageUtilityIndexed<Case>
 ) : BulkProcessingCaseXmlParser(parser) {
 

--- a/commcare-core/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/instance/utils/TreeUtilities.kt
@@ -19,7 +19,7 @@ import org.javarosa.xpath.expr.XPathEqExpr
 import org.javarosa.xpath.expr.XPathExpression
 import org.javarosa.xpath.expr.XPathPathExpr
 import org.javarosa.xpath.expr.XPathStringLiteral
-import org.kxml2.io.KXmlParser
+import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream

--- a/commcare-core/src/main/java/org/javarosa/xform/parse/XFormParser.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/parse/XFormParser.kt
@@ -47,7 +47,6 @@ import org.kxml2.io.KXmlParser
 import org.kxml2.kdom.Document
 import org.kxml2.kdom.Element
 import org.kxml2.kdom.Node
-import org.javarosa.xml.PlatformXmlParser
 import org.javarosa.xml.PlatformXmlParserException
 import org.javarosa.core.util.externalizable.PlatformIOException
 import java.io.InputStream
@@ -609,7 +608,7 @@ class XFormParser {
                 }
 
                 parser.setInput(reader)
-                parser.setFeature(PlatformXmlParser.FEATURE_PROCESS_NAMESPACES, true)
+                parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, true)
                 doc.parse(parser)
             } catch (e: PlatformXmlParserException) {
                 val errorMsg = "XML Syntax Error at Line: ${e.lineNumber}, Column: ${e.columnNumber}!"

--- a/commcare-core/src/main/java/org/javarosa/xml/ElementParser.java
+++ b/commcare-core/src/main/java/org/javarosa/xml/ElementParser.java
@@ -4,7 +4,6 @@ import org.javarosa.core.model.utils.DateUtils;
 import org.javarosa.core.services.Logger;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
-import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -27,7 +26,7 @@ import java.util.Date;
  * @author ctsims
  */
 public abstract class ElementParser<T> {
-    protected final KXmlParser parser;
+    protected final PlatformXmlParser parser;
 
     private int level = 0;
 
@@ -42,7 +41,7 @@ public abstract class ElementParser<T> {
      *               position of the top level element that represents this
      *               element's XML structure.
      */
-    public ElementParser(KXmlParser parser) {
+    public ElementParser(PlatformXmlParser parser) {
         this.parser = parser;
         level = parser.getDepth();
     }
@@ -56,22 +55,11 @@ public abstract class ElementParser<T> {
      * @throws IOException If the stream cannot be read for any reason
      *                     other than invalid XML Structures.
      */
-    public static KXmlParser instantiateParser(InputStream stream) throws IOException {
-        KXmlParser parser = new KXmlParser();
+    public static PlatformXmlParser instantiateParser(InputStream stream) throws IOException {
         try {
-            parser.setInput(stream, "UTF-8");
-            parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, true);
-
-            //Point to the first available tag.
-            parser.next();
-
-            return parser;
-        } catch (XmlPullParserException e) {
-            // TODO Auto-generated catch block
+            return PlatformXmlParserJvmKt.createXmlParser(stream, "UTF-8");
+        } catch (Exception e) {
             Logger.exception("Element Parser", e);
-            throw new IOException(e.getMessage());
-        } catch (IllegalArgumentException e) {
-            e.printStackTrace();
             throw new IOException(e.getMessage());
         }
     }
@@ -111,13 +99,7 @@ public abstract class ElementParser<T> {
             }
         }
         if (!checksOut) {
-            int eventType = -1;
-            try {
-                eventType = parser.getEventType();
-            } catch (XmlPullParserException xppe) {
-                //This event type is just here to help elaborate on the exception
-                //so don't crash on it
-            }
+            int eventType = parser.getEventType();
             String oneOf = null;
             if (names.length == 1) {
                 oneOf = "<" + names[0] + "> ";
@@ -130,11 +112,11 @@ public abstract class ElementParser<T> {
             }
 
             String foundInstead = "";
-            if (eventType == KXmlParser.END_TAG) {
+            if (eventType == PlatformXmlParser.END_TAG) {
                 foundInstead = "Closing tag </" + parser.getName() + ">";
-            } else if (eventType == KXmlParser.START_TAG) {
+            } else if (eventType == PlatformXmlParser.START_TAG) {
                 foundInstead = "Element <" + parser.getName() + ">";
-            } else if (eventType == KXmlParser.TEXT) {
+            } else if (eventType == PlatformXmlParser.TEXT) {
                 foundInstead = "Text \"" + parser.getText() + "\"";
             } else {
                 foundInstead = "Unknown";
@@ -183,17 +165,17 @@ public abstract class ElementParser<T> {
 
         //eventType = parser.nextTag();
         eventType = parser.next();
-        while (eventType == KXmlParser.TEXT && parser.isWhitespace()) {   // skip whitespace
+        while (eventType == PlatformXmlParser.TEXT && parser.isWhitespace()) {   // skip whitespace
             eventType = parser.next();
         }
 
-        if (eventType == KXmlParser.START_DOCUMENT) {
+        if (eventType == PlatformXmlParser.START_DOCUMENT) {
             //
-        } else if (eventType == KXmlParser.END_DOCUMENT) {
+        } else if (eventType == PlatformXmlParser.END_DOCUMENT) {
             return false;
-        } else if (eventType == KXmlParser.START_TAG) {
+        } else if (eventType == PlatformXmlParser.START_TAG) {
             return true;
-        } else if (eventType == KXmlParser.END_TAG) {
+        } else if (eventType == PlatformXmlParser.END_TAG) {
             //If we've reached the end of the current node path,
             //return false (signaling that the parsing action should end).
             if (isTagNamed(terminal)) {
@@ -207,7 +189,7 @@ public abstract class ElementParser<T> {
             else {
                 return false;
             }
-        } else if (eventType == KXmlParser.TEXT) {
+        } else if (eventType == PlatformXmlParser.TEXT) {
             return true;
         }
         return true;
@@ -325,21 +307,21 @@ public abstract class ElementParser<T> {
 
     public void skipBlock(String tag) throws XmlPullParserException, IOException {
 
-        while (parser.getEventType() != KXmlParser.END_DOCUMENT) {
+        while (parser.getEventType() != PlatformXmlParser.END_DOCUMENT) {
             int eventType;
             eventType = parser.next();
 
-            if (eventType == KXmlParser.START_DOCUMENT) {
+            if (eventType == PlatformXmlParser.START_DOCUMENT) {
 
-            } else if (eventType == KXmlParser.END_DOCUMENT) {
+            } else if (eventType == PlatformXmlParser.END_DOCUMENT) {
                 return;
-            } else if (eventType == KXmlParser.START_TAG) {
+            } else if (eventType == PlatformXmlParser.START_TAG) {
 
-            } else if (eventType == KXmlParser.END_TAG) {
+            } else if (eventType == PlatformXmlParser.END_TAG) {
                 if (parser.getName().equals(tag)) {
                     return;
                 }
-            } else if (eventType == KXmlParser.TEXT) {
+            } else if (eventType == PlatformXmlParser.TEXT) {
 
             }
         }
@@ -347,7 +329,7 @@ public abstract class ElementParser<T> {
 
     protected int nextNonWhitespace() throws XmlPullParserException, IOException {
         int ret = parser.next();
-        if (ret == KXmlParser.TEXT && parser.isWhitespace()) {
+        if (ret == PlatformXmlParser.TEXT && parser.isWhitespace()) {
             ret = parser.next();
         }
         return ret;

--- a/commcare-core/src/main/java/org/javarosa/xml/TreeElementParser.java
+++ b/commcare-core/src/main/java/org/javarosa/xml/TreeElementParser.java
@@ -4,7 +4,6 @@ import org.javarosa.core.model.data.UncastData;
 import org.javarosa.core.model.instance.TreeElement;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.javarosa.xml.util.UnfullfilledRequirementsException;
-import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -17,7 +16,7 @@ public class TreeElementParser extends ElementParser<TreeElement> {
     final int multiplicity;
     final String instanceId;
 
-    public TreeElementParser(KXmlParser parser, int multiplicity, String instanceId) {
+    public TreeElementParser(PlatformXmlParser parser, int multiplicity, String instanceId) {
         super(parser);
         this.multiplicity = multiplicity;
         this.instanceId = instanceId;
@@ -39,7 +38,7 @@ public class TreeElementParser extends ElementParser<TreeElement> {
         // loop parses all siblings at a given depth
         while (parser.getDepth() >= depth) {
             switch (this.nextNonWhitespace()) {
-                case KXmlParser.START_TAG:
+                case PlatformXmlParser.START_TAG:
                     String name = parser.getName();
                     int val;
                     if (multiplicities.containsKey(name)) {
@@ -52,9 +51,9 @@ public class TreeElementParser extends ElementParser<TreeElement> {
                     TreeElement kid = new TreeElementParser(parser, val, instanceId).parse();
                     element.addChild(kid);
                     break;
-                case KXmlParser.END_TAG:
+                case PlatformXmlParser.END_TAG:
                     return element;
-                case KXmlParser.TEXT:
+                case PlatformXmlParser.TEXT:
                     element.setValue(new UncastData(parser.getText().trim()));
                     break;
                 default:

--- a/commcare-core/src/main/java/org/javarosa/xml/util/InvalidStructureException.java
+++ b/commcare-core/src/main/java/org/javarosa/xml/util/InvalidStructureException.java
@@ -1,6 +1,6 @@
 package org.javarosa.xml.util;
 
-import org.kxml2.io.KXmlParser;
+import org.javarosa.xml.PlatformXmlParser;
 
 /**
  * Invalid Structure Exceptions are thrown when an invalid
@@ -14,7 +14,7 @@ public class InvalidStructureException extends Exception {
      * @param message A Message associated with the error.
      * @param parser  The parser in the position at which the error was detected.
      */
-    public InvalidStructureException(String message, KXmlParser parser) {
+    public InvalidStructureException(String message, PlatformXmlParser parser) {
         super("Invalid XML Structure(" + parser.getPositionDescription() + "): " + message);
     }
 
@@ -23,7 +23,7 @@ public class InvalidStructureException extends Exception {
      * @param parser  The parser in the position at which the error was detected.
      * @param file    The file being parsed
      */
-    public InvalidStructureException(String message, String file, KXmlParser parser) {
+    public InvalidStructureException(String message, String file, PlatformXmlParser parser) {
         super("Invalid XML Structure in document " + file + "(" + parser.getPositionDescription() + "): " + message);
     }
 
@@ -31,12 +31,12 @@ public class InvalidStructureException extends Exception {
         super(message);
     }
 
-    public static InvalidStructureException readableInvalidStructureException(String message, KXmlParser parser) {
+    public static InvalidStructureException readableInvalidStructureException(String message, PlatformXmlParser parser) {
         String humanReadableMessage = message + buildParserMessage(parser);
         return new InvalidStructureException(humanReadableMessage);
     }
 
-    private static String buildParserMessage(KXmlParser parser) {
+    private static String buildParserMessage(PlatformXmlParser parser) {
         String prefix = parser.getPrefix();
         if (prefix != null) {
             return ". Source: <" + prefix + ":" + parser.getName() + "> tag in namespace: " + parser.getNamespace();

--- a/commcare-core/src/test/java/org/commcare/cases/util/test/CaseParseReindexTests.java
+++ b/commcare-core/src/test/java/org/commcare/cases/util/test/CaseParseReindexTests.java
@@ -10,9 +10,9 @@ import org.commcare.data.xml.TransactionParserFactory;
 import org.commcare.util.mocks.MockDataUtils;
 import org.commcare.util.mocks.MockUserDataSandbox;
 import org.commcare.xml.CaseXmlParser;
+import org.javarosa.xml.PlatformXmlParser;
 import org.junit.Before;
 import org.junit.Test;
-import org.kxml2.io.KXmlParser;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -79,7 +79,7 @@ public class CaseParseReindexTests {
                     CaseXmlParser created = null;
 
                     @Override
-                    public TransactionParser<Case> getParser(KXmlParser parser) {
+                    public TransactionParser<Case> getParser(PlatformXmlParser parser) {
                         if (created == null) {
                             created = new CaseXmlParser(parser, sandbox.getCaseStorage()) {
                                 @Override

--- a/commcare-core/src/test/java/org/commcare/xml/ParserTestUtils.java
+++ b/commcare-core/src/test/java/org/commcare/xml/ParserTestUtils.java
@@ -1,7 +1,7 @@
 package org.commcare.xml;
 
 import org.javarosa.xml.ElementParser;
-import org.kxml2.io.KXmlParser;
+import org.javarosa.xml.PlatformXmlParser;
 
 import java.io.ByteArrayInputStream;
 import java.lang.reflect.Constructor;
@@ -15,7 +15,7 @@ public class ParserTestUtils {
     public static <T extends CommCareElementParser> T buildParser(String xml, Class<T> parserClass) {
         return buildParser(xml, (xmlParser) -> {
             try {
-                Constructor<T> constructor = parserClass.getConstructor(KXmlParser.class);
+                Constructor<T> constructor = parserClass.getConstructor(PlatformXmlParser.class);
                 return constructor.newInstance(xmlParser);
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -23,10 +23,10 @@ public class ParserTestUtils {
         });
     }
 
-    public static <T extends CommCareElementParser> T buildParser(String xml, Function<KXmlParser, T> builder) {
+    public static <T extends CommCareElementParser> T buildParser(String xml, Function<PlatformXmlParser, T> builder) {
         try {
             ByteArrayInputStream inputStream = new ByteArrayInputStream(xml.getBytes("UTF-8"));
-            KXmlParser parser = ElementParser.instantiateParser(inputStream);
+            PlatformXmlParser parser = ElementParser.instantiateParser(inputStream);
             return builder.apply(parser);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/commcare-core/src/translate/java/org/javarosa/engine/xml/ElementParser.java
+++ b/commcare-core/src/translate/java/org/javarosa/engine/xml/ElementParser.java
@@ -1,5 +1,7 @@
 package org.javarosa.engine.xml;
 
+import org.javarosa.xml.JvmXmlParser;
+import org.javarosa.xml.PlatformXmlParser;
 import org.javarosa.xml.util.InvalidStructureException;
 import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
@@ -25,7 +27,7 @@ import java.io.InputStream;
  *
  */
 public abstract class ElementParser<T> {
-    protected final KXmlParser parser;
+    protected final PlatformXmlParser parser;
 
     int level = 0;
 
@@ -39,11 +41,11 @@ public abstract class ElementParser<T> {
      * other than invalid CommCare XML Structures.
      */
     public ElementParser(InputStream suiteStream) throws IOException{
-        parser = new KXmlParser();
+        KXmlParser kxml = new KXmlParser();
         try {
-            parser.setInput(suiteStream,"UTF-8");
-            parser.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, true);
-            parser.next();
+            kxml.setInput(suiteStream,"UTF-8");
+            kxml.setFeature(KXmlParser.FEATURE_PROCESS_NAMESPACES, true);
+            kxml.next();
 
         } catch (XmlPullParserException e) {
             // TODO Auto-generated catch block
@@ -51,6 +53,7 @@ public abstract class ElementParser<T> {
         } catch (IllegalArgumentException e) {
             throw new IOException(e.getMessage());
         }
+        parser = new JvmXmlParser(kxml);
     }
 
     /**
@@ -60,7 +63,7 @@ public abstract class ElementParser<T> {
      * position of the top level element that represents this
      * element's XML structure.
      */
-    public ElementParser(KXmlParser parser) {
+    public ElementParser(PlatformXmlParser parser) {
         this.parser = parser;
         level = parser.getDepth();
     }
@@ -119,17 +122,17 @@ public abstract class ElementParser<T> {
 
             //eventType = parser.nextTag();
             eventType = parser.next();
-            if(eventType == KXmlParser.TEXT && parser.isWhitespace()) {   // skip whitespace
+            if(eventType == PlatformXmlParser.TEXT && parser.isWhitespace()) {   // skip whitespace
                  eventType = parser.next();
             }
 
-            if(eventType == KXmlParser.START_DOCUMENT) {
+            if(eventType == PlatformXmlParser.START_DOCUMENT) {
                 //
-            } else if(eventType == KXmlParser.END_DOCUMENT) {
+            } else if(eventType == PlatformXmlParser.END_DOCUMENT) {
                 return false;
-            } else if(eventType == KXmlParser.START_TAG) {
+            } else if(eventType == PlatformXmlParser.START_TAG) {
                 return true;
-            } else if(eventType == KXmlParser.END_TAG) {
+            } else if(eventType == PlatformXmlParser.END_TAG) {
                 //If we've reached the end of the current node path,
                 //return false (signaling that the parsing action should end).
                 if(parser.getName().toLowerCase().equals(terminal.toLowerCase())) { return false; }
@@ -137,7 +140,7 @@ public abstract class ElementParser<T> {
                 else if(parser.getDepth() >= level) { return nextTagInBlock(terminal); }
                 //if we're below the limit, get out.
                 else { return false; }
-            } else if(eventType == KXmlParser.TEXT) {
+            } else if(eventType == PlatformXmlParser.TEXT) {
                 return true;
             }
             return true;
@@ -226,21 +229,21 @@ public abstract class ElementParser<T> {
 
     public void skipBlock(String tag) throws XmlPullParserException, IOException {
 
-        while(parser.getEventType() != KXmlParser.END_DOCUMENT) {
+        while(parser.getEventType() != PlatformXmlParser.END_DOCUMENT) {
             int eventType;
             eventType = parser.next();
 
-            if(eventType == KXmlParser.START_DOCUMENT) {
+            if(eventType == PlatformXmlParser.START_DOCUMENT) {
 
-            } else if(eventType == KXmlParser.END_DOCUMENT) {
+            } else if(eventType == PlatformXmlParser.END_DOCUMENT) {
                 return;
-            } else if(eventType == KXmlParser.START_TAG) {
+            } else if(eventType == PlatformXmlParser.START_TAG) {
 
-            } else if(eventType == KXmlParser.END_TAG) {
+            } else if(eventType == PlatformXmlParser.END_TAG) {
                 if(parser.getName().equals(tag)) {
                     return;
                 }
-            } else if(eventType == KXmlParser.TEXT) {
+            } else if(eventType == PlatformXmlParser.TEXT) {
 
             }
         }
@@ -248,7 +251,7 @@ public abstract class ElementParser<T> {
 
     protected int nextNonWhitespace() throws XmlPullParserException, IOException {
         int ret = parser.next();
-        if(ret == KXmlParser.TEXT && parser.isWhitespace()) {
+        if(ret == PlatformXmlParser.TEXT && parser.isWhitespace()) {
             ret = parser.next();
         }
         return ret;

--- a/commcare-core/src/translate/java/org/javarosa/engine/xml/FormInstanceParser.java
+++ b/commcare-core/src/translate/java/org/javarosa/engine/xml/FormInstanceParser.java
@@ -5,8 +5,8 @@ package org.javarosa.engine.xml;
 
 import org.javarosa.core.model.instance.FormInstance;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.xml.PlatformXmlParser;
 import org.javarosa.xml.util.InvalidStructureException;
-import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -22,7 +22,7 @@ import java.io.IOException;
  */
 public class FormInstanceParser extends ElementParser<FormInstance> {
 
-    public FormInstanceParser(KXmlParser parser) {
+    public FormInstanceParser(PlatformXmlParser parser) {
         super(parser);
     }
 

--- a/commcare-core/src/translate/java/org/javarosa/engine/xml/SessionParser.java
+++ b/commcare-core/src/translate/java/org/javarosa/engine/xml/SessionParser.java
@@ -1,8 +1,8 @@
 package org.javarosa.engine.xml;
 
 import org.javarosa.engine.models.Session;
+import org.javarosa.xml.PlatformXmlParser;
 import org.javarosa.xml.util.InvalidStructureException;
-import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -12,7 +12,7 @@ import java.io.IOException;
  */
 public class SessionParser extends ElementParser<Session> {
 
-    public SessionParser(KXmlParser parser) throws IOException {
+    public SessionParser(PlatformXmlParser parser) throws IOException {
         super(parser);
     }
 

--- a/commcare-core/src/translate/java/org/javarosa/engine/xml/TreeElementParser.java
+++ b/commcare-core/src/translate/java/org/javarosa/engine/xml/TreeElementParser.java
@@ -2,8 +2,8 @@ package org.javarosa.engine.xml;
 
 import org.javarosa.core.model.data.UncastData;
 import org.javarosa.core.model.instance.TreeElement;
+import org.javarosa.xml.PlatformXmlParser;
 import org.javarosa.xml.util.InvalidStructureException;
-import org.kxml2.io.KXmlParser;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
@@ -17,7 +17,7 @@ public class TreeElementParser extends ElementParser<TreeElement> {
     final int multiplicity;
     final String instanceId;
 
-    public TreeElementParser(KXmlParser parser, int  multiplicity, String instanceId) {
+    public TreeElementParser(PlatformXmlParser parser, int  multiplicity, String instanceId) {
         super(parser);
         this.multiplicity = multiplicity;
         this.instanceId = instanceId;
@@ -37,7 +37,7 @@ public class TreeElementParser extends ElementParser<TreeElement> {
         //NOTE: We never expect this to be the exit condition
         while (parser.getDepth() >= depth) {
             switch (this.nextNonWhitespace()) {
-                case KXmlParser.START_TAG:
+                case PlatformXmlParser.START_TAG:
                     String name = parser.getName();
                     int val;
                     if (multiplicities.containsKey(name)) {
@@ -49,9 +49,9 @@ public class TreeElementParser extends ElementParser<TreeElement> {
                     TreeElement kid = new TreeElementParser(parser, val, instanceId).parse();
                     element.addChild(kid);
                     break;
-                case KXmlParser.END_TAG:
+                case PlatformXmlParser.END_TAG:
                     return element;
-                case KXmlParser.TEXT:
+                case PlatformXmlParser.TEXT:
                     element.setValue(new UncastData(parser.getText().trim()));
                     break;
                 default:


### PR DESCRIPTION
## Summary
- Migrated 50+ parser files from kxml2's `KXmlParser` to the cross-platform `PlatformXmlParser` interface
- Enhanced `PlatformXmlParser` with `val` properties (for Kotlin property synthesis), default `nextTag()`/`nextText()` implementations
- Added `JvmXmlParser(KXmlParser)` constructor for wrapping existing parser instances and `createXmlParser(InputStream)` factory
- Updated translate/ and test/ source sets for compatibility

## Details

**Core infrastructure changes:**
- `PlatformXmlParser`: Changed from `fun` getters to `val` properties to enable Kotlin property syntax (`parser.name` vs `parser.getName()`)
- `PlatformXmlParser`: Added default `nextTag()` and `nextText()` implementations
- `JvmXmlParser`: Added constructor wrapping existing `KXmlParser` instances (used by `ElementParser.instantiateParser`)
- `IosXmlParser`: Renamed backing fields (`_eventType`, `_depth`, `_name`, etc.) to avoid property conflicts

**Migrated files (50+):**
- `ElementParser.java`, `TransactionParser.java`, `TransactionParserFactory.java`, `InvalidStructureException.java`, `TreeElementParser.java`
- 46 Kotlin parser files in `org.commcare.xml` package
- 4 translate/ source set files, 2 test/ source set files

**Files retaining kxml2 imports (DOM types — not abstractable in this wave):**
- `XFormParser.kt` — uses `KXmlParser()` constructor, `parser.setInput(reader)`, kxml2 DOM (`Document`, `Element`, `Node`)
- `InterningKXmlParser.kt` — extends `KXmlParser` as a class
- `XFormSerializingVisitor.kt`, `DataModelSerializer.kt`, `XFormSerializer.kt` — use `KXmlSerializer`
- `XFormUtils.kt`, `QuestionExtensionParser.kt` — use kxml2 `Element`/`Document`

These DOM-dependent files will be addressed when their containing modules move to commonMain (Waves 6-7).

## Test plan
- [x] `./gradlew compileKotlinJvm compileJava` passes
- [x] All source sets compile (main, translate, test, cli, ccapi)
- [x] `./gradlew test` — 710+ JVM tests pass
- [ ] CI verification

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)