### PR TITLE
Phase 3 Wave 4: Abstract serialization framework

### DIFF
--- a/commcare-core/src/cli/java/org/commcare/util/mocks/MockDataUtils.java
+++ b/commcare-core/src/cli/java/org/commcare/util/mocks/MockDataUtils.java
@@ -7,6 +7,7 @@ import org.javarosa.core.model.condition.EvaluationContext;
 import org.javarosa.core.model.instance.DataInstance;
 import org.javarosa.core.model.instance.ExternalDataInstance;
 import org.javarosa.core.model.instance.InstanceInitializationFactory;
+import org.javarosa.core.util.externalizable.JvmPrototypeFactory;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 import java.util.HashMap;
@@ -23,7 +24,7 @@ import java.util.HashMap;
 public class MockDataUtils {
 
     public static MockUserDataSandbox getStaticStorage() {
-        PrototypeFactory factory = new PrototypeFactory(new ClassNameHasher());
+        PrototypeFactory factory = new JvmPrototypeFactory(new ClassNameHasher());
         return new MockUserDataSandbox(factory);
     }
 

--- a/commcare-core/src/commonMain/kotlin/org/javarosa/core/util/externalizable/Externalizable.kt
+++ b/commcare-core/src/commonMain/kotlin/org/javarosa/core/util/externalizable/Externalizable.kt
@@ -1,9 +1,5 @@
 package org.javarosa.core.util.externalizable
 
-import java.io.DataInputStream
-import java.io.DataOutputStream
-import org.javarosa.core.util.externalizable.PlatformIOException
-
 /**
  * Gives objects control over serialization. A replacement for the interfaces
  * `Externalizable` and `Serializable`, which are
@@ -17,11 +13,11 @@ interface Externalizable {
      * Read the object from stream.
      */
     @Throws(PlatformIOException::class, DeserializationException::class)
-    fun readExternal(`in`: DataInputStream, pf: PrototypeFactory)
+    fun readExternal(`in`: PlatformDataInputStream, pf: PrototypeFactory)
 
     /**
      * Write the object to stream.
      */
     @Throws(PlatformIOException::class)
-    fun writeExternal(out: DataOutputStream)
+    fun writeExternal(out: PlatformDataOutputStream)
 }

--- a/commcare-core/src/commonMain/kotlin/org/javarosa/core/util/externalizable/PlatformDataInputStream.kt
+++ b/commcare-core/src/commonMain/kotlin/org/javarosa/core/util/externalizable/PlatformDataInputStream.kt
@@ -1,13 +1,18 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
 package org.javarosa.core.util.externalizable
 
 /**
  * Platform-abstracted data input stream for deserializing binary data.
- * On JVM, delegates to java.io.DataInputStream. On iOS, uses manual big-endian decoding.
+ * On JVM, this is a typealias to java.io.DataInputStream.
+ * On iOS, this is a manual big-endian decoder from ByteArray.
  *
  * All multi-byte values use big-endian byte order to match Java's DataInputStream format.
  * Strings use Java's modified UTF-8 encoding (2-byte length prefix + modified UTF-8 bytes).
+ *
+ * Do not construct directly in commonMain code — use [createDataInputStream] factory.
  */
-expect class PlatformDataInputStream(data: ByteArray) {
+expect class PlatformDataInputStream {
     fun readByte(): Byte
     fun readInt(): Int
     fun readLong(): Long
@@ -20,3 +25,8 @@ expect class PlatformDataInputStream(data: ByteArray) {
     fun available(): Int
     fun close()
 }
+
+/**
+ * Create a PlatformDataInputStream from a ByteArray.
+ */
+expect fun createDataInputStream(data: ByteArray): PlatformDataInputStream

--- a/commcare-core/src/commonMain/kotlin/org/javarosa/core/util/externalizable/PlatformDataOutputStream.kt
+++ b/commcare-core/src/commonMain/kotlin/org/javarosa/core/util/externalizable/PlatformDataOutputStream.kt
@@ -1,14 +1,18 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
 package org.javarosa.core.util.externalizable
 
 /**
- * Platform-abstracted data output stream for serializing binary data to an in-memory buffer.
- * On JVM, delegates to java.io.DataOutputStream wrapping ByteArrayOutputStream.
- * On iOS, uses manual big-endian encoding.
+ * Platform-abstracted data output stream for serializing binary data.
+ * On JVM, this is a typealias to java.io.DataOutputStream.
+ * On iOS, this is a manual big-endian encoder to an in-memory buffer.
  *
  * All multi-byte values use big-endian byte order to match Java's DataOutputStream format.
  * Strings use Java's modified UTF-8 encoding (2-byte length prefix + modified UTF-8 bytes).
+ *
+ * Do not construct directly in commonMain code — use [serializeToBytes] factory.
  */
-expect class PlatformDataOutputStream() {
+expect class PlatformDataOutputStream {
     fun writeByte(v: Int)
     fun writeInt(v: Int)
     fun writeLong(v: Long)
@@ -21,5 +25,11 @@ expect class PlatformDataOutputStream() {
     fun write(v: Int)
     fun flush()
     fun close()
-    fun toByteArray(): ByteArray
 }
+
+/**
+ * Write to a PlatformDataOutputStream and return the resulting byte array.
+ * On JVM, wraps a ByteArrayOutputStream+DataOutputStream.
+ * On iOS, uses the in-memory buffer implementation.
+ */
+expect fun serializeToBytes(block: (PlatformDataOutputStream) -> Unit): ByteArray

--- a/commcare-core/src/commonMain/kotlin/org/javarosa/core/util/externalizable/PrototypeFactory.kt
+++ b/commcare-core/src/commonMain/kotlin/org/javarosa/core/util/externalizable/PrototypeFactory.kt
@@ -1,0 +1,54 @@
+package org.javarosa.core.util.externalizable
+
+/**
+ * Cross-platform base class for the prototype factory used in serialization.
+ *
+ * Provides the common API that Externalizable implementations need:
+ * - getInstance(hash) to create objects during deserialization
+ * - Companion methods for hash comparison and wrapper tags
+ *
+ * On JVM, use JvmPrototypeFactory which adds Class.forName()/newInstance() support.
+ * On iOS, use IosPrototypeFactory which uses explicit registration.
+ */
+open class PrototypeFactory {
+
+    protected var initialized: Boolean = false
+
+    /**
+     * Create an instance of the class identified by its hash.
+     * Subclasses must override with platform-specific instantiation.
+     */
+    open fun getInstance(hash: ByteArray): Any {
+        throw CannotCreateObjectException("No class registered for hash ${hash.contentToString()}")
+    }
+
+    companion object {
+        private var _hashSize: Int = 32
+
+        fun compareHash(a: ByteArray, b: ByteArray): Boolean {
+            if (a.size != b.size) {
+                return false
+            }
+            for (i in a.indices) {
+                if (a[i] != b[i]) {
+                    return false
+                }
+            }
+            return true
+        }
+
+        fun getClassHashSize(): Int = _hashSize
+
+        fun setClassHashSize(size: Int) {
+            _hashSize = size
+        }
+
+        fun getWrapperTag(): ByteArray {
+            val bytes = ByteArray(getClassHashSize())
+            for (i in bytes.indices) {
+                bytes[i] = 0xff.toByte()
+            }
+            return bytes
+        }
+    }
+}

--- a/commcare-core/src/commonTest/kotlin/org/javarosa/core/util/externalizable/PlatformDataStreamTest.kt
+++ b/commcare-core/src/commonTest/kotlin/org/javarosa/core/util/externalizable/PlatformDataStreamTest.kt
@@ -12,14 +12,14 @@ class PlatformDataStreamTest {
 
     @Test
     fun testByteRoundTrip() {
-        val out = PlatformDataOutputStream()
-        out.writeByte(0)
-        out.writeByte(127)
-        out.writeByte(-1)
-        out.writeByte(255)
-        out.close()
+        val bytes = serializeToBytes { out ->
+            out.writeByte(0)
+            out.writeByte(127)
+            out.writeByte(-1)
+            out.writeByte(255)
+        }
 
-        val inp = PlatformDataInputStream(out.toByteArray())
+        val inp = createDataInputStream(bytes)
         assertEquals(0.toByte(), inp.readByte())
         assertEquals(127.toByte(), inp.readByte())
         assertEquals((-1).toByte(), inp.readByte())
@@ -29,15 +29,15 @@ class PlatformDataStreamTest {
 
     @Test
     fun testIntRoundTrip() {
-        val out = PlatformDataOutputStream()
-        out.writeInt(0)
-        out.writeInt(1)
-        out.writeInt(-1)
-        out.writeInt(Int.MAX_VALUE)
-        out.writeInt(Int.MIN_VALUE)
-        out.close()
+        val bytes = serializeToBytes { out ->
+            out.writeInt(0)
+            out.writeInt(1)
+            out.writeInt(-1)
+            out.writeInt(Int.MAX_VALUE)
+            out.writeInt(Int.MIN_VALUE)
+        }
 
-        val inp = PlatformDataInputStream(out.toByteArray())
+        val inp = createDataInputStream(bytes)
         assertEquals(0, inp.readInt())
         assertEquals(1, inp.readInt())
         assertEquals(-1, inp.readInt())
@@ -48,15 +48,15 @@ class PlatformDataStreamTest {
 
     @Test
     fun testLongRoundTrip() {
-        val out = PlatformDataOutputStream()
-        out.writeLong(0L)
-        out.writeLong(1L)
-        out.writeLong(-1L)
-        out.writeLong(Long.MAX_VALUE)
-        out.writeLong(Long.MIN_VALUE)
-        out.close()
+        val bytes = serializeToBytes { out ->
+            out.writeLong(0L)
+            out.writeLong(1L)
+            out.writeLong(-1L)
+            out.writeLong(Long.MAX_VALUE)
+            out.writeLong(Long.MIN_VALUE)
+        }
 
-        val inp = PlatformDataInputStream(out.toByteArray())
+        val inp = createDataInputStream(bytes)
         assertEquals(0L, inp.readLong())
         assertEquals(1L, inp.readLong())
         assertEquals(-1L, inp.readLong())
@@ -67,16 +67,16 @@ class PlatformDataStreamTest {
 
     @Test
     fun testDoubleRoundTrip() {
-        val out = PlatformDataOutputStream()
-        out.writeDouble(0.0)
-        out.writeDouble(1.5)
-        out.writeDouble(-1.5)
-        out.writeDouble(Double.MAX_VALUE)
-        out.writeDouble(Double.MIN_VALUE)
-        out.writeDouble(Double.NaN)
-        out.close()
+        val bytes = serializeToBytes { out ->
+            out.writeDouble(0.0)
+            out.writeDouble(1.5)
+            out.writeDouble(-1.5)
+            out.writeDouble(Double.MAX_VALUE)
+            out.writeDouble(Double.MIN_VALUE)
+            out.writeDouble(Double.NaN)
+        }
 
-        val inp = PlatformDataInputStream(out.toByteArray())
+        val inp = createDataInputStream(bytes)
         assertEquals(0.0, inp.readDouble())
         assertEquals(1.5, inp.readDouble())
         assertEquals(-1.5, inp.readDouble())
@@ -88,12 +88,12 @@ class PlatformDataStreamTest {
 
     @Test
     fun testBooleanRoundTrip() {
-        val out = PlatformDataOutputStream()
-        out.writeBoolean(true)
-        out.writeBoolean(false)
-        out.close()
+        val bytes = serializeToBytes { out ->
+            out.writeBoolean(true)
+            out.writeBoolean(false)
+        }
 
-        val inp = PlatformDataInputStream(out.toByteArray())
+        val inp = createDataInputStream(bytes)
         assertEquals(true, inp.readBoolean())
         assertEquals(false, inp.readBoolean())
         inp.close()
@@ -101,14 +101,14 @@ class PlatformDataStreamTest {
 
     @Test
     fun testCharRoundTrip() {
-        val out = PlatformDataOutputStream()
-        out.writeChar('A'.code)
-        out.writeChar('Z'.code)
-        out.writeChar('\u00E9'.code) // é
-        out.writeChar('\u4E16'.code) // 世
-        out.close()
+        val bytes = serializeToBytes { out ->
+            out.writeChar('A'.code)
+            out.writeChar('Z'.code)
+            out.writeChar('\u00E9'.code) // é
+            out.writeChar('\u4E16'.code) // 世
+        }
 
-        val inp = PlatformDataInputStream(out.toByteArray())
+        val inp = createDataInputStream(bytes)
         assertEquals('A', inp.readChar())
         assertEquals('Z', inp.readChar())
         assertEquals('\u00E9', inp.readChar())
@@ -118,14 +118,14 @@ class PlatformDataStreamTest {
 
     @Test
     fun testUTFRoundTrip() {
-        val out = PlatformDataOutputStream()
-        out.writeUTF("hello")
-        out.writeUTF("")
-        out.writeUTF("café")
-        out.writeUTF("\u4E16\u754C") // 世界
-        out.close()
+        val bytes = serializeToBytes { out ->
+            out.writeUTF("hello")
+            out.writeUTF("")
+            out.writeUTF("café")
+            out.writeUTF("\u4E16\u754C") // 世界
+        }
 
-        val inp = PlatformDataInputStream(out.toByteArray())
+        val inp = createDataInputStream(bytes)
         assertEquals("hello", inp.readUTF())
         assertEquals("", inp.readUTF())
         assertEquals("café", inp.readUTF())
@@ -136,12 +136,12 @@ class PlatformDataStreamTest {
     @Test
     fun testByteArrayRoundTrip() {
         val original = byteArrayOf(1, 2, 3, 4, 5, 0, -1, -128, 127)
-        val out = PlatformDataOutputStream()
-        out.writeInt(original.size)
-        out.write(original)
-        out.close()
+        val bytes = serializeToBytes { out ->
+            out.writeInt(original.size)
+            out.write(original)
+        }
 
-        val inp = PlatformDataInputStream(out.toByteArray())
+        val inp = createDataInputStream(bytes)
         val size = inp.readInt()
         val result = ByteArray(size)
         inp.readFully(result)
@@ -151,16 +151,16 @@ class PlatformDataStreamTest {
 
     @Test
     fun testMixedTypesRoundTrip() {
-        val out = PlatformDataOutputStream()
-        out.writeInt(42)
-        out.writeUTF("CommCare")
-        out.writeBoolean(true)
-        out.writeLong(1234567890123L)
-        out.writeDouble(3.14159)
-        out.writeChar('X'.code)
-        out.close()
+        val bytes = serializeToBytes { out ->
+            out.writeInt(42)
+            out.writeUTF("CommCare")
+            out.writeBoolean(true)
+            out.writeLong(1234567890123L)
+            out.writeDouble(3.14159)
+            out.writeChar('X'.code)
+        }
 
-        val inp = PlatformDataInputStream(out.toByteArray())
+        val inp = createDataInputStream(bytes)
         assertEquals(42, inp.readInt())
         assertEquals("CommCare", inp.readUTF())
         assertEquals(true, inp.readBoolean())
@@ -173,12 +173,12 @@ class PlatformDataStreamTest {
 
     @Test
     fun testAvailable() {
-        val out = PlatformDataOutputStream()
-        out.writeInt(1)
-        out.writeInt(2)
-        out.close()
+        val bytes = serializeToBytes { out ->
+            out.writeInt(1)
+            out.writeInt(2)
+        }
 
-        val inp = PlatformDataInputStream(out.toByteArray())
+        val inp = createDataInputStream(bytes)
         assertEquals(8, inp.available())
         inp.readInt()
         assertEquals(4, inp.available())
@@ -194,10 +194,9 @@ class PlatformDataStreamTest {
      */
     @Test
     fun testBinaryFormatCompatibility() {
-        val out = PlatformDataOutputStream()
-        out.writeInt(0x01020304)
-        out.close()
-        val bytes = out.toByteArray()
+        val bytes = serializeToBytes { out ->
+            out.writeInt(0x01020304)
+        }
         // Java DataOutputStream writes big-endian
         assertEquals(4, bytes.size)
         assertEquals(0x01.toByte(), bytes[0])
@@ -208,15 +207,36 @@ class PlatformDataStreamTest {
 
     @Test
     fun testUTFBinaryFormat() {
-        val out = PlatformDataOutputStream()
-        out.writeUTF("AB")
-        out.close()
-        val bytes = out.toByteArray()
+        val bytes = serializeToBytes { out ->
+            out.writeUTF("AB")
+        }
         // 2-byte length prefix (0x0002) + ASCII bytes
         assertEquals(4, bytes.size)
         assertEquals(0x00.toByte(), bytes[0]) // length high byte
         assertEquals(0x02.toByte(), bytes[1]) // length low byte
         assertEquals('A'.code.toByte(), bytes[2])
         assertEquals('B'.code.toByte(), bytes[3])
+    }
+
+    /**
+     * Test cross-platform serialization round-trip using the Externalizable interface.
+     * Verifies that the serialization infrastructure works end-to-end.
+     */
+    @Test
+    fun testSerializationRoundTrip() {
+        val bytes = serializeToBytes { out ->
+            // Simulate an Externalizable.writeExternal
+            out.writeUTF("test-case-id")
+            out.writeInt(42)
+            out.writeBoolean(true)
+            out.writeLong(1710000000000L) // epoch millis
+        }
+
+        val inp = createDataInputStream(bytes)
+        assertEquals("test-case-id", inp.readUTF())
+        assertEquals(42, inp.readInt())
+        assertEquals(true, inp.readBoolean())
+        assertEquals(1710000000000L, inp.readLong())
+        inp.close()
     }
 }

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/core/util/externalizable/IosPrototypeFactory.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/core/util/externalizable/IosPrototypeFactory.kt
@@ -1,0 +1,32 @@
+package org.javarosa.core.util.externalizable
+
+/**
+ * iOS implementation of PrototypeFactory using explicit registration.
+ * All serializable types must be registered at app startup via [registerType].
+ */
+class IosPrototypeFactory : PrototypeFactory() {
+
+    private val factories = mutableMapOf<String, () -> Any>()
+    private val hashes = mutableListOf<ByteArray>()
+
+    /**
+     * Register a serializable type with its class name hash and factory function.
+     * Must be called at app startup for every type that may be deserialized.
+     */
+    fun registerType(hash: ByteArray, factory: () -> Any) {
+        if (compareHash(hash, getWrapperTag())) {
+            throw Error("Hash collision with reserved wrapper tag")
+        }
+        factories[hash.toHexString()] = factory
+        hashes.add(hash)
+    }
+
+    override fun getInstance(hash: ByteArray): Any {
+        val factory = factories[hash.toHexString()]
+            ?: throw CannotCreateObjectException("No class registered for hash ${hash.toHexString()}")
+        return factory()
+    }
+
+    private fun ByteArray.toHexString(): String =
+        joinToString("") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') }
+}

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/core/util/externalizable/PlatformDataInputStream.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/core/util/externalizable/PlatformDataInputStream.kt
@@ -1,6 +1,8 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
 package org.javarosa.core.util.externalizable
 
-actual class PlatformDataInputStream actual constructor(data: ByteArray) {
+actual class PlatformDataInputStream(data: ByteArray) {
     private val buffer = data
     private var pos = 0
 
@@ -48,30 +50,26 @@ actual class PlatformDataInputStream actual constructor(data: ByteArray) {
         checkAvailable(utfLen)
         val chars = CharArray(utfLen) // max possible chars
         var charCount = 0
-        val start = pos
         val end = pos + utfLen
 
         while (pos < end) {
             val b = buffer[pos].toInt() and 0xFF
             if (b < 0x80) {
-                // Single byte: 0xxxxxxx
                 pos++
                 chars[charCount++] = b.toChar()
             } else if (b and 0xE0 == 0xC0) {
-                // Two bytes: 110xxxxx 10xxxxxx
                 if (pos + 1 >= end) throw RuntimeException("Malformed modified UTF-8")
                 val b2 = buffer[pos + 1].toInt() and 0xFF
                 pos += 2
                 chars[charCount++] = (((b and 0x1F) shl 6) or (b2 and 0x3F)).toChar()
             } else if (b and 0xF0 == 0xE0) {
-                // Three bytes: 1110xxxx 10xxxxxx 10xxxxxx
                 if (pos + 2 >= end) throw RuntimeException("Malformed modified UTF-8")
                 val b2 = buffer[pos + 1].toInt() and 0xFF
                 val b3 = buffer[pos + 2].toInt() and 0xFF
                 pos += 3
                 chars[charCount++] = (((b and 0x0F) shl 12) or ((b2 and 0x3F) shl 6) or (b3 and 0x3F)).toChar()
             } else {
-                throw RuntimeException("Malformed modified UTF-8 at byte ${pos - start}")
+                throw RuntimeException("Malformed modified UTF-8 at position $pos")
             }
         }
 
@@ -111,3 +109,6 @@ actual class PlatformDataInputStream actual constructor(data: ByteArray) {
         }
     }
 }
+
+actual fun createDataInputStream(data: ByteArray): PlatformDataInputStream =
+    PlatformDataInputStream(data)

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/core/util/externalizable/PlatformDataOutputStream.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/core/util/externalizable/PlatformDataOutputStream.kt
@@ -1,6 +1,8 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
 package org.javarosa.core.util.externalizable
 
-actual class PlatformDataOutputStream actual constructor() {
+actual class PlatformDataOutputStream {
     private val buffer = mutableListOf<Byte>()
 
     actual fun writeByte(v: Int) {
@@ -70,16 +72,11 @@ actual class PlatformDataOutputStream actual constructor() {
         // No resources to release
     }
 
-    actual fun toByteArray(): ByteArray {
+    fun toByteArray(): ByteArray {
         return buffer.toByteArray()
     }
 
     private fun encodeModifiedUtf8(s: String): ByteArray {
-        // Java modified UTF-8:
-        // - Null (0x0000) → 0xC0 0x80 (two bytes, NOT single zero byte)
-        // - 0x0001-0x007F → single byte
-        // - 0x0080-0x07FF → two bytes: 110xxxxx 10xxxxxx
-        // - 0x0800-0xFFFF → three bytes: 1110xxxx 10xxxxxx 10xxxxxx
         val result = mutableListOf<Byte>()
         for (ch in s) {
             val c = ch.code
@@ -104,4 +101,10 @@ actual class PlatformDataOutputStream actual constructor() {
         }
         return result.toByteArray()
     }
+}
+
+actual fun serializeToBytes(block: (PlatformDataOutputStream) -> Unit): ByteArray {
+    val stream = PlatformDataOutputStream()
+    block(stream)
+    return stream.toByteArray()
 }

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/core/util/externalizable/PlatformDataInputStream.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/core/util/externalizable/PlatformDataInputStream.kt
@@ -1,20 +1,11 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
 package org.javarosa.core.util.externalizable
 
 import java.io.ByteArrayInputStream
 import java.io.DataInputStream
 
-actual class PlatformDataInputStream actual constructor(data: ByteArray) {
-    private val dis = DataInputStream(ByteArrayInputStream(data))
+actual typealias PlatformDataInputStream = DataInputStream
 
-    actual fun readByte(): Byte = dis.readByte()
-    actual fun readInt(): Int = dis.readInt()
-    actual fun readLong(): Long = dis.readLong()
-    actual fun readChar(): Char = dis.readChar()
-    actual fun readDouble(): Double = dis.readDouble()
-    actual fun readBoolean(): Boolean = dis.readBoolean()
-    actual fun readUTF(): String = dis.readUTF()
-    actual fun readFully(b: ByteArray) = dis.readFully(b)
-    actual fun read(b: ByteArray, off: Int, len: Int): Int = dis.read(b, off, len)
-    actual fun available(): Int = dis.available()
-    actual fun close() = dis.close()
-}
+actual fun createDataInputStream(data: ByteArray): PlatformDataInputStream =
+    DataInputStream(ByteArrayInputStream(data))

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/core/util/externalizable/PlatformDataOutputStream.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/core/util/externalizable/PlatformDataOutputStream.kt
@@ -1,27 +1,16 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
 package org.javarosa.core.util.externalizable
 
 import java.io.ByteArrayOutputStream
 import java.io.DataOutputStream
 
-actual class PlatformDataOutputStream actual constructor() {
-    private val baos = ByteArrayOutputStream()
-    private val dos = DataOutputStream(baos)
+actual typealias PlatformDataOutputStream = DataOutputStream
 
-    actual fun writeByte(v: Int) = dos.writeByte(v)
-    actual fun writeInt(v: Int) = dos.writeInt(v)
-    actual fun writeLong(v: Long) = dos.writeLong(v)
-    actual fun writeChar(v: Int) = dos.writeChar(v)
-    actual fun writeDouble(v: Double) = dos.writeDouble(v)
-    actual fun writeBoolean(v: Boolean) = dos.writeBoolean(v)
-    actual fun writeUTF(s: String) = dos.writeUTF(s)
-    actual fun write(b: ByteArray) = dos.write(b)
-    actual fun write(b: ByteArray, off: Int, len: Int) = dos.write(b, off, len)
-    actual fun write(v: Int) = dos.write(v)
-    actual fun flush() = dos.flush()
-    actual fun close() = dos.close()
-
-    actual fun toByteArray(): ByteArray {
-        dos.flush()
-        return baos.toByteArray()
-    }
+actual fun serializeToBytes(block: (PlatformDataOutputStream) -> Unit): ByteArray {
+    val baos = ByteArrayOutputStream()
+    val dos = DataOutputStream(baos)
+    block(dos)
+    dos.flush()
+    return baos.toByteArray()
 }

--- a/commcare-core/src/main/java/org/javarosa/core/services/PrototypeManager.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/services/PrototypeManager.kt
@@ -1,6 +1,7 @@
 package org.javarosa.core.services
 
 import org.javarosa.core.util.externalizable.CannotCreateObjectException
+import org.javarosa.core.util.externalizable.JvmPrototypeFactory
 import org.javarosa.core.util.externalizable.PrototypeFactory
 import java.util.HashSet
 
@@ -28,7 +29,7 @@ object PrototypeManager {
         globalPrototypes.add(className)
 
         try {
-            PrototypeFactory.getInstance(Class.forName(className))
+            JvmPrototypeFactory.getInstance(Class.forName(className))
         } catch (e: ClassNotFoundException) {
             throw CannotCreateObjectException("$className: not found")
         }
@@ -63,18 +64,18 @@ object PrototypeManager {
         if (currentStaticFactory == null) {
             if (useThreadLocalStrategy) {
                 @Suppress("UNCHECKED_CAST")
-                threadLocalPrototypeFactory.set(PrototypeFactory(globalPrototypes.clone() as HashSet<String>))
+                threadLocalPrototypeFactory.set(JvmPrototypeFactory(globalPrototypes.clone() as HashSet<String>))
             } else {
-                globalStaticDefault = PrototypeFactory(globalPrototypes)
+                globalStaticDefault = JvmPrototypeFactory(globalPrototypes)
             }
             return
         }
         synchronized(currentStaticFactory) {
             if (useThreadLocalStrategy) {
                 @Suppress("UNCHECKED_CAST")
-                threadLocalPrototypeFactory.set(PrototypeFactory(globalPrototypes.clone() as HashSet<String>))
+                threadLocalPrototypeFactory.set(JvmPrototypeFactory(globalPrototypes.clone() as HashSet<String>))
             } else {
-                globalStaticDefault = PrototypeFactory(globalPrototypes)
+                globalStaticDefault = JvmPrototypeFactory(globalPrototypes)
             }
         }
     }

--- a/commcare-core/src/main/java/org/javarosa/core/util/externalizable/ExtUtil.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/util/externalizable/ExtUtil.kt
@@ -130,7 +130,7 @@ class ExtUtil {
         ): Any {
             return when {
                 Externalizable::class.java.isAssignableFrom(type) -> {
-                    val ext = PrototypeFactory.getInstance(type) as Externalizable
+                    val ext = JvmPrototypeFactory.getInstance(type) as Externalizable
                     ext.readExternal(`in`, pf ?: defaultPrototypes())
                     ext
                 }

--- a/commcare-core/src/main/java/org/javarosa/core/util/externalizable/ExtWrapTagged.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/util/externalizable/ExtWrapTagged.kt
@@ -70,7 +70,7 @@ class ExtWrapTagged : ExternalizableWrapper {
                     val t = e.next()
                     if (WRAPPER_CODES[t]!! == wrapperCode) {
                         try {
-                            type = PrototypeFactory.getInstance(t) as ExternalizableWrapper
+                            type = JvmPrototypeFactory.getInstance(t) as ExternalizableWrapper
                         } catch (ccoe: CannotCreateObjectException) {
                             throw CannotCreateObjectException(
                                 "Serious problem: cannot create built-in ExternalizableWrapper [${t.name}]"
@@ -87,7 +87,7 @@ class ExtWrapTagged : ExternalizableWrapper {
                 type.metaReadExternal(`in`, pf)
                 return type
             } else {
-                val type = pf.getClass(tag)
+                val type = (pf as JvmPrototypeFactory).getClass(tag)
                     ?: throw DeserializationException(
                         "No datatype registered to serialization code ${ExtUtil.printBytes(tag)}"
                     )
@@ -119,7 +119,7 @@ class ExtWrapTagged : ExternalizableWrapper {
                     type = obj.javaClass
                 }
 
-                val tag = PrototypeFactory.getClassHash(type) // cache this?
+                val tag = JvmPrototypeFactory.getClassHash(type) // cache this?
                 out.write(tag, 0, tag.size)
             }
         }

--- a/commcare-core/src/main/java/org/javarosa/core/util/externalizable/JvmPrototypeFactory.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/util/externalizable/JvmPrototypeFactory.kt
@@ -6,20 +6,16 @@ import java.util.Date
 import java.util.HashSet
 
 /**
- * ProtoType factory for serializing and deserializing persisted classes using
- * their hash codes. To use a non-default hasher, use one of the overriding constructors
- * or call setStaticHasher().
+ * JVM implementation of PrototypeFactory using Class.forName() + newInstance()
+ * for reflection-based class instantiation during deserialization.
  */
-open class PrototypeFactory {
+open class JvmPrototypeFactory : PrototypeFactory {
 
     private var classes: ArrayList<Class<*>>? = null
     private var hashes: ArrayList<ByteArray>? = null
 
     // lazy evaluation
     private var classNames: HashSet<String>?
-
-    @JvmField
-    protected var initialized: Boolean
 
     constructor() : this(null, null)
 
@@ -126,7 +122,7 @@ open class PrototypeFactory {
         return null
     }
 
-    open fun getInstance(hash: ByteArray): Any {
+    override fun getInstance(hash: ByteArray): Any {
         return getInstance(getClass(hash)!!)
     }
 
@@ -155,37 +151,9 @@ open class PrototypeFactory {
         }
 
         @JvmStatic
-        fun compareHash(a: ByteArray, b: ByteArray): Boolean {
-            if (a.size != b.size) {
-                return false
-            }
-
-            for (i in a.indices) {
-                if (a[i] != b[i]) {
-                    return false
-                }
-            }
-
-            return true
-        }
-
-        @JvmStatic
         fun setStaticHasher(staticHasher: Hasher) {
             mStaticHasher = staticHasher
-        }
-
-        @JvmStatic
-        fun getClassHashSize(): Int {
-            return mStaticHasher!!.getHashSize()
-        }
-
-        @JvmStatic
-        fun getWrapperTag(): ByteArray {
-            val bytes = ByteArray(getClassHashSize())
-            for (i in bytes.indices) {
-                bytes[i] = 0xff.toByte()
-            }
-            return bytes
+            setClassHashSize(staticHasher.getHashSize())
         }
     }
 }

--- a/commcare-core/src/main/java/org/javarosa/core/util/externalizable/LivePrototypeFactory.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/util/externalizable/LivePrototypeFactory.kt
@@ -15,7 +15,7 @@ import org.javarosa.core.api.ClassNameHasher
  *
  * @author ctsims
  */
-class LivePrototypeFactory : PrototypeFactory {
+class LivePrototypeFactory : JvmPrototypeFactory {
     private val factoryTable = HashMap<String, Class<*>>()
     private val mLiveHasher: LiveHasher
 
@@ -23,7 +23,7 @@ class LivePrototypeFactory : PrototypeFactory {
 
     private constructor(hasher: Hasher) : super() {
         this.mLiveHasher = LiveHasher(this, hasher)
-        PrototypeFactory.setStaticHasher(this.mLiveHasher)
+        JvmPrototypeFactory.setStaticHasher(this.mLiveHasher)
     }
 
     override fun lazyInit() {
@@ -40,7 +40,7 @@ class LivePrototypeFactory : PrototypeFactory {
     }
 
     override fun getInstance(hash: ByteArray): Any {
-        return PrototypeFactory.getInstance(getClass(hash)!!)
+        return JvmPrototypeFactory.getInstance(getClass(hash)!!)
     }
 
     private fun getLiveHasher(): LiveHasher {

--- a/commcare-core/src/main/java/org/javarosa/xform/parse/XFormParser.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/parse/XFormParser.kt
@@ -33,6 +33,7 @@ import org.javarosa.core.services.locale.TableLocaleSource
 import org.javarosa.core.util.DataUtil
 import org.javarosa.core.util.Interner
 import org.javarosa.core.util.ShortestCycleAlgorithm
+import org.javarosa.core.util.externalizable.JvmPrototypeFactory
 import org.javarosa.core.util.externalizable.PrototypeFactory
 import org.javarosa.model.xform.XPathReference
 import org.javarosa.xform.util.InterningKXmlParser
@@ -725,7 +726,7 @@ class XFormParser {
 
         @JvmStatic
         fun restoreDataModel(doc: Document, restorableType: Class<*>?): FormInstance {
-            val r = if (restorableType != null) PrototypeFactory.getInstance(restorableType) as? org.javarosa.core.model.util.restorable.Restorable else null
+            val r = if (restorableType != null) JvmPrototypeFactory.getInstance(restorableType) as? org.javarosa.core.model.util.restorable.Restorable else null
 
             val e = doc.rootElement
 

--- a/commcare-core/src/test/java/org/commcare/test/utilities/PersistableSandbox.java
+++ b/commcare-core/src/test/java/org/commcare/test/utilities/PersistableSandbox.java
@@ -4,6 +4,7 @@ import org.javarosa.core.api.ClassNameHasher;
 import org.javarosa.core.util.externalizable.DeserializationException;
 import org.javarosa.core.util.externalizable.ExtUtil;
 import org.javarosa.core.util.externalizable.Externalizable;
+import org.javarosa.core.util.externalizable.JvmPrototypeFactory;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 
 import java.io.ByteArrayOutputStream;
@@ -20,7 +21,7 @@ public class PersistableSandbox {
     private final PrototypeFactory factory;
     
     public PersistableSandbox() {
-        factory = new PrototypeFactory(new ClassNameHasher());
+        factory = new JvmPrototypeFactory(new ClassNameHasher());
     }
     
     public static <T extends Externalizable> byte[] serialize(T t) {

--- a/commcare-core/src/test/java/org/javarosa/core/model/test/QuestionDefTest.java
+++ b/commcare-core/src/test/java/org/javarosa/core/model/test/QuestionDefTest.java
@@ -11,6 +11,7 @@ import org.javarosa.core.services.PrototypeManager;
 import org.javarosa.core.services.locale.Localizer;
 import org.javarosa.core.test.FormParseInit;
 import org.javarosa.core.util.externalizable.ExtUtil;
+import org.javarosa.core.util.externalizable.JvmPrototypeFactory;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.form.api.FormEntryPrompt;
 import org.javarosa.model.xform.XPathReference;
@@ -33,11 +34,11 @@ public class QuestionDefTest {
         fep = new FormEntryPrompt(fpi.getFormDef(), fpi.getFormEntryModel().getFormIndex());
     }
 
-    static final PrototypeFactory pf;
+    static final JvmPrototypeFactory pf;
 
     static {
         PrototypeManager.registerPrototype("org.javarosa.model.xform.XPathReference");
-        pf = ExtUtil.defaultPrototypes();
+        pf = (JvmPrototypeFactory) ExtUtil.defaultPrototypes();
     }
 
     private void testSerialize(QuestionDef q, String msg) {

--- a/commcare-core/src/test/java/org/javarosa/core/model/utils/test/LocalizerTest.java
+++ b/commcare-core/src/test/java/org/javarosa/core/model/utils/test/LocalizerTest.java
@@ -3,7 +3,7 @@ package org.javarosa.core.model.utils.test;
 import org.javarosa.core.services.locale.Localizer;
 import org.javarosa.core.services.locale.TableLocaleSource;
 import org.javarosa.core.util.UnregisteredLocaleException;
-import org.javarosa.core.util.externalizable.PrototypeFactory;
+import org.javarosa.core.util.externalizable.JvmPrototypeFactory;
 import org.javarosa.core.util.test.ExternalizableTest;
 import org.junit.Test;
 
@@ -15,7 +15,7 @@ import static org.junit.Assert.fail;
 
 public class LocalizerTest {
     private void testSerialize(Localizer l, String msg) {
-        PrototypeFactory pf = new PrototypeFactory();
+        JvmPrototypeFactory pf = new JvmPrototypeFactory();
         pf.addClass(TableLocaleSource.class);
         ExternalizableTest.testExternalizable(l, pf, "Localizer [" + msg + "]");
     }

--- a/commcare-core/src/test/java/org/javarosa/core/util/externalizable/PlatformStreamRoundTripTest.java
+++ b/commcare-core/src/test/java/org/javarosa/core/util/externalizable/PlatformStreamRoundTripTest.java
@@ -15,18 +15,24 @@ import static org.junit.Assert.assertTrue;
 /**
  * Tests that PlatformDataInputStream and PlatformDataOutputStream produce
  * byte-compatible output with java.io.DataInputStream/DataOutputStream.
+ *
+ * Since PlatformDataInputStream/PlatformDataOutputStream are now typealiases
+ * to java.io.DataInputStream/DataOutputStream on JVM, these tests verify
+ * basic round-trip correctness using the ByteArrayOutputStream/ByteArrayInputStream pattern.
  */
 public class PlatformStreamRoundTripTest {
 
     @Test
-    public void testRoundTripByte() {
-        PlatformDataOutputStream out = new PlatformDataOutputStream();
+    public void testRoundTripByte() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
         out.writeByte(0);
         out.writeByte(127);
         out.writeByte(-128);
         out.writeByte(255); // wraps to -1 as signed byte
+        out.flush();
 
-        PlatformDataInputStream in = new PlatformDataInputStream(out.toByteArray());
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         assertEquals((byte) 0, in.readByte());
         assertEquals((byte) 127, in.readByte());
         assertEquals((byte) -128, in.readByte());
@@ -35,16 +41,18 @@ public class PlatformStreamRoundTripTest {
     }
 
     @Test
-    public void testRoundTripInt() {
-        PlatformDataOutputStream out = new PlatformDataOutputStream();
+    public void testRoundTripInt() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
         out.writeInt(0);
         out.writeInt(1);
         out.writeInt(-1);
         out.writeInt(Integer.MAX_VALUE);
         out.writeInt(Integer.MIN_VALUE);
         out.writeInt(0x12345678);
+        out.flush();
 
-        PlatformDataInputStream in = new PlatformDataInputStream(out.toByteArray());
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         assertEquals(0, in.readInt());
         assertEquals(1, in.readInt());
         assertEquals(-1, in.readInt());
@@ -55,16 +63,18 @@ public class PlatformStreamRoundTripTest {
     }
 
     @Test
-    public void testRoundTripLong() {
-        PlatformDataOutputStream out = new PlatformDataOutputStream();
+    public void testRoundTripLong() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
         out.writeLong(0L);
         out.writeLong(1L);
         out.writeLong(-1L);
         out.writeLong(Long.MAX_VALUE);
         out.writeLong(Long.MIN_VALUE);
         out.writeLong(0x123456789ABCDEF0L);
+        out.flush();
 
-        PlatformDataInputStream in = new PlatformDataInputStream(out.toByteArray());
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         assertEquals(0L, in.readLong());
         assertEquals(1L, in.readLong());
         assertEquals(-1L, in.readLong());
@@ -75,14 +85,16 @@ public class PlatformStreamRoundTripTest {
     }
 
     @Test
-    public void testRoundTripChar() {
-        PlatformDataOutputStream out = new PlatformDataOutputStream();
+    public void testRoundTripChar() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
         out.writeChar('A');
         out.writeChar('Z');
         out.writeChar('\u00E9'); // e-acute
         out.writeChar('\u4E16'); // Chinese character
+        out.flush();
 
-        PlatformDataInputStream in = new PlatformDataInputStream(out.toByteArray());
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         assertEquals('A', in.readChar());
         assertEquals('Z', in.readChar());
         assertEquals('\u00E9', in.readChar());
@@ -91,8 +103,9 @@ public class PlatformStreamRoundTripTest {
     }
 
     @Test
-    public void testRoundTripDouble() {
-        PlatformDataOutputStream out = new PlatformDataOutputStream();
+    public void testRoundTripDouble() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
         out.writeDouble(0.0);
         out.writeDouble(1.0);
         out.writeDouble(-1.0);
@@ -102,8 +115,9 @@ public class PlatformStreamRoundTripTest {
         out.writeDouble(Double.NaN);
         out.writeDouble(Double.POSITIVE_INFINITY);
         out.writeDouble(Double.NEGATIVE_INFINITY);
+        out.flush();
 
-        PlatformDataInputStream in = new PlatformDataInputStream(out.toByteArray());
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         assertEquals(0.0, in.readDouble(), 0.0);
         assertEquals(1.0, in.readDouble(), 0.0);
         assertEquals(-1.0, in.readDouble(), 0.0);
@@ -117,27 +131,31 @@ public class PlatformStreamRoundTripTest {
     }
 
     @Test
-    public void testRoundTripBoolean() {
-        PlatformDataOutputStream out = new PlatformDataOutputStream();
+    public void testRoundTripBoolean() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
         out.writeBoolean(true);
         out.writeBoolean(false);
+        out.flush();
 
-        PlatformDataInputStream in = new PlatformDataInputStream(out.toByteArray());
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         assertTrue(in.readBoolean());
         assertFalse(in.readBoolean());
         in.close();
     }
 
     @Test
-    public void testRoundTripUTF() {
-        PlatformDataOutputStream out = new PlatformDataOutputStream();
+    public void testRoundTripUTF() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
         out.writeUTF("Hello, World!");
         out.writeUTF("");
         out.writeUTF("café");
         out.writeUTF("\u4E16\u754C"); // "世界" (Chinese for "world")
         out.writeUTF("abc\u0000def"); // embedded null (modified UTF-8 edge case)
+        out.flush();
 
-        PlatformDataInputStream in = new PlatformDataInputStream(out.toByteArray());
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         assertEquals("Hello, World!", in.readUTF());
         assertEquals("", in.readUTF());
         assertEquals("café", in.readUTF());
@@ -147,12 +165,14 @@ public class PlatformStreamRoundTripTest {
     }
 
     @Test
-    public void testRoundTripBytes() {
+    public void testRoundTripBytes() throws Exception {
         byte[] data = new byte[]{1, 2, 3, 4, 5, -1, -128, 127, 0};
-        PlatformDataOutputStream out = new PlatformDataOutputStream();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
         out.write(data);
+        out.flush();
 
-        PlatformDataInputStream in = new PlatformDataInputStream(out.toByteArray());
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         byte[] result = new byte[data.length];
         in.readFully(result);
         assertArrayEquals(data, result);
@@ -160,12 +180,14 @@ public class PlatformStreamRoundTripTest {
     }
 
     @Test
-    public void testRoundTripPartialRead() {
+    public void testRoundTripPartialRead() throws Exception {
         byte[] data = new byte[]{10, 20, 30, 40, 50};
-        PlatformDataOutputStream out = new PlatformDataOutputStream();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
         out.write(data);
+        out.flush();
 
-        PlatformDataInputStream in = new PlatformDataInputStream(out.toByteArray());
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         byte[] buf = new byte[3];
         int read = in.read(buf, 0, 3);
         assertEquals(3, read);
@@ -177,8 +199,9 @@ public class PlatformStreamRoundTripTest {
     }
 
     @Test
-    public void testMixedTypes() {
-        PlatformDataOutputStream out = new PlatformDataOutputStream();
+    public void testMixedTypes() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
         out.writeInt(42);
         out.writeUTF("test");
         out.writeBoolean(true);
@@ -186,8 +209,9 @@ public class PlatformStreamRoundTripTest {
         out.writeLong(999999999999L);
         out.writeByte(0xFF);
         out.writeChar('X');
+        out.flush();
 
-        PlatformDataInputStream in = new PlatformDataInputStream(out.toByteArray());
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         assertEquals(42, in.readInt());
         assertEquals("test", in.readUTF());
         assertTrue(in.readBoolean());
@@ -201,7 +225,8 @@ public class PlatformStreamRoundTripTest {
 
     /**
      * Verify that Platform streams produce byte-identical output to java.io.Data*Stream.
-     * This ensures cross-platform serialization compatibility.
+     * Since they are now typealiases on JVM, this is trivially true but still worth
+     * keeping as a sanity check.
      */
     @Test
     public void testByteCompatibilityWithJavaIO() throws Exception {
@@ -218,8 +243,9 @@ public class PlatformStreamRoundTripTest {
         javaDos.flush();
         byte[] javaBytes = baos.toByteArray();
 
-        // Write using Platform streams
-        PlatformDataOutputStream platformDos = new PlatformDataOutputStream();
+        // Write using a second DataOutputStream (Platform streams are typealiases on JVM)
+        ByteArrayOutputStream baos2 = new ByteArrayOutputStream();
+        DataOutputStream platformDos = new DataOutputStream(baos2);
         platformDos.writeInt(42);
         platformDos.writeUTF("Hello");
         platformDos.writeBoolean(true);
@@ -227,13 +253,14 @@ public class PlatformStreamRoundTripTest {
         platformDos.writeLong(Long.MAX_VALUE);
         platformDos.writeChar('Z');
         platformDos.writeByte(99);
-        byte[] platformBytes = platformDos.toByteArray();
+        platformDos.flush();
+        byte[] platformBytes = baos2.toByteArray();
 
         // Byte-identical output
         assertArrayEquals(javaBytes, platformBytes);
 
-        // Read java.io bytes with Platform stream
-        PlatformDataInputStream platformDis = new PlatformDataInputStream(javaBytes);
+        // Read java.io bytes with a second DataInputStream
+        DataInputStream platformDis = new DataInputStream(new ByteArrayInputStream(javaBytes));
         assertEquals(42, platformDis.readInt());
         assertEquals("Hello", platformDis.readUTF());
         assertTrue(platformDis.readBoolean());
@@ -242,7 +269,7 @@ public class PlatformStreamRoundTripTest {
         assertEquals('Z', platformDis.readChar());
         assertEquals(99, platformDis.readByte());
 
-        // Read Platform bytes with java.io
+        // Read second stream bytes with java.io
         DataInputStream javaDis = new DataInputStream(new ByteArrayInputStream(platformBytes));
         assertEquals(42, javaDis.readInt());
         assertEquals("Hello", javaDis.readUTF());
@@ -254,12 +281,14 @@ public class PlatformStreamRoundTripTest {
     }
 
     @Test
-    public void testWritePartialByteArray() {
+    public void testWritePartialByteArray() throws Exception {
         byte[] data = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-        PlatformDataOutputStream out = new PlatformDataOutputStream();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
         out.write(data, 3, 4); // write bytes at indices 3,4,5,6
+        out.flush();
 
-        byte[] result = out.toByteArray();
+        byte[] result = baos.toByteArray();
         assertEquals(4, result.length);
         assertEquals(3, result[0]);
         assertEquals(4, result[1]);
@@ -268,11 +297,13 @@ public class PlatformStreamRoundTripTest {
     }
 
     @Test
-    public void testWriteSingleByte() {
-        PlatformDataOutputStream out = new PlatformDataOutputStream();
+    public void testWriteSingleByte() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
         out.write(0xAB);
+        out.flush();
 
-        PlatformDataInputStream in = new PlatformDataInputStream(out.toByteArray());
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
         assertEquals((byte) 0xAB, in.readByte());
     }
 }

--- a/commcare-core/src/test/java/org/javarosa/core/util/test/ExternalizableTest.java
+++ b/commcare-core/src/test/java/org/javarosa/core/util/test/ExternalizableTest.java
@@ -17,6 +17,7 @@ import org.javarosa.core.util.externalizable.ExtWrapTagged;
 import org.javarosa.core.util.externalizable.Externalizable;
 import org.javarosa.core.util.externalizable.ExternalizableWrapper;
 import org.javarosa.core.util.externalizable.LivePrototypeFactory;
+import org.javarosa.core.util.externalizable.JvmPrototypeFactory;
 import org.javarosa.core.util.externalizable.PrototypeFactory;
 import org.javarosa.core.util.externalizable.SerializationLimitationException;
 import org.junit.Test;
@@ -127,8 +128,8 @@ public class ExternalizableTest {
     public void doTests() {
         //base types (built-in + externalizable)
 
-        PrototypeFactory pf = new PrototypeFactory();
-        PrototypeFactory.setStaticHasher(new ClassNameHasher());
+        JvmPrototypeFactory pf = new JvmPrototypeFactory();
+        JvmPrototypeFactory.setStaticHasher(new ClassNameHasher());
 
         testExternalizable("string", String.class);
         testExternalizable(Byte.valueOf((byte)0), Byte.class);


### PR DESCRIPTION
## Summary

- Move `Externalizable` interface and `PrototypeFactory` base class to commonMain for cross-platform serialization
- Add factory functions (`createDataInputStream`, `serializeToBytes`) replacing direct constructors on expect classes (typealias actuals can't have constructors)
- Split PrototypeFactory into commonMain base + `JvmPrototypeFactory` (reflection-based) + `IosPrototypeFactory` (registration-based)
- Update all callers (ExtUtil, ExtWrapTagged, LivePrototypeFactory, PrototypeManager, XFormParser) and test files

## Details

**Problem**: `Externalizable` and `PrototypeFactory` use `PlatformDataInputStream`/`PlatformDataOutputStream` in their signatures. To move them to commonMain, the stream types must be platform-abstracted, and PrototypeFactory's JVM reflection must be separated.

**Approach**:
- `PlatformDataInputStream`/`PlatformDataOutputStream` already existed as expect/actual. Remove constructors from expect (not allowed with typealias), add factory functions instead
- `Externalizable` → commonMain (now uses platform stream types)
- `PrototypeFactory` → commonMain base class (hash comparison, wrapper tag, class hash size)
- `JvmPrototypeFactory` → src/main/java (Class.forName, newInstance, hash storage)
- `IosPrototypeFactory` → iosMain (registration map, no reflection)

**Key architectural decisions**:
- Used open class (not expect/actual) for PrototypeFactory because `actual` can't be in `src/main/java`, and `jvmMain` can't see `src/main/java` classes (Hasher, ClassNameHasher)
- JVM typealias approach means zero changes needed to 85+ Externalizable implementor files

## Files changed (22)
- 4 new files (commonMain PrototypeFactory, commonMain Externalizable, IosPrototypeFactory, JvmPrototypeFactory)
- 1 deleted file (old PrototypeFactory in src/main/java, replaced by commonMain + JvmPrototypeFactory)
- 6 modified platform stream files (commonMain, jvmMain, iosMain)
- 5 modified callers (ExtUtil, ExtWrapTagged, LivePrototypeFactory, PrototypeManager, XFormParser)
- 1 modified CLI file (MockDataUtils)
- 5 modified test files

## Test plan
- [x] `compileCommonMainKotlinMetadata` passes
- [x] `compileKotlinJvm` passes
- [x] `jvmTest` passes — all tests green
- [x] PlatformDataStreamTest (commonTest) uses factory functions

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)