### PR TITLE
docs: Phase 3 completion report + Phase 4 plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,28 +71,45 @@ commcare-ios/
 
 **Phase 2 Complete.** All 9 waves done. 88 files in commonMain, 21 cross-platform tests pass on both JVM and iOS. See `docs/plans/2026-03-10-phase2-completion-report.md`.
 
-**Phase 3: Engine on iOS** — Resolve JVM dependency blockers and move core engine code to commonMain so it's callable from iOS.
+**Phase 3: Engine on iOS** — Partially complete. Moved 96 files to commonMain (88→184), removed JVM collections, abstracted serialization. Core model classes blocked by 67 files with direct JVM deps. See `docs/plans/2026-03-11-phase3-completion-report.md`.
 
 | Wave | Group | Files | Issue | Status |
 |------|-------|-------|-------|--------|
 | 1 | Replace JVM collections | 265 | #64 | Done (PR #74) |
-| 2 | Migrate XML consumers to PlatformXmlParser | ~55 | #65 | Open |
+| 2 | Migrate XML consumers to PlatformXmlParser | ~55 | #65 | Done (partial) |
 | 3 | Replace Date and regex | ~32 | #66 | Done (PR #100) |
 | 4 | Abstract serialization framework | ~10 new | #67 | Done (PR #101) |
-| 5 | Extend java.io abstractions | ~160 | #68 | Open |
-| 6 | Move XPath engine to commonMain | ~80 | #69 | Open |
-| 7 | Move XForm/cases/session to commonMain | ~150+ | #70 | Open |
-| 8 | Real iOS platform implementations | ~10 | #71 | Open |
-| 9 | Integration testing and validation | ~5 new | #72 | Open |
+| 5 | Extend java.io abstractions | ~160 | #68 | Done (partial) |
+| 6 | Move XPath engine to commonMain | ~80 | #69 | Done (partial) |
+| 7 | Move XForm/cases/session to commonMain | ~150+ | #70 | Done (27 files, PR #109) |
+| 8 | Real iOS platform implementations | ~10 | #71 | Blocked |
+| 9 | Integration testing and validation | ~5 new | #72 | Blocked |
 
-**Next wave**: Wave 5 (Issue #68) — Extend java.io abstractions. Waves 2 and 5 can proceed in parallel.
+**Phase 4: Deep Migration** — Remove JVM dependencies from 67 blocker files + convert 13 Java files to unlock ~390 transitively-blocked files.
 
-**Dependency graph:** Wave 1 first (most pervasive). Waves 2-3 can parallel with Wave 4. Wave 5 after Wave 4. Waves 6-7 after 1-5. Waves 8-9 after 7.
+| Wave | Group | Files | Issue | Status |
+|------|-------|-------|-------|--------|
+| 1 | Quick wins (Math, Locale, Objects, synchronized) | ~10 | #111 | Open |
+| 2 | Convert remaining Java files to Kotlin | 13 | #112 | Open |
+| 3 | Complete Date/Calendar migration | ~7 | #113 | Open |
+| 4 | Migrate xmlpull/kxml2 consumers | 9 | #114 | Open |
+| 5 | Abstract org.json to PlatformJson | 8 | #115 | Open |
+| 6 | Abstract io.reactivex and tracing | 7 | #116 | Open |
+| 7 | Abstract java.io and java.net | ~18 | #117 | Open |
+| 8 | KClass conversion for serialization | ~16 | #118 | Open |
+| 9 | Move HTTP/network files to jvmMain | 7 | #119 | Open |
+| 10 | Bulk migration to commonMain | 390+ | #120 | Open |
+
+**Next wave**: Wave 1 (Issue #111) — quick wins. Waves 1-9 can largely run in parallel. Wave 10 depends on all.
+
+**Plan**: `docs/plans/2026-03-11-phase4-deep-migration-plan.md`
 
 ## Key Docs
 
 **Plans:**
 - **Design**: `docs/plans/2026-03-07-commcare-ios-design.md` — full architecture, phasing, verification strategy
+- **Phase 4 plan**: `docs/plans/2026-03-11-phase4-deep-migration-plan.md` — targeted JVM dep removal from 67 blocker files, wave details
+- **Phase 3 completion**: `docs/plans/2026-03-11-phase3-completion-report.md` — 184 commonMain files, blocker analysis, remaining JVM deps
 - **Phase 3 plan**: `docs/plans/2026-03-10-phase3-engine-on-ios-plan.md` — wave details, dependency analysis, serialization framework strategy
 - **Phase 2 plan**: `docs/plans/2026-03-10-phase2-kmp-multiplatform-plan.md` — wave details, dependency analysis, expect/actual strategy
 - **Phase 2 completion**: `docs/plans/2026-03-10-phase2-completion-report.md` — file distribution, test coverage, known limitations, Phase 3 readiness

--- a/docs/plans/2026-03-11-phase3-completion-report.md
+++ b/docs/plans/2026-03-11-phase3-completion-report.md
@@ -1,0 +1,102 @@
+# Phase 3: Engine on iOS — Completion Report
+
+**Date:** 2026-03-11
+**Status:** Partially complete (ceiling reached)
+
+---
+
+## Summary
+
+Phase 3 aimed to move core engine code from `src/main/java` to `src/commonMain/kotlin` so that XPath evaluation, XForm parsing, case management, and session navigation would be callable from iOS. The phase achieved significant JVM dependency removal and moved 96 additional files to commonMain, but hit a natural ceiling: the core model classes (TreeReference, TreeElement, EvaluationContext, FormDef, etc.) have deep transitive dependencies on JVM APIs that require targeted refactoring rather than bulk migration.
+
+---
+
+## What Was Done
+
+### Wave 1: Replace JVM collections (PR #74)
+- Replaced `Vector<T>` → `MutableList<T>`, `Hashtable<K,V>` → `MutableMap<K,V>`, `Stack<T>` → `ArrayDeque<T>`, `Enumeration<T>` → `Iterator<T>` across 265 files
+- Zero imports of java.util.Vector/Hashtable/Stack/Enumeration remaining
+
+### Waves 2-6: Platform abstractions and dependency removal (PRs #88, #91, #95, #101-105)
+- Migrated XML consumers to PlatformXmlParser (partial — 9 files still use kxml2/xmlpull directly)
+- Replaced java.util.Date with PlatformDate abstraction
+- Replaced java.util.regex with Kotlin Regex
+- Extended serialization framework (Externalizable → expect/actual, PrototypeFactory with KClass)
+- Extended java.io abstractions (PlatformDataInputStream/OutputStream)
+- Moved XPath engine components to commonMain (partial)
+
+### Wave 7: Move XForm/cases/session to commonMain (PRs #105, #109)
+- Moved 27 files to commonMain (bringing total from 157 → 184)
+- Converted 8 Java files to Kotlin (32 → 13 Java files remaining)
+- Converted storage interfaces from `Class<*>` to `KClass<*>` with factory lambda pattern
+- Added explicit `kotlin.jvm.*` imports to 137 files for commonMain compatibility
+- Replaced `Math.xxx` with `kotlin.math.xxx` in 22 files
+- Replaced `java.lang.Double.valueOf()` with Kotlin idioms in 12 files
+- Moved `QueryContext.getQueryCache(Class<T>)` to jvmMain extension function
+
+### Waves 8-9: Blocked
+- Real iOS platform implementations and integration testing could not proceed because core engine classes remain in main/java
+
+---
+
+## File Distribution (end of Phase 3)
+
+| Source Set | Files | Change from Phase 2 |
+|-----------|-------|---------------------|
+| commonMain | 184 .kt | +96 from 88 |
+| jvmMain | 21 .kt | +11 from 10 |
+| iosMain | 21 .kt | +10 from 11 |
+| commonTest | 6 .kt | unchanged |
+| src/main/java | 470 .kt, 13 .java | -97 .kt, -19 .java |
+
+---
+
+## Remaining JVM Dependencies in src/main/java
+
+| Blocker | Files | Notes |
+|---------|-------|-------|
+| kxml2/xmlpull direct imports | 9 | XForm parser, serializers |
+| java.io.* direct imports | 16 | Streams, File, URI |
+| java.net.* imports | 7 | URL, URLConnection |
+| okhttp3/retrofit2 imports | 7 | HTTP client layer |
+| io.reactivex (RxJava) | 4 | Menu, Text, Entry, MenuDisplayable |
+| javax.crypto/java.security | 3 | Crypto operations |
+| io.opentracing | 1 | FormDef |
+| Transitive deps (no direct JVM imports) | ~420 | Blocked by core model classes |
+
+---
+
+## Why Further Migration Stalled
+
+The ~420 "pure" files (no direct JVM imports) can't move because they depend on core model classes that themselves depend on JVM APIs:
+
+1. **EvaluationContext** → depends on TreeReference, XPath, java.io
+2. **TreeReference / TreeElement** → depend on XPath engine, serialization with Class<*>
+3. **FormDef** → depends on io.opentracing, java.io
+4. **DataInstance / FormInstance** → depend on serialization framework
+5. **Text / Entry / Menu** → depend on io.reactivex
+
+Moving these requires targeted refactoring of each core class to abstract its JVM dependencies.
+
+---
+
+## Key Technical Decisions
+
+1. **KClass + factory lambda pattern**: Replaced `Class<T>` reflection with `KClass<T>` + `() -> T` lambdas. Java callers use jvmMain extension functions.
+2. **Iterative compiler-validated migration**: Move all candidates → compile → rollback failures → repeat. Safely identified moveable files.
+3. **`fun interface`** for SAM conversion: Used for `TransactionParserFactory` to preserve Java lambda compatibility.
+4. **`kotlin.jvm.*` explicit imports**: Required in commonMain files — the annotations work cross-platform when explicitly imported.
+
+---
+
+## Tests
+
+- **710+ JVM tests passing** (`./gradlew jvmTest` — BUILD SUCCESSFUL)
+- **21 cross-platform tests passing** (commonTest)
+- No regressions introduced
+
+---
+
+## Assessment
+
+Phase 3 achieved ~50% of its goal. The "easy" files moved (leaf types, interfaces, simple models), but the core engine graph remains JVM-bound. Further progress requires a different approach: instead of bulk migration, targeted refactoring of the ~10 core blocker classes to abstract their JVM dependencies. This is the focus of Phase 4.

--- a/docs/plans/2026-03-11-phase4-deep-migration-plan.md
+++ b/docs/plans/2026-03-11-phase4-deep-migration-plan.md
@@ -1,0 +1,125 @@
+# Phase 4: Deep Migration — Implementation Plan
+
+**Date:** 2026-03-11
+**Status:** Draft
+**Prerequisite:** Phase 3 complete (184 files in commonMain, 470 .kt + 13 .java in main/java).
+
+---
+
+## Goal
+
+Remove JVM dependencies from the 67 Kotlin files and 13 Java files that are blocking ~390 transitively-dependent files from moving to commonMain. This unlocks moving the core engine (EvaluationContext, TreeReference, TreeElement, XPath, case management, session) to commonMain.
+
+**Exit criteria:** 400+ files in commonMain. Core engine APIs (XPath evaluation, case management) accessible from iOS. All 710+ JVM tests pass.
+
+---
+
+## Current State
+
+| Source Set | Files |
+|-----------|-------|
+| commonMain | 184 .kt |
+| jvmMain | 21 .kt |
+| iosMain | 21 .kt |
+| src/main/java | 470 .kt, 13 .java |
+
+### Blocker Analysis
+
+67 Kotlin files have direct JVM imports. 13 Java files need conversion. The remaining 390 Kotlin files have zero JVM imports but are transitively blocked.
+
+| Blocker Category | Files | Strategy |
+|-----------------|-------|----------|
+| xmlpull/kxml2 (9) | XFormParser, XFormSerializer, etc. | Migrate to PlatformXmlParser |
+| org.json (8) | Graph config, JsonUtils, XPathJsonPropertyFunc | Create PlatformJson abstraction |
+| java.io (12) | ElementParser, ResourceTable, FileUtils, etc. | Extend PlatformFile/PlatformIO |
+| okhttp3/retrofit2 (7) | CommCareNetworkService, ModernHttpRequester, etc. | Move to jvmMain (JVM-only) |
+| java.util.Date/Calendar (7) | DateUtils, CalendarUtils, StringUtils, etc. | Complete PlatformDate migration |
+| java.net (6) | PostRequest, RemoteQueryDatum, etc. | Extend PlatformUrl |
+| io.reactivex (4) | Text, Entry, Menu, MenuDisplayable | Abstract to interface |
+| javax.crypto (3) | CryptUtil, EncryptionUtils, FileBitCache | Complete PlatformCrypto migration |
+| datadog/opentracing (3) | FormDef, FormEntryController, FormEntryPrompt | Abstract to interface |
+| java.util.Locale/concurrent (6) | EntitySortUtil, ColorUtils, etc. | Targeted replacements |
+| Class<*>/.javaClass (16) | ExtUtil, ExtWrap*, Hasher, etc. | KClass conversion |
+| Java files (13) | TransactionParser, Reference, etc. | Convert to Kotlin |
+
+---
+
+## Wave Plan
+
+### Wave 1: Quick wins — java.lang, java.util.Locale, synchronized, Objects
+**Files:** ~10
+**What:** Replace `java.lang.Math` → `kotlin.math`, `java.util.Locale` → expect/actual, `synchronized` → expect/actual or remove, `Objects.equals` → `==`
+**Risk:** Low
+
+### Wave 2: Convert remaining Java files to Kotlin
+**Files:** 13 Java → Kotlin
+**What:** TransactionParser, SimpleNode, TreeBuilder, DataModelPullParser, VirtualInstances, Reference, ReferenceHandler, ReferenceManager, ResourceReference, ReleasedOnTimeSupportedReference, ClassNameHasher, IDataPointer, TreeElementParser
+**Risk:** Medium — must maintain Java interop for test files that import these
+
+### Wave 3: Complete Date/Calendar migration
+**Files:** ~7
+**What:** Replace remaining `java.util.Date`, `java.util.Calendar`, `java.util.TimeZone`, `java.text.SimpleDateFormat` with PlatformDate abstractions
+**Risk:** Medium — date formatting is tricky cross-platform
+
+### Wave 4: Migrate xmlpull/kxml2 consumers
+**Files:** 9
+**What:** Replace remaining `org.kxml2`/`org.xmlpull` imports with PlatformXmlParser
+**Risk:** Medium — XFormParser is large and complex
+
+### Wave 5: Abstract org.json to PlatformJson
+**Files:** 8
+**What:** Create expect/actual PlatformJson abstraction, migrate graph config and JsonUtils
+**Risk:** Medium — need iOS JSON implementation
+
+### Wave 6: Abstract io.reactivex and tracing
+**Files:** 7
+**What:** Replace `io.reactivex.Single` with callback interface or expect/actual. Replace `datadog`/`opentracing` with no-op interface.
+**Risk:** Medium — reactive patterns are architectural
+
+### Wave 7: Abstract java.io and java.net
+**Files:** ~18
+**What:** Replace remaining java.io.File, InputStream, OutputStream, java.net.URL with platform abstractions
+**Risk:** Medium — many file I/O patterns
+
+### Wave 8: KClass conversion for serialization
+**Files:** ~16
+**What:** Replace `Class<*>`, `.javaClass`, `Class.forName()` in ExtUtil, ExtWrap*, Hasher, LivePrototypeFactory
+**Risk:** High — serialization is deeply embedded
+
+### Wave 9: Move HTTP/network files to jvmMain
+**Files:** 7
+**What:** Move okhttp3/retrofit2 consumers to jvmMain. Create commonMain interfaces if needed.
+**Risk:** Low — these are inherently JVM-specific
+
+### Wave 10: Bulk migration attempt
+**Files:** 390+
+**What:** Move all remaining pure files to commonMain. Iterate compiler-validation until stable.
+**Risk:** Medium — may discover additional hidden dependencies
+
+---
+
+## Dependency Graph
+
+```
+Wave 1 (quick wins) ─────────────────────────────────────┐
+Wave 2 (Java→Kotlin) ────────────────────────────────────│
+Wave 3 (Date) ────────────────────────────────────────────├─→ Wave 10 (bulk move)
+Wave 4 (xmlpull) ─────────────────────────────────────────│
+Wave 5 (json) ────────────────────────────────────────────│
+Wave 6 (rxjava+tracing) ─────────────────────────────────│
+Wave 7 (java.io+net) ────────────────────────────────────│
+Wave 8 (KClass) ──────────────────────────────────────────│
+Wave 9 (jvmMain move) ───────────────────────────────────┘
+```
+
+Waves 1-9 can largely run in parallel. Wave 10 depends on all of them.
+
+---
+
+## Acceptance Criteria
+
+- [ ] 400+ files in commonMain
+- [ ] Zero JVM-specific imports in commonMain files
+- [ ] All 710+ JVM tests pass
+- [ ] `compileCommonMainKotlinMetadata` succeeds
+- [ ] Core engine types (EvaluationContext, TreeReference, TreeElement, XPathExpression) are in commonMain


### PR DESCRIPTION
## Summary
- Phase 3 completion report documenting 184 commonMain files and blocker analysis
- Phase 4 deep migration plan: targeted removal of JVM deps from 67 blocker files across 10 waves
- CLAUDE.md updated with Phase 4 wave table and issue links (#111-#120)

## Test plan
- [ ] Doc-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)