### PR TITLE
Phase 4 Wave 3: Abstract Date/Calendar/TimeZone

### DIFF
--- a/commcare-core/src/commonMain/kotlin/org/javarosa/core/model/utils/PlatformCalendar.kt
+++ b/commcare-core/src/commonMain/kotlin/org/javarosa/core/model/utils/PlatformCalendar.kt
@@ -1,0 +1,46 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package org.javarosa.core.model.utils
+
+/**
+ * Cross-platform calendar representation for date field extraction and construction.
+ * On JVM: typealiased to java.util.Calendar.
+ * On iOS: wraps NSCalendar/NSDateComponents.
+ */
+expect class PlatformCalendar {
+    var time: PlatformDate
+    var timeZone: PlatformTimeZone
+    fun get(field: Int): Int
+    fun set(field: Int, value: Int)
+    fun add(field: Int, amount: Int)
+}
+
+expect fun platformCalendarInstance(): PlatformCalendar
+expect fun platformCalendarInstance(tz: PlatformTimeZone): PlatformCalendar
+
+// Field constants
+expect val CALENDAR_YEAR: Int
+expect val CALENDAR_MONTH: Int
+expect val CALENDAR_DAY_OF_MONTH: Int
+expect val CALENDAR_HOUR_OF_DAY: Int
+expect val CALENDAR_MINUTE: Int
+expect val CALENDAR_SECOND: Int
+expect val CALENDAR_MILLISECOND: Int
+expect val CALENDAR_DAY_OF_WEEK: Int
+
+// Month constants (0-based on JVM: January=0)
+expect val MONTH_JANUARY: Int
+expect val MONTH_FEBRUARY: Int
+expect val MONTH_APRIL: Int
+expect val MONTH_JUNE: Int
+expect val MONTH_SEPTEMBER: Int
+expect val MONTH_NOVEMBER: Int
+
+// Day-of-week constants (1-based on JVM: Sunday=1)
+expect val DAY_SUNDAY: Int
+expect val DAY_MONDAY: Int
+expect val DAY_TUESDAY: Int
+expect val DAY_WEDNESDAY: Int
+expect val DAY_THURSDAY: Int
+expect val DAY_FRIDAY: Int
+expect val DAY_SATURDAY: Int

--- a/commcare-core/src/commonMain/kotlin/org/javarosa/core/model/utils/PlatformDateFormatting.kt
+++ b/commcare-core/src/commonMain/kotlin/org/javarosa/core/model/utils/PlatformDateFormatting.kt
@@ -1,0 +1,16 @@
+package org.javarosa.core.model.utils
+
+/**
+ * Cross-platform date formatting/parsing (replaces SimpleDateFormat).
+ * On JVM: delegates to java.text.SimpleDateFormat.
+ * On iOS: uses NSDateFormatter.
+ */
+
+/** Format epoch millis using the given pattern and optional timezone */
+expect fun platformFormatDate(millis: Long, pattern: String, timezoneName: String? = null): String
+
+/** Format a PlatformDate using the given pattern */
+expect fun platformFormatPlatformDate(date: PlatformDate, pattern: String): String
+
+/** Parse a date string using the given pattern. Returns null if unparseable. */
+expect fun platformParseDate(dateString: String, pattern: String): PlatformDate?

--- a/commcare-core/src/commonMain/kotlin/org/javarosa/core/model/utils/PlatformTimeZone.kt
+++ b/commcare-core/src/commonMain/kotlin/org/javarosa/core/model/utils/PlatformTimeZone.kt
@@ -1,0 +1,16 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package org.javarosa.core.model.utils
+
+/**
+ * Cross-platform timezone representation.
+ * On JVM: typealiased to java.util.TimeZone.
+ * On iOS: wraps NSTimeZone.
+ */
+expect class PlatformTimeZone {
+    fun getOffset(date: Long): Int
+    fun getOffset(era: Int, year: Int, month: Int, day: Int, dayOfWeek: Int, millisOfDay: Int): Int
+}
+
+expect fun platformDefaultTimeZone(): PlatformTimeZone
+expect fun platformTimeZone(id: String): PlatformTimeZone

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/core/model/utils/PlatformCalendar.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/core/model/utils/PlatformCalendar.kt
@@ -1,0 +1,151 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package org.javarosa.core.model.utils
+
+import platform.Foundation.*
+
+actual class PlatformCalendar(
+    private val calendar: NSCalendar,
+    private var components: NSDateComponents,
+    private var _timeZone: PlatformTimeZone
+) {
+    actual var time: PlatformDate
+        get() {
+            val nsDate = calendar.dateFromComponents(components) ?: NSDate()
+            return PlatformDate((nsDate.timeIntervalSince1970 * 1000).toLong())
+        }
+        set(value) {
+            val nsDate = NSDate.dateWithTimeIntervalSince1970(value.getTime() / 1000.0)
+            calendar.timeZone = _timeZone.nsTimeZone
+            components = calendar.components(
+                NSCalendarUnitYear or NSCalendarUnitMonth or NSCalendarUnitDay or
+                        NSCalendarUnitHour or NSCalendarUnitMinute or NSCalendarUnitSecond or
+                        NSCalendarUnitNanosecond or NSCalendarUnitWeekday,
+                nsDate
+            )
+        }
+
+    actual var timeZone: PlatformTimeZone
+        get() = _timeZone
+        set(value) {
+            _timeZone = value
+            calendar.timeZone = value.nsTimeZone
+            // Re-extract components in new timezone
+            val nsDate = calendar.dateFromComponents(components) ?: NSDate()
+            components = calendar.components(
+                NSCalendarUnitYear or NSCalendarUnitMonth or NSCalendarUnitDay or
+                        NSCalendarUnitHour or NSCalendarUnitMinute or NSCalendarUnitSecond or
+                        NSCalendarUnitNanosecond or NSCalendarUnitWeekday,
+                nsDate
+            )
+        }
+
+    actual fun get(field: Int): Int {
+        return when (field) {
+            0 -> components.year.toInt()        // YEAR
+            1 -> (components.month - 1).toInt() // MONTH (0-based)
+            2 -> components.day.toInt()          // DAY_OF_MONTH
+            3 -> components.hour.toInt()         // HOUR_OF_DAY
+            4 -> components.minute.toInt()       // MINUTE
+            5 -> components.second.toInt()       // SECOND
+            6 -> ((components.nanosecond / 1_000_000).toInt()) // MILLISECOND
+            7 -> components.weekday.toInt()      // DAY_OF_WEEK (1=Sunday)
+            else -> 0
+        }
+    }
+
+    actual fun set(field: Int, value: Int) {
+        when (field) {
+            0 -> components.year = value.toLong()
+            1 -> components.month = (value + 1).toLong() // Convert 0-based to 1-based
+            2 -> components.day = value.toLong()
+            3 -> components.hour = value.toLong()
+            4 -> components.minute = value.toLong()
+            5 -> components.second = value.toLong()
+            6 -> components.nanosecond = (value * 1_000_000).toLong()
+            7 -> components.weekday = value.toLong()
+        }
+    }
+
+    actual fun add(field: Int, amount: Int) {
+        val addComponents = NSDateComponents()
+        when (field) {
+            0 -> addComponents.year = amount.toLong()
+            1 -> addComponents.month = amount.toLong()
+            2 -> addComponents.day = amount.toLong()
+            3 -> addComponents.hour = amount.toLong()
+            4 -> addComponents.minute = amount.toLong()
+            5 -> addComponents.second = amount.toLong()
+            6 -> {
+                // Add milliseconds as nanoseconds
+                val currentNs = components.nanosecond
+                val totalMs = (currentNs / 1_000_000) + amount
+                addComponents.second = (totalMs / 1000).toLong()
+                val remainingMs = totalMs % 1000
+                components.nanosecond = (remainingMs * 1_000_000)
+            }
+        }
+        val nsDate = calendar.dateFromComponents(components) ?: return
+        val newDate = calendar.dateByAddingComponents(addComponents, nsDate, 0u) ?: return
+        components = calendar.components(
+            NSCalendarUnitYear or NSCalendarUnitMonth or NSCalendarUnitDay or
+                    NSCalendarUnitHour or NSCalendarUnitMinute or NSCalendarUnitSecond or
+                    NSCalendarUnitNanosecond or NSCalendarUnitWeekday,
+            newDate
+        )
+    }
+}
+
+actual fun platformCalendarInstance(): PlatformCalendar {
+    val cal = NSCalendar.currentCalendar
+    val tz = platformDefaultTimeZone()
+    cal.timeZone = tz.nsTimeZone
+    val now = NSDate()
+    val components = cal.components(
+        NSCalendarUnitYear or NSCalendarUnitMonth or NSCalendarUnitDay or
+                NSCalendarUnitHour or NSCalendarUnitMinute or NSCalendarUnitSecond or
+                NSCalendarUnitNanosecond or NSCalendarUnitWeekday,
+        now
+    )
+    return PlatformCalendar(cal, components, tz)
+}
+
+actual fun platformCalendarInstance(tz: PlatformTimeZone): PlatformCalendar {
+    val cal = NSCalendar.currentCalendar
+    cal.timeZone = tz.nsTimeZone
+    val now = NSDate()
+    val components = cal.components(
+        NSCalendarUnitYear or NSCalendarUnitMonth or NSCalendarUnitDay or
+                NSCalendarUnitHour or NSCalendarUnitMinute or NSCalendarUnitSecond or
+                NSCalendarUnitNanosecond or NSCalendarUnitWeekday,
+        now
+    )
+    return PlatformCalendar(cal, components, tz)
+}
+
+// Field constants (must match JVM Calendar values for cross-platform compatibility)
+actual val CALENDAR_YEAR: Int = 0
+actual val CALENDAR_MONTH: Int = 1
+actual val CALENDAR_DAY_OF_MONTH: Int = 2
+actual val CALENDAR_HOUR_OF_DAY: Int = 3
+actual val CALENDAR_MINUTE: Int = 4
+actual val CALENDAR_SECOND: Int = 5
+actual val CALENDAR_MILLISECOND: Int = 6
+actual val CALENDAR_DAY_OF_WEEK: Int = 7
+
+// Month constants (0-based to match JVM Calendar)
+actual val MONTH_JANUARY: Int = 0
+actual val MONTH_FEBRUARY: Int = 1
+actual val MONTH_APRIL: Int = 3
+actual val MONTH_JUNE: Int = 5
+actual val MONTH_SEPTEMBER: Int = 8
+actual val MONTH_NOVEMBER: Int = 10
+
+// Day-of-week constants (1-based, Sunday=1 to match JVM Calendar)
+actual val DAY_SUNDAY: Int = 1
+actual val DAY_MONDAY: Int = 2
+actual val DAY_TUESDAY: Int = 3
+actual val DAY_WEDNESDAY: Int = 4
+actual val DAY_THURSDAY: Int = 5
+actual val DAY_FRIDAY: Int = 6
+actual val DAY_SATURDAY: Int = 7

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/core/model/utils/PlatformDateFormatting.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/core/model/utils/PlatformDateFormatting.kt
@@ -1,0 +1,35 @@
+package org.javarosa.core.model.utils
+
+import platform.Foundation.*
+
+actual fun platformFormatDate(millis: Long, pattern: String, timezoneName: String?): String {
+    val formatter = NSDateFormatter()
+    formatter.dateFormat = convertJavaPatternToNS(pattern)
+    formatter.locale = NSLocale.localeWithLocaleIdentifier("en_US_POSIX")
+    if (timezoneName != null) {
+        formatter.timeZone = NSTimeZone.timeZoneWithName(timezoneName) ?: NSTimeZone.localTimeZone
+    }
+    val date = NSDate.dateWithTimeIntervalSince1970(millis / 1000.0)
+    return formatter.stringFromDate(date)
+}
+
+actual fun platformFormatPlatformDate(date: PlatformDate, pattern: String): String {
+    return platformFormatDate(date.getTime(), pattern)
+}
+
+actual fun platformParseDate(dateString: String, pattern: String): PlatformDate? {
+    val formatter = NSDateFormatter()
+    formatter.dateFormat = convertJavaPatternToNS(pattern)
+    formatter.locale = NSLocale.localeWithLocaleIdentifier("en_US_POSIX")
+    val nsDate = formatter.dateFromString(dateString) ?: return null
+    return PlatformDate((nsDate.timeIntervalSince1970 * 1000).toLong())
+}
+
+/** Convert common Java SimpleDateFormat patterns to NSDateFormatter patterns */
+private fun convertJavaPatternToNS(javaPattern: String): String {
+    // Most patterns are the same between Java and NSDateFormatter
+    // Key differences: Java uses 'y' for year, NSDateFormatter also uses 'y'
+    // Java 'EEE' = short day name, same in NSDateFormatter
+    // Java uses single-quoted literals, NSDateFormatter also uses single quotes
+    return javaPattern
+}

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/core/model/utils/PlatformTimeZone.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/core/model/utils/PlatformTimeZone.kt
@@ -1,0 +1,32 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package org.javarosa.core.model.utils
+
+import platform.Foundation.NSTimeZone
+import platform.Foundation.localTimeZone
+import platform.Foundation.secondsFromGMTForDate
+import platform.Foundation.timeZoneWithName
+
+actual class PlatformTimeZone(val nsTimeZone: NSTimeZone) {
+    actual fun getOffset(date: Long): Int {
+        val nsDate = platform.Foundation.NSDate.dateWithTimeIntervalSince1970(date / 1000.0)
+        return (nsTimeZone.secondsFromGMTForDate(nsDate) * 1000).toInt()
+    }
+
+    actual fun getOffset(era: Int, year: Int, month: Int, day: Int, dayOfWeek: Int, millisOfDay: Int): Int {
+        // Approximate: construct a date from the components and get offset
+        val cal = platform.Foundation.NSCalendar.currentCalendar
+        val components = platform.Foundation.NSDateComponents()
+        components.year = year.toLong()
+        components.month = (month + 1).toLong() // NSCalendar months are 1-based
+        components.day = day.toLong()
+        val nsDate = cal.dateFromComponents(components) ?: return 0
+        return (nsTimeZone.secondsFromGMTForDate(nsDate) * 1000).toInt()
+    }
+}
+
+actual fun platformDefaultTimeZone(): PlatformTimeZone =
+    PlatformTimeZone(NSTimeZone.localTimeZone)
+
+actual fun platformTimeZone(id: String): PlatformTimeZone =
+    PlatformTimeZone(NSTimeZone.timeZoneWithName(id) ?: NSTimeZone.localTimeZone)

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/core/model/utils/PlatformCalendar.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/core/model/utils/PlatformCalendar.kt
@@ -1,0 +1,50 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package org.javarosa.core.model.utils
+
+import java.util.Calendar
+
+actual class PlatformCalendar(val javaCal: Calendar) {
+    actual var time: PlatformDate
+        get() = javaCal.time
+        set(value) { javaCal.time = value }
+
+    actual var timeZone: PlatformTimeZone
+        get() = PlatformTimeZone(javaCal.timeZone)
+        set(value) { javaCal.timeZone = value.javaTimeZone }
+
+    actual fun get(field: Int): Int = javaCal.get(field)
+    actual fun set(field: Int, value: Int) = javaCal.set(field, value)
+    actual fun add(field: Int, amount: Int) = javaCal.add(field, amount)
+}
+
+actual fun platformCalendarInstance(): PlatformCalendar = PlatformCalendar(Calendar.getInstance())
+actual fun platformCalendarInstance(tz: PlatformTimeZone): PlatformCalendar =
+    PlatformCalendar(Calendar.getInstance(tz.javaTimeZone))
+
+// Field constants
+actual val CALENDAR_YEAR: Int = Calendar.YEAR
+actual val CALENDAR_MONTH: Int = Calendar.MONTH
+actual val CALENDAR_DAY_OF_MONTH: Int = Calendar.DAY_OF_MONTH
+actual val CALENDAR_HOUR_OF_DAY: Int = Calendar.HOUR_OF_DAY
+actual val CALENDAR_MINUTE: Int = Calendar.MINUTE
+actual val CALENDAR_SECOND: Int = Calendar.SECOND
+actual val CALENDAR_MILLISECOND: Int = Calendar.MILLISECOND
+actual val CALENDAR_DAY_OF_WEEK: Int = Calendar.DAY_OF_WEEK
+
+// Month constants
+actual val MONTH_JANUARY: Int = Calendar.JANUARY
+actual val MONTH_FEBRUARY: Int = Calendar.FEBRUARY
+actual val MONTH_APRIL: Int = Calendar.APRIL
+actual val MONTH_JUNE: Int = Calendar.JUNE
+actual val MONTH_SEPTEMBER: Int = Calendar.SEPTEMBER
+actual val MONTH_NOVEMBER: Int = Calendar.NOVEMBER
+
+// Day-of-week constants
+actual val DAY_SUNDAY: Int = Calendar.SUNDAY
+actual val DAY_MONDAY: Int = Calendar.MONDAY
+actual val DAY_TUESDAY: Int = Calendar.TUESDAY
+actual val DAY_WEDNESDAY: Int = Calendar.WEDNESDAY
+actual val DAY_THURSDAY: Int = Calendar.THURSDAY
+actual val DAY_FRIDAY: Int = Calendar.FRIDAY
+actual val DAY_SATURDAY: Int = Calendar.SATURDAY

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/core/model/utils/PlatformDateFormatting.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/core/model/utils/PlatformDateFormatting.kt
@@ -1,0 +1,25 @@
+package org.javarosa.core.model.utils
+
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+actual fun platformFormatDate(millis: Long, pattern: String, timezoneName: String?): String {
+    val sdf = SimpleDateFormat(pattern, Locale.US)
+    if (timezoneName != null) {
+        sdf.timeZone = TimeZone.getTimeZone(timezoneName)
+    }
+    return sdf.format(java.util.Date(millis))
+}
+
+actual fun platformFormatPlatformDate(date: PlatformDate, pattern: String): String {
+    return SimpleDateFormat(pattern, Locale.US).format(date)
+}
+
+actual fun platformParseDate(dateString: String, pattern: String): PlatformDate? {
+    return try {
+        SimpleDateFormat(pattern, Locale.US).parse(dateString)
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/core/model/utils/PlatformTimeZone.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/core/model/utils/PlatformTimeZone.kt
@@ -1,0 +1,14 @@
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+
+package org.javarosa.core.model.utils
+
+import java.util.TimeZone
+
+actual class PlatformTimeZone(val javaTimeZone: TimeZone) {
+    actual fun getOffset(date: Long): Int = javaTimeZone.getOffset(date)
+    actual fun getOffset(era: Int, year: Int, month: Int, day: Int, dayOfWeek: Int, millisOfDay: Int): Int =
+        javaTimeZone.getOffset(era, year, month, day, dayOfWeek, millisOfDay)
+}
+
+actual fun platformDefaultTimeZone(): PlatformTimeZone = PlatformTimeZone(TimeZone.getDefault())
+actual fun platformTimeZone(id: String): PlatformTimeZone = PlatformTimeZone(TimeZone.getTimeZone(id))

--- a/commcare-core/src/main/java/org/commcare/suite/model/Text.kt
+++ b/commcare-core/src/main/java/org/commcare/suite/model/Text.kt
@@ -20,9 +20,10 @@ import org.javarosa.xpath.parser.XPathSyntaxException
 import org.javarosa.core.util.externalizable.PlatformDataInputStream
 import org.javarosa.core.util.externalizable.PlatformDataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
-import java.util.Calendar
 
 import org.javarosa.core.model.utils.PlatformDate
+import org.javarosa.core.model.utils.platformCalendarInstance
+import org.javarosa.core.model.utils.CALENDAR_DAY_OF_WEEK
 import kotlin.jvm.JvmStatic
 
 /**
@@ -130,9 +131,9 @@ class Text : Externalizable, DetailTemplate, XPathAnalyzable {
 
                     temp.addFunctionHandler(object : IFunctionHandler {
                         override fun eval(args: Array<Any?>?, ec: EvaluationContext?): Any? {
-                            val c = Calendar.getInstance()
+                            val c = platformCalendarInstance()
                             c.time = PlatformDate()
-                            return c.get(Calendar.DAY_OF_WEEK).toString()
+                            return c.get(CALENDAR_DAY_OF_WEEK).toString()
                         }
 
                         override fun getName(): String = "dow"

--- a/commcare-core/src/main/java/org/commcare/util/DateRangeUtils.kt
+++ b/commcare-core/src/main/java/org/commcare/util/DateRangeUtils.kt
@@ -2,9 +2,9 @@ package org.commcare.util
 
 import org.commcare.modern.util.Pair
 import java.text.ParseException
-import java.text.SimpleDateFormat
 import org.javarosa.core.model.utils.PlatformDate
-import java.util.Locale
+import org.javarosa.core.model.utils.platformFormatPlatformDate
+import org.javarosa.core.model.utils.platformParseDate
 import kotlin.jvm.JvmStatic
 
 object DateRangeUtils {
@@ -26,9 +26,10 @@ object DateRangeUtils {
         if (humanReadableDateRange.contains(DATE_RANGE_ANSWER_HUMAN_READABLE_DELIMITER)) {
             val humanReadableDateRangeSplit = humanReadableDateRange.split(DATE_RANGE_ANSWER_HUMAN_READABLE_DELIMITER)
             if (humanReadableDateRangeSplit.size == 2) {
-                val sdf = SimpleDateFormat(DATE_FORMAT, Locale.US)
-                val startDate = sdf.parse(humanReadableDateRangeSplit[0])
-                val endDate = sdf.parse(humanReadableDateRangeSplit[1])
+                val startDate = platformParseDate(humanReadableDateRangeSplit[0], DATE_FORMAT)
+                    ?: throw ParseException("Cannot parse start date: ${humanReadableDateRangeSplit[0]}", 0)
+                val endDate = platformParseDate(humanReadableDateRangeSplit[1], DATE_FORMAT)
+                    ?: throw ParseException("Cannot parse end date: ${humanReadableDateRangeSplit[1]}", 0)
                 return Pair(
                     getTimeFromDateOffsettingTz(startDate),
                     getTimeFromDateOffsettingTz(endDate)
@@ -86,6 +87,6 @@ object DateRangeUtils {
     // Converts given time as yyyy-mm-dd
     @JvmStatic
     fun getDateFromTime(time: Long): String {
-        return SimpleDateFormat(DATE_FORMAT, Locale.US).format(PlatformDate(time))
+        return platformFormatPlatformDate(PlatformDate(time), DATE_FORMAT)
     }
 }

--- a/commcare-core/src/main/java/org/javarosa/core/model/utils/DateUtils.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/utils/DateUtils.kt
@@ -3,12 +3,6 @@ package org.javarosa.core.model.utils
 import org.javarosa.core.services.locale.Localization
 import org.javarosa.core.util.DataUtil
 import org.javarosa.core.util.MathUtils
-import java.text.DateFormat
-import java.text.SimpleDateFormat
-import java.util.Arrays
-import java.util.Calendar
-import java.util.TimeZone
-import java.util.concurrent.TimeUnit
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmOverloads
@@ -20,7 +14,7 @@ import kotlin.math.abs
  * @author Clayton Sims
  */
 object DateUtils {
-    private val MONTH_OFFSET = 1 - Calendar.JANUARY
+    private val MONTH_OFFSET = 1 - MONTH_JANUARY
 
     const val FORMAT_ISO8601: Int = 1
     const val FORMAT_ISO8601_WALL_TIME: Int = 10
@@ -34,9 +28,9 @@ object DateUtils {
     private var tzProvider = TimezoneProvider()
 
     @JvmField
-    val HOUR_IN_MS: Long = TimeUnit.HOURS.toMillis(1)
+    val HOUR_IN_MS: Long = 60L * 60 * 1000
     @JvmField
-    val DAY_IN_MS: Long = TimeUnit.DAYS.toMillis(1)
+    val DAY_IN_MS: Long = 24L * 60 * 60 * 1000
 
     private val EPOCH_DATE: PlatformDate = getDate(1970, 1, 1)!!
 
@@ -96,7 +90,7 @@ object DateUtils {
     }
 
     @JvmStatic
-    fun timezone(): TimeZone? {
+    fun timezone(): PlatformTimeZone? {
         return tzProvider.getTimezone()
     }
 
@@ -116,12 +110,12 @@ object DateUtils {
 
     @JvmStatic
     fun getFields(d: PlatformDate, timezone: String?): DateFields {
-        val cd = Calendar.getInstance()
+        val cd = platformCalendarInstance()
         cd.time = d
         if (timezone != null) {
-            cd.timeZone = TimeZone.getTimeZone(timezone)
+            cd.timeZone = platformTimeZone(timezone)
         } else if (timezone() != null) {
-            cd.timeZone = timezone()
+            cd.timeZone = timezone()!!
         } else if (timezoneOffset() != -1) {
             return getFields(d, timezoneOffset())
         }
@@ -129,23 +123,23 @@ object DateUtils {
     }
 
     private fun getFields(d: PlatformDate, timezoneOffset: Int): DateFields {
-        val cd = Calendar.getInstance()
-        cd.timeZone = TimeZone.getTimeZone("UTC")
+        val cd = platformCalendarInstance()
+        cd.timeZone = platformTimeZone("UTC")
         cd.time = d
-        cd.add(Calendar.MILLISECOND, timezoneOffset)
+        cd.add(CALENDAR_MILLISECOND, timezoneOffset)
         return getFields(cd, timezoneOffset)
     }
 
-    private fun getFields(cal: Calendar, timezoneOffset: Int): DateFields {
+    private fun getFields(cal: PlatformCalendar, timezoneOffset: Int): DateFields {
         val fields = DateFields()
-        fields.year = cal.get(Calendar.YEAR)
-        fields.month = cal.get(Calendar.MONTH) + MONTH_OFFSET
-        fields.day = cal.get(Calendar.DAY_OF_MONTH)
-        fields.hour = cal.get(Calendar.HOUR_OF_DAY)
-        fields.minute = cal.get(Calendar.MINUTE)
-        fields.second = cal.get(Calendar.SECOND)
-        fields.secTicks = cal.get(Calendar.MILLISECOND)
-        fields.dow = cal.get(Calendar.DAY_OF_WEEK)
+        fields.year = cal.get(CALENDAR_YEAR)
+        fields.month = cal.get(CALENDAR_MONTH) + MONTH_OFFSET
+        fields.day = cal.get(CALENDAR_DAY_OF_MONTH)
+        fields.hour = cal.get(CALENDAR_HOUR_OF_DAY)
+        fields.minute = cal.get(CALENDAR_MINUTE)
+        fields.second = cal.get(CALENDAR_SECOND)
+        fields.secTicks = cal.get(CALENDAR_MILLISECOND)
+        fields.dow = cal.get(CALENDAR_DAY_OF_WEEK)
         fields.timezoneOffsetInMillis = timezoneOffset
         return fields
     }
@@ -178,40 +172,40 @@ object DateUtils {
      * timezone into account.
      */
     private fun getDate(df: DateFields, timezone: String?): PlatformDate? {
-        val cd = Calendar.getInstance()
+        val cd = platformCalendarInstance()
 
         if (timezone != null) {
-            cd.timeZone = TimeZone.getTimeZone(timezone)
+            cd.timeZone = platformTimeZone(timezone)
         } else if (timezone() != null) {
-            cd.timeZone = timezone()
+            cd.timeZone = timezone()!!
         } else if (timezoneOffset() != -1) {
             return getDate(df, timezoneOffset())
         }
 
-        cd.set(Calendar.YEAR, df.year)
-        cd.set(Calendar.MONTH, df.month - MONTH_OFFSET)
-        cd.set(Calendar.DAY_OF_MONTH, df.day)
-        cd.set(Calendar.HOUR_OF_DAY, df.hour)
-        cd.set(Calendar.MINUTE, df.minute)
-        cd.set(Calendar.SECOND, df.second)
-        cd.set(Calendar.MILLISECOND, df.secTicks)
+        cd.set(CALENDAR_YEAR, df.year)
+        cd.set(CALENDAR_MONTH, df.month - MONTH_OFFSET)
+        cd.set(CALENDAR_DAY_OF_MONTH, df.day)
+        cd.set(CALENDAR_HOUR_OF_DAY, df.hour)
+        cd.set(CALENDAR_MINUTE, df.minute)
+        cd.set(CALENDAR_SECOND, df.second)
+        cd.set(CALENDAR_MILLISECOND, df.secTicks)
 
         return cd.time
     }
 
     private fun getDate(df: DateFields, timezoneOffset: Int): PlatformDate {
-        val cd = Calendar.getInstance()
-        cd.timeZone = TimeZone.getTimeZone("UTC")
+        val cd = platformCalendarInstance()
+        cd.timeZone = platformTimeZone("UTC")
 
-        cd.set(Calendar.YEAR, df.year)
-        cd.set(Calendar.MONTH, df.month - MONTH_OFFSET)
-        cd.set(Calendar.DAY_OF_MONTH, df.day)
-        cd.set(Calendar.HOUR_OF_DAY, df.hour)
-        cd.set(Calendar.MINUTE, df.minute)
-        cd.set(Calendar.SECOND, df.second)
-        cd.set(Calendar.MILLISECOND, df.secTicks)
+        cd.set(CALENDAR_YEAR, df.year)
+        cd.set(CALENDAR_MONTH, df.month - MONTH_OFFSET)
+        cd.set(CALENDAR_DAY_OF_MONTH, df.day)
+        cd.set(CALENDAR_HOUR_OF_DAY, df.hour)
+        cd.set(CALENDAR_MINUTE, df.minute)
+        cd.set(CALENDAR_SECOND, df.second)
+        cd.set(CALENDAR_MILLISECOND, df.secTicks)
 
-        cd.add(Calendar.MILLISECOND, -1 * timezoneOffset)
+        cd.add(CALENDAR_MILLISECOND, -1 * timezoneOffset)
 
         return cd.time
     }
@@ -313,7 +307,7 @@ object DateUtils {
             offset = timezoneOffset()
         } else {
             //Time Zone ops (1 in the first field corresponds to 'CE' ERA)
-            offset = TimeZone.getDefault().getOffset(1, f.year, f.month - 1, f.day, f.dow, 0)
+            offset = platformDefaultTimeZone().getOffset(1, f.year, f.month - 1, f.day, f.dow, 0)
         }
 
         //NOTE: offset is in millis
@@ -534,14 +528,14 @@ object DateUtils {
         }
 
         // Now apply any relevant offsets from the timezone.
-        val c = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+        val c = platformCalendarInstance(platformTimeZone("UTC"))
 
         c.time = PlatformDate(getDate(df, "UTC")!!.time + (((60 * timeOffset.hour) + timeOffset.minute) * 60 * 1000))
 
         // c is now in the timezone of the parsed value, so put
         // it in the local timezone.
 
-        c.timeZone = TimeZone.getDefault()
+        c.timeZone = platformDefaultTimeZone()
 
         val adjusted = getFields(c.time)
 
@@ -608,8 +602,8 @@ object DateUtils {
     @JvmStatic
     fun daysInMonth(month: Int, year: Int): Int {
         return when (month) {
-            Calendar.APRIL, Calendar.JUNE, Calendar.SEPTEMBER, Calendar.NOVEMBER -> 30
-            Calendar.FEBRUARY -> 28 + (if (isLeap(year)) 1 else 0)
+            MONTH_APRIL, MONTH_JUNE, MONTH_SEPTEMBER, MONTH_NOVEMBER -> 30
+            MONTH_FEBRUARY -> 28 + (if (isLeap(year)) 1 else 0)
             else -> 31
         }
     }
@@ -664,17 +658,17 @@ object DateUtils {
                 throw RuntimeException()
             }
 
-            val cd = Calendar.getInstance()
+            val cd = platformCalendarInstance()
             cd.time = ref
 
-            val current_dow = when (cd.get(Calendar.DAY_OF_WEEK)) {
-                Calendar.SUNDAY -> 0
-                Calendar.MONDAY -> 1
-                Calendar.TUESDAY -> 2
-                Calendar.WEDNESDAY -> 3
-                Calendar.THURSDAY -> 4
-                Calendar.FRIDAY -> 5
-                Calendar.SATURDAY -> 6
+            val current_dow = when (cd.get(CALENDAR_DAY_OF_WEEK)) {
+                DAY_SUNDAY -> 0
+                DAY_MONDAY -> 1
+                DAY_TUESDAY -> 2
+                DAY_WEDNESDAY -> 3
+                DAY_THURSDAY -> 4
+                DAY_FRIDAY -> 5
+                DAY_SATURDAY -> 6
                 else -> throw RuntimeException() //something is wrong
             }
 
@@ -693,14 +687,14 @@ object DateUtils {
     fun getMonthsDifference(earlierDate: PlatformDate, laterDate: PlatformDate): Int {
         val span = PlatformDate(laterDate.time - earlierDate.time)
         val firstDate = PlatformDate(0)
-        val calendar = Calendar.getInstance()
+        val calendar = platformCalendarInstance()
         calendar.time = firstDate
-        val firstYear = calendar.get(Calendar.YEAR)
-        val firstMonth = calendar.get(Calendar.MONTH)
+        val firstYear = calendar.get(CALENDAR_YEAR)
+        val firstMonth = calendar.get(CALENDAR_MONTH)
 
         calendar.time = span
-        val spanYear = calendar.get(Calendar.YEAR)
-        val spanMonth = calendar.get(Calendar.MONTH)
+        val spanYear = calendar.get(CALENDAR_YEAR)
+        val spanMonth = calendar.get(CALENDAR_MONTH)
         return (spanYear - firstYear) * 12 + (spanMonth - firstMonth)
     }
 
@@ -794,9 +788,7 @@ object DateUtils {
         return if (ms == 0L) {
             ""
         } else {
-            val df: DateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'")
-            df.timeZone = TimeZone.getTimeZone("UTC")
-            df.format(ms)
+            platformFormatDate(ms, "yyyy-MM-dd'T'HH:mm'Z'", "UTC")
         }
     }
 }

--- a/commcare-core/src/main/java/org/javarosa/core/model/utils/TimezoneProvider.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/utils/TimezoneProvider.kt
@@ -1,7 +1,5 @@
 package org.javarosa.core.model.utils
 
-import java.util.TimeZone
-
 /**
  * Created by amstone326 on 1/5/18.
  */
@@ -11,7 +9,7 @@ open class TimezoneProvider {
         return -1
     }
 
-    open fun getTimezone(): TimeZone? {
+    open fun getTimezone(): PlatformTimeZone? {
         return null
     }
 }

--- a/commcare-core/src/main/java/org/javarosa/xform/util/CalendarUtils.kt
+++ b/commcare-core/src/main/java/org/javarosa/xform/util/CalendarUtils.kt
@@ -6,8 +6,15 @@ import org.commcare.util.LocaleArrayDataSource
 import org.javarosa.core.model.utils.DateUtils
 
 import org.javarosa.core.model.utils.PlatformDate
-import java.util.Calendar
-import java.util.TimeZone
+import org.javarosa.core.model.utils.PlatformCalendar
+import org.javarosa.core.model.utils.PlatformTimeZone
+import org.javarosa.core.model.utils.platformCalendarInstance
+import org.javarosa.core.model.utils.platformDefaultTimeZone
+import org.javarosa.core.model.utils.platformTimeZone
+import org.javarosa.core.model.utils.CALENDAR_HOUR_OF_DAY
+import org.javarosa.core.model.utils.CALENDAR_MINUTE
+import org.javarosa.core.model.utils.CALENDAR_SECOND
+import org.javarosa.core.model.utils.CALENDAR_MILLISECOND
 import kotlin.jvm.JvmStatic
 
 class CalendarUtils {
@@ -344,7 +351,7 @@ class CalendarUtils {
          *                            timezone issues when casting to a calendar date
          */
         @JvmStatic
-        fun fromMillis(millisFromJavaEpoch: Long, currentTimeZone: TimeZone): UniversalDate {
+        fun fromMillis(millisFromJavaEpoch: Long, currentTimeZone: PlatformTimeZone): UniversalDate {
             // Since epoch calculations are relative to UTC, take current timezone
             // into account. This prevents two time values that lie on the same day
             // in the given timezone from falling on different GMT days.
@@ -384,12 +391,12 @@ class CalendarUtils {
 
         @JvmStatic
         fun fromMillis(date: PlatformDate, timezone: String?): UniversalDate {
-            val cd = Calendar.getInstance()
+            val cd = platformCalendarInstance()
             cd.time = date
             if (timezone != null) {
-                cd.timeZone = TimeZone.getTimeZone(timezone)
+                cd.timeZone = platformTimeZone(timezone)
             } else if (DateUtils.timezone() != null) {
-                cd.timeZone = DateUtils.timezone()
+                cd.timeZone = DateUtils.timezone()!!
             }
             val dateInMillis = cd.time.time
             return fromMillis(dateInMillis, cd.timeZone)
@@ -454,11 +461,11 @@ class CalendarUtils {
 
         @JvmStatic
         fun toMillisFromJavaEpoch(year: Int, month: Int, day: Int): Long {
-            return toMillisFromJavaEpoch(year, month, day, TimeZone.getDefault())
+            return toMillisFromJavaEpoch(year, month, day, platformDefaultTimeZone())
         }
 
         @JvmStatic
-        fun toMillisFromJavaEpoch(year: Int, month: Int, day: Int, currentTimeZone: TimeZone): Long {
+        fun toMillisFromJavaEpoch(year: Int, month: Int, day: Int, currentTimeZone: PlatformTimeZone): Long {
             val daysFromMinDay = countDaysFromMinDay(year, month, day)
             val millisFromMinDay = daysFromMinDay.toLong() * UniversalDate.MILLIS_IN_DAY
             val timezoneOffsetFromUTC = currentTimeZone.getOffset(millisFromMinDay)
@@ -477,11 +484,11 @@ class CalendarUtils {
         }
 
         @JvmStatic
-        fun toMidnight(cal: Calendar) {
-            cal.set(Calendar.HOUR_OF_DAY, 0)
-            cal.set(Calendar.MINUTE, 0)
-            cal.set(Calendar.SECOND, 0)
-            cal.set(Calendar.MILLISECOND, 0)
+        fun toMidnight(cal: PlatformCalendar) {
+            cal.set(CALENDAR_HOUR_OF_DAY, 0)
+            cal.set(CALENDAR_MINUTE, 0)
+            cal.set(CALENDAR_SECOND, 0)
+            cal.set(CALENDAR_MILLISECOND, 0)
         }
     }
 }

--- a/commcare-core/src/test/java/org/javarosa/xform/util/test/CalendarTests.java
+++ b/commcare-core/src/test/java/org/javarosa/xform/util/test/CalendarTests.java
@@ -1,6 +1,7 @@
 package org.javarosa.xform.util.test;
 
 import org.javarosa.core.model.utils.DateUtils;
+import org.javarosa.core.model.utils.PlatformTimeZone;
 import org.javarosa.core.model.utils.TimezoneProvider;
 import org.javarosa.core.services.locale.Localization;
 import org.javarosa.core.services.locale.TableLocaleSource;
@@ -32,6 +33,10 @@ public class CalendarTests {
         Localization.getGlobalLocalizerAdvanced().registerLocaleResource("default", localeData);
     }
 
+    private static PlatformTimeZone wrap(TimeZone tz) {
+        return new PlatformTimeZone(tz);
+    }
+
     @Test
     public void testTimesFallOnSameDate() {
         TimeZone nepaliTimeZone = TimeZone.getTimeZone("GMT+05:45");
@@ -43,14 +48,14 @@ public class CalendarTests {
         nepaliBeginningOfDayDate.set(2007, Calendar.JULY, 7, 0, 0);
 
         UniversalDate middleOfDay = CalendarUtils.fromMillis(nepaliMiddleOfDayDate.getTimeInMillis(),
-                nepaliTimeZone);
+                wrap(nepaliTimeZone));
         UniversalDate beginningOfDay = CalendarUtils.fromMillis(nepaliBeginningOfDayDate.getTimeInMillis(),
-                nepaliTimeZone);
+                wrap(nepaliTimeZone));
         assertSameDate(middleOfDay, beginningOfDay);
 
         Calendar nepaliEndOfDayDate = Calendar.getInstance(nepaliTimeZone);
         nepaliEndOfDayDate.set(2007, Calendar.JULY, 7, 23, 59, 59);
-        UniversalDate endOfDay = CalendarUtils.fromMillis(nepaliEndOfDayDate.getTimeInMillis(), nepaliTimeZone);
+        UniversalDate endOfDay = CalendarUtils.fromMillis(nepaliEndOfDayDate.getTimeInMillis(), wrap(nepaliTimeZone));
         assertSameDate(endOfDay, beginningOfDay);
     }
 
@@ -59,7 +64,7 @@ public class CalendarTests {
     public void testConvertToNepaliString() {
         MockTimeZoneProvider mockTimeZoneProvider = new MockTimeZoneProvider(TimeZone.getTimeZone("Europe/Madrid"));
         DateUtils.setTimezoneProvider(mockTimeZoneProvider);
-        TimeZone timeZone = mockTimeZoneProvider.timeZone;
+        PlatformTimeZone timeZone = mockTimeZoneProvider.getTimezone();
         // this is what Nepali widget uses to calculate the millis from date fields
         long millis = CalendarUtils.toMillisFromJavaEpoch(2081, 6, 16, timeZone);
         String nepaliDateStr = CalendarUtils.convertToNepaliString(new Date(millis), null);
@@ -67,14 +72,14 @@ public class CalendarTests {
 
 
         mockTimeZoneProvider.setTimezone(TimeZone.getTimeZone("Asia/Kathmandu"));
-        timeZone = mockTimeZoneProvider.timeZone;
+        timeZone = mockTimeZoneProvider.getTimezone();
         millis = CalendarUtils.toMillisFromJavaEpoch(2081, 6, 16, timeZone);
         nepaliDateStr = CalendarUtils.convertToNepaliString(new Date(millis), null);
         assertEquals( "16 Ashwin 2081", nepaliDateStr);
 
 
         mockTimeZoneProvider.setTimezone(TimeZone.getTimeZone("America/Chicago"));
-        timeZone = mockTimeZoneProvider.timeZone;
+        timeZone = mockTimeZoneProvider.getTimezone();
         millis = CalendarUtils.toMillisFromJavaEpoch(2081, 6, 16, timeZone);
         nepaliDateStr = CalendarUtils.convertToNepaliString(new Date(millis), null);
         assertEquals( "16 Ashwin 2081", nepaliDateStr);
@@ -96,8 +101,8 @@ public class CalendarTests {
         Calendar mexicoCal = Calendar.getInstance(mexicanTimeZone);
         mexicoCal.set(2007, Calendar.JULY, 7, 18, 46);
 
-        UniversalDate mexicanDate = CalendarUtils.fromMillis(mexicoCal.getTimeInMillis(), mexicanTimeZone);
-        UniversalDate nepaliDate = CalendarUtils.fromMillis(nepalCal.getTimeInMillis(), nepaliTimeZone);
+        UniversalDate mexicanDate = CalendarUtils.fromMillis(mexicoCal.getTimeInMillis(), wrap(mexicanTimeZone));
+        UniversalDate nepaliDate = CalendarUtils.fromMillis(nepalCal.getTimeInMillis(), wrap(nepaliTimeZone));
         assertSameDate(nepaliDate, mexicanDate);
     }
 
@@ -108,10 +113,10 @@ public class CalendarTests {
         Calendar mexicoCal = Calendar.getInstance(mexicanTimeZone);
         mexicoCal.set(2007, Calendar.JULY, 7, 18, 46);
 
-        UniversalDate mexicanDate = CalendarUtils.fromMillis(mexicoCal.getTimeInMillis(), mexicanTimeZone);
+        UniversalDate mexicanDate = CalendarUtils.fromMillis(mexicoCal.getTimeInMillis(), wrap(mexicanTimeZone));
         long time = CalendarUtils.toMillisFromJavaEpoch(mexicanDate.year, mexicanDate.month, mexicanDate.day,
-                mexicanTimeZone);
-        UniversalDate rebuiltDateInUsingDifferentTimezone = CalendarUtils.fromMillis(time, nepaliTimeZone);
+                wrap(mexicanTimeZone));
+        UniversalDate rebuiltDateInUsingDifferentTimezone = CalendarUtils.fromMillis(time, wrap(nepaliTimeZone));
         assertSameDate(rebuiltDateInUsingDifferentTimezone, mexicanDate);
     }
 
@@ -121,15 +126,15 @@ public class CalendarTests {
 
         Calendar dayInNewYork = Calendar.getInstance(nycTimeZone);
         dayInNewYork.set(2007, Calendar.JULY, 7);
-        UniversalDate nycTime = CalendarUtils.fromMillis(dayInNewYork.getTimeInMillis(), nycTimeZone);
+        UniversalDate nycTime = CalendarUtils.fromMillis(dayInNewYork.getTimeInMillis(), wrap(nycTimeZone));
 
-        long time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, nycTimeZone);
-        UniversalDate unpackedNycTime = CalendarUtils.fromMillis(time, nycTimeZone);
+        long time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, wrap(nycTimeZone));
+        UniversalDate unpackedNycTime = CalendarUtils.fromMillis(time, wrap(nycTimeZone));
         assertSameDate(nycTime, unpackedNycTime);
 
         TimeZone nepaliTimeZone = TimeZone.getTimeZone("GMT+05:45");
-        time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, nepaliTimeZone);
-        UniversalDate unpackedNepaliTime = CalendarUtils.fromMillis(time, nepaliTimeZone);
+        time = CalendarUtils.toMillisFromJavaEpoch(nycTime.year, nycTime.month, nycTime.day, wrap(nepaliTimeZone));
+        UniversalDate unpackedNepaliTime = CalendarUtils.fromMillis(time, wrap(nepaliTimeZone));
         assertSameDate(nycTime, unpackedNepaliTime);
     }
 
@@ -138,20 +143,20 @@ public class CalendarTests {
         // India
         TimeZone indiaTimeZone = TimeZone.getTimeZone("GMT+05:00");
         UniversalDate nepaliDate = new UniversalDate(2073, 5, 2, 0);
-        long normalizedTime = CalendarUtils.toMillisFromJavaEpoch(2073, 5, 2, indiaTimeZone);
+        long normalizedTime = CalendarUtils.toMillisFromJavaEpoch(2073, 5, 2, wrap(indiaTimeZone));
         Date date = new Date(normalizedTime);
-        UniversalDate deserializedNepaliDate = CalendarUtils.fromMillis(date.getTime(), indiaTimeZone);
+        UniversalDate deserializedNepaliDate = CalendarUtils.fromMillis(date.getTime(), wrap(indiaTimeZone));
         assertSameDate(nepaliDate, deserializedNepaliDate);
 
         // Boston
         TimeZone bostonTimeZone = TimeZone.getTimeZone("GMT-04:00");
-        normalizedTime = CalendarUtils.toMillisFromJavaEpoch(2073, 5, 2, bostonTimeZone);
+        normalizedTime = CalendarUtils.toMillisFromJavaEpoch(2073, 5, 2, wrap(bostonTimeZone));
         date = new Date(normalizedTime);
-        deserializedNepaliDate = CalendarUtils.fromMillis(date.getTime(), bostonTimeZone);
+        deserializedNepaliDate = CalendarUtils.fromMillis(date.getTime(), wrap(bostonTimeZone));
         assertSameDate(nepaliDate, deserializedNepaliDate);
     }
 
-    private  class MockTimeZoneProvider extends TimezoneProvider {
+    private class MockTimeZoneProvider extends TimezoneProvider {
 
         private TimeZone timeZone;
 
@@ -159,13 +164,13 @@ public class CalendarTests {
             this.timeZone = timeZone;
         }
 
-        public  void  setTimezone(TimeZone timeZone){
+        public void setTimezone(TimeZone timeZone) {
             this.timeZone = timeZone;
         }
 
         @Override
-        public TimeZone getTimezone() {
-            return timeZone;
+        public PlatformTimeZone getTimezone() {
+            return new PlatformTimeZone(timeZone);
         }
     }
 }


### PR DESCRIPTION
## Summary
- New expect/actual abstractions: `PlatformCalendar`, `PlatformTimeZone`, `PlatformDateFormatting` (commonMain/jvmMain/iosMain)
- Replaced all `java.util.Calendar`, `java.util.TimeZone`, `java.text.SimpleDateFormat` imports in Kotlin source
- Updated 5 source files (DateUtils, CalendarUtils, TimezoneProvider, Text, DateRangeUtils) + 1 test file
- JVM wrapper classes (not typealias) since Calendar/TimeZone are abstract with field access issues

## Test plan
- [x] Zero imports of `java.util.Calendar`, `java.util.TimeZone`, `java.text.SimpleDateFormat` in `src/main/java`
- [x] `compileKotlinJvm` passes
- [x] `compileCommonMainKotlinMetadata` passes
- [x] `jvmTest` passes (710+ tests including CalendarTests, DateUtilsTests)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)