### PR TITLE
Phase 4 Wave 8: KClass conversion for cross-platform type system

### DIFF
--- a/commcare-core/src/commonMain/kotlin/org/javarosa/xpath/expr/TypeTokenUtils.kt
+++ b/commcare-core/src/commonMain/kotlin/org/javarosa/xpath/expr/TypeTokenUtils.kt
@@ -1,0 +1,12 @@
+package org.javarosa.xpath.expr
+
+import kotlin.reflect.KClass
+
+/**
+ * Cross-platform type token matching for XPath function prototype system.
+ *
+ * Type tokens can be KClass<*> (from Kotlin code) or Class<*> (from Java code on JVM).
+ * These helpers abstract the matching so the prototype system works cross-platform.
+ */
+expect fun isInstanceOfTypeToken(token: Any, value: Any): Boolean
+expect fun isTypeTokenEqual(token: Any, target: KClass<*>): Boolean

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/xpath/expr/TypeTokenUtils.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/xpath/expr/TypeTokenUtils.kt
@@ -1,0 +1,12 @@
+package org.javarosa.xpath.expr
+
+import kotlin.reflect.KClass
+
+/**
+ * iOS implementation only handles KClass<*> type tokens.
+ */
+actual fun isInstanceOfTypeToken(token: Any, value: Any): Boolean =
+    (token as? KClass<*>)?.isInstance(value) ?: false
+
+actual fun isTypeTokenEqual(token: Any, target: KClass<*>): Boolean =
+    token == target

--- a/commcare-core/src/jvmMain/kotlin/org/javarosa/xpath/expr/TypeTokenUtils.kt
+++ b/commcare-core/src/jvmMain/kotlin/org/javarosa/xpath/expr/TypeTokenUtils.kt
@@ -1,0 +1,18 @@
+package org.javarosa.xpath.expr
+
+import kotlin.reflect.KClass
+
+/**
+ * JVM implementation handles both KClass<*> (from Kotlin) and Class<*> (from Java) type tokens.
+ */
+actual fun isInstanceOfTypeToken(token: Any, value: Any): Boolean = when (token) {
+    is KClass<*> -> token.isInstance(value)
+    is Class<*> -> token.isInstance(value)
+    else -> false
+}
+
+actual fun isTypeTokenEqual(token: Any, target: KClass<*>): Boolean = when (token) {
+    is KClass<*> -> token == target
+    is Class<*> -> token.kotlin == target
+    else -> false
+}

--- a/commcare-core/src/main/java/org/commcare/cases/util/LruCache.kt
+++ b/commcare-core/src/main/java/org/commcare/cases/util/LruCache.kt
@@ -104,7 +104,7 @@ open class LruCache<K, V>(private var maxSize: Int) {
             entryEvicted(key, value)
         }
         check(!(size < 0 || (map.isEmpty() && size != 0))) {
-            "${javaClass.name}.sizeOf() is reporting inconsistent results!"
+            "${this::class.qualifiedName}.sizeOf() is reporting inconsistent results!"
         }
     }
 

--- a/commcare-core/src/main/java/org/commcare/suite/model/Text.kt
+++ b/commcare-core/src/main/java/org/commcare/suite/model/Text.kt
@@ -118,9 +118,9 @@ class Text : Externalizable, DetailTemplate, XPathAnalyzable {
 
                         override fun getPrototypes(): ArrayList<Any> {
                             val format = ArrayList<Any>()
-                            val prototypes = arrayOf<Class<*>>(
-                                PlatformDate::class.java,
-                                String::class.java
+                            val prototypes = arrayOf<Any>(
+                                PlatformDate::class,
+                                String::class
                             )
                             format.add(prototypes)
                             return format
@@ -140,7 +140,7 @@ class Text : Externalizable, DetailTemplate, XPathAnalyzable {
 
                         override fun getPrototypes(): ArrayList<Any> {
                             val format = ArrayList<Any>()
-                            val prototypes = arrayOf<Class<*>>()
+                            val prototypes = arrayOf<Any>()
                             format.add(prototypes)
                             return format
                         }

--- a/commcare-core/src/main/java/org/javarosa/core/model/FormDef.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/FormDef.kt
@@ -48,6 +48,7 @@ import org.javarosa.core.model.trace.PlatformTrace
 import org.javarosa.core.model.trace.setActiveSpanTag
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
+import kotlin.reflect.KClass
 
 /**
  * Definition of a form. This has some meta data about the form definition and a
@@ -1019,7 +1020,7 @@ class FormDef : IFormElement, IMetaData, ActionController.ActionResultProcessor 
                 }
 
                 override fun getPrototypes(): ArrayList<Any> {
-                    val proto = arrayOf<Class<*>>(String::class.java)
+                    val proto = arrayOf<Any>(String::class)
                     val v = ArrayList<Any>()
                     v.add(proto)
                     return v
@@ -1073,7 +1074,7 @@ class FormDef : IFormElement, IMetaData, ActionController.ActionResultProcessor 
                 }
 
                 override fun getPrototypes(): ArrayList<Any> {
-                    val proto = arrayOf<Class<*>>(String::class.java, String::class.java)
+                    val proto = arrayOf<Any>(String::class, String::class)
                     val v = ArrayList<Any>()
                     v.add(proto)
                     return v
@@ -1590,21 +1591,13 @@ class FormDef : IFormElement, IMetaData, ActionController.ActionResultProcessor 
     }
 
     @Suppress("UNCHECKED_CAST")
-    fun <X : XFormExtension> getExtension(extension: Class<X>): X {
+    fun <X : XFormExtension> getExtension(extension: KClass<X>, factory: () -> X): X {
         for (ex in extensions) {
-            if (ex.javaClass.isAssignableFrom(extension)) {
+            if (extension.isInstance(ex)) {
                 return ex as X
             }
         }
-        val newEx: X
-        try {
-            @Suppress("DEPRECATION")
-            newEx = extension.newInstance()
-        } catch (e: InstantiationException) {
-            throw RuntimeException("Illegally Structured XForm Extension " + extension.name)
-        } catch (e: IllegalAccessException) {
-            throw RuntimeException("Illegally Structured XForm Extension " + extension.name)
-        }
+        val newEx = factory()
         extensions.add(newEx)
         return newEx
     }

--- a/commcare-core/src/main/java/org/javarosa/core/model/User.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/User.kt
@@ -141,12 +141,12 @@ class User : Persistable, Restorable, IMetaData {
     }
 
     override fun templateData(dm: FormInstance, parentRef: TreeReference) {
-        RestoreUtils.applyDataType(dm, "name", parentRef, String::class.java)
-        RestoreUtils.applyDataType(dm, "pass", parentRef, String::class.java)
-        RestoreUtils.applyDataType(dm, "type", parentRef, String::class.java)
-        RestoreUtils.applyDataType(dm, "user-id", parentRef, Int::class.java)
-        RestoreUtils.applyDataType(dm, "uuid", parentRef, String::class.java)
-        RestoreUtils.applyDataType(dm, "remember", parentRef, Boolean::class.java)
+        RestoreUtils.applyDataType(dm, "name", parentRef, String::class)
+        RestoreUtils.applyDataType(dm, "pass", parentRef, String::class)
+        RestoreUtils.applyDataType(dm, "type", parentRef, String::class)
+        RestoreUtils.applyDataType(dm, "user-id", parentRef, Int::class)
+        RestoreUtils.applyDataType(dm, "uuid", parentRef, String::class)
+        RestoreUtils.applyDataType(dm, "remember", parentRef, Boolean::class)
     }
 
     override fun getMetaData(fieldName: String): Any {

--- a/commcare-core/src/main/java/org/javarosa/core/model/condition/HereFunctionHandler.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/condition/HereFunctionHandler.kt
@@ -6,7 +6,7 @@ abstract class HereFunctionHandler : IFunctionHandler {
     protected var listener: HereFunctionHandlerListener? = null
 
     override fun getPrototypes(): ArrayList<*> {
-        val p = ArrayList<Array<Class<*>>>()
+        val p = ArrayList<Array<Any>>()
         p.add(arrayOf())
         return p
     }

--- a/commcare-core/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/instance/ExternalDataInstanceSource.kt
@@ -42,7 +42,7 @@ class ExternalDataInstanceSource : InstanceRoot, Externalizable {
     ) {
         if (sourceUri == null && storageReferenceId == null) {
             throw RuntimeException(
-                javaClass.canonicalName +
+                this::class.qualifiedName +
                         " must be initialised with one of sourceUri or storageReferenceId"
             )
         }

--- a/commcare-core/src/main/java/org/javarosa/core/model/util/restorable/RestoreUtils.kt
+++ b/commcare-core/src/main/java/org/javarosa/core/model/util/restorable/RestoreUtils.kt
@@ -13,6 +13,7 @@ import org.javarosa.xpath.expr.XPathPathExpr
 import org.javarosa.core.model.utils.PlatformDate
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
+import kotlin.reflect.KClass
 
 object RestoreUtils {
     @JvmField
@@ -37,16 +38,15 @@ object RestoreUtils {
     }
 
     //used for incoming data
-    private fun getDataType(c: Class<*>): Int {
+    private fun getDataType(c: KClass<*>): Int {
         return when (c) {
-            String::class.java -> Constants.DATATYPE_TEXT
-            Integer::class.java, Int::class.java -> Constants.DATATYPE_INTEGER
-            java.lang.Long::class.java, Long::class.java -> Constants.DATATYPE_LONG
-            java.lang.Float::class.java, Float::class.java,
-            java.lang.Double::class.java, Double::class.java -> Constants.DATATYPE_DECIMAL
-            PlatformDate::class.java -> Constants.DATATYPE_DATE
-            java.lang.Boolean::class.java, Boolean::class.java -> Constants.DATATYPE_TEXT
-            else -> throw RuntimeException("Can't handle data type ${c.name}")
+            String::class -> Constants.DATATYPE_TEXT
+            Int::class -> Constants.DATATYPE_INTEGER
+            Long::class -> Constants.DATATYPE_LONG
+            Float::class, Double::class -> Constants.DATATYPE_DECIMAL
+            PlatformDate::class -> Constants.DATATYPE_DATE
+            Boolean::class -> Constants.DATATYPE_TEXT
+            else -> throw RuntimeException("Can't handle data type ${c.qualifiedName}")
         }
     }
 
@@ -67,7 +67,7 @@ object RestoreUtils {
     }
 
     @JvmStatic
-    fun applyDataType(dm: FormInstance, path: String, parent: TreeReference, type: Class<*>) {
+    fun applyDataType(dm: FormInstance, path: String, parent: TreeReference, type: KClass<*>) {
         val dataType = getDataType(type)
         val ref = childRef(path, parent)
 
@@ -83,11 +83,11 @@ object RestoreUtils {
         var resolvedParent = parent
         if (resolvedParent == null) {
             resolvedParent = topRef(dm)
-            applyDataType(dm, "timestamp", resolvedParent, PlatformDate::class.java)
+            applyDataType(dm, "timestamp", resolvedParent, PlatformDate::class)
         }
 
         if (r is Persistable) {
-            applyDataType(dm, RECORD_ID_TAG, resolvedParent, Integer::class.java)
+            applyDataType(dm, RECORD_ID_TAG, resolvedParent, Int::class)
         }
 
         r.templateData(dm, resolvedParent)

--- a/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathCustomRuntimeFunc.kt
+++ b/commcare-core/src/main/java/org/javarosa/xpath/expr/XPathCustomRuntimeFunc.kt
@@ -16,6 +16,7 @@ import org.javarosa.core.util.externalizable.PlatformDataOutputStream
 import org.javarosa.core.util.externalizable.PlatformIOException
 import org.javarosa.core.model.utils.PlatformDate
 import kotlin.jvm.JvmStatic
+import kotlin.reflect.KClass
 
 /**
  * Custom function that is dispatched at runtime
@@ -70,7 +71,7 @@ class XPathCustomRuntimeFunc : XPathFuncExpr {
             var argPrototypeArityMatch = false
             while (typedArgs == null && e.hasNext()) {
                 // try to coerce args into prototype, stopping on first success
-                val proto = e.next() as Array<Class<*>>
+                val proto = e.next() as Array<*>
                 typedArgs = matchPrototype(args, proto)
                 argPrototypeArityMatch = argPrototypeArityMatch ||
                         (proto.size == args.size)
@@ -107,7 +108,7 @@ class XPathCustomRuntimeFunc : XPathFuncExpr {
          * argument list -- these will be the arguments used to evaluate the
          * function.  If not coercible, return null.
          */
-        private fun matchPrototype(args: Array<Any?>, prototype: Array<Class<*>>): Array<Any?>? {
+        private fun matchPrototype(args: Array<Any?>, prototype: Array<*>): Array<Any?>? {
             var typed: Array<Any?>? = null
 
             if (prototype.size == args.size) {
@@ -115,19 +116,20 @@ class XPathCustomRuntimeFunc : XPathFuncExpr {
 
                 for (i in prototype.indices) {
                     typed[i] = null
+                    val typeToken = prototype[i] ?: return null
 
                     // how to handle type conversions of custom types?
-                    if (prototype[i].isAssignableFrom(args[i]!!.javaClass)) {
+                    if (isInstanceOfTypeToken(typeToken, args[i]!!)) {
                         typed[i] = args[i]
                     } else {
                         try {
-                            if (prototype[i] == java.lang.Boolean::class.java) {
+                            if (isTypeTokenEqual(typeToken, Boolean::class)) {
                                 typed[i] = FunctionUtils.toBoolean(args[i])
-                            } else if (prototype[i] == java.lang.Double::class.java) {
+                            } else if (isTypeTokenEqual(typeToken, Double::class)) {
                                 typed[i] = FunctionUtils.toNumeric(args[i])
-                            } else if (prototype[i] == String::class.java) {
+                            } else if (isTypeTokenEqual(typeToken, String::class)) {
                                 typed[i] = FunctionUtils.toString(args[i])
-                            } else if (prototype[i] == PlatformDate::class.java) {
+                            } else if (isTypeTokenEqual(typeToken, PlatformDate::class)) {
                                 typed[i] = FunctionUtils.toDate(args[i])
                             }
                         } catch (xptme: XPathTypeMismatchException) {


### PR DESCRIPTION
## Summary

- Replace `Class<*>`/`.javaClass` patterns with `KClass<*>` and cross-platform alternatives in 8 commonMain-candidate files
- Create `TypeTokenUtils` expect/actual to bridge Kotlin `KClass<*>` and Java `Class<*>` type tokens in the XPath function prototype system
- Java test files continue to work unchanged — the JVM bridge handles both `KClass` and `Class` transparently

## Files changed (11)

| File | Change |
|------|--------|
| `LruCache.kt` | `javaClass.name` → `this::class.qualifiedName` |
| `ExternalDataInstanceSource.kt` | `javaClass.canonicalName` → `this::class.qualifiedName` |
| `Text.kt` | `arrayOf<Class<*>>(PlatformDate::class.java, ...)` → `arrayOf<Any>(PlatformDate::class, ...)` |
| `FormDef.kt` | Same prototype change + `getExtension(Class<X>)` → `getExtension(KClass<X>, factory)` |
| `User.kt` | `String::class.java` → `String::class` in applyDataType calls |
| `RestoreUtils.kt` | `Class<*>` → `KClass<*>` throughout type mapping |
| `HereFunctionHandler.kt` | `Array<Class<*>>` → `Array<Any>` for empty prototype |
| `XPathCustomRuntimeFunc.kt` | matchPrototype uses `TypeTokenUtils` for cross-platform matching |
| `TypeTokenUtils.kt` (common) | expect declarations for `isInstanceOfTypeToken`/`isTypeTokenEqual` |
| `TypeTokenUtils.kt` (jvm) | actual impl handles both KClass and Class |
| `TypeTokenUtils.kt` (ios) | actual impl handles KClass only |

## Test plan

- [x] `./gradlew compileKotlinJvm compileJava` passes
- [x] `./gradlew jvmTest` passes (710 tests — Java tests using Class[] prototypes work via bridge)
- [x] `./gradlew compileCommonMainKotlinMetadata` passes
- [x] Zero `Class<*>`/`.javaClass`/`::class.java` in the 8 candidate files

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)