### PR TITLE
docs: Phase 4 completion report and learnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,9 @@ iOS implementation of CommCare Mobile using Kotlin Multiplatform (KMP) + Compose
 ```
 commcare-ios/
 ├── commcare-core/           # CommCare engine (git subtree from jjackson/commcare-core)
-│   ├── src/commonMain/      # KMP shared code (88 .kt files — platform-agnostic)
-│   ├── src/jvmMain/         # JVM platform implementations (10 .kt files)
-│   ├── src/iosMain/         # iOS/Native platform implementations (11 .kt files)
+│   ├── src/commonMain/      # KMP shared code (204 .kt files — platform-agnostic)
+│   ├── src/jvmMain/         # JVM platform implementations (59 .kt files)
+│   ├── src/iosMain/         # iOS/Native platform implementations (33 .kt files)
 │   ├── src/main/java/       # JVM-only Kotlin + Java source (being migrated to commonMain)
 │   ├── src/test/java/       # JUnit 4 tests (JVM)
 │   ├── src/commonTest/      # Cross-platform tests (run on both JVM and iOS)
@@ -90,24 +90,23 @@ commcare-ios/
 | Wave | Group | Files | Issue | Status |
 |------|-------|-------|-------|--------|
 | 1 | Quick wins (Math, Locale, Objects, synchronized) | ~10 | #111 | Done (PR #122) |
-| 2 | Convert remaining Java files to Kotlin | 13 | #112 | Done (PR #123) |
+| 2 | Convert remaining Java files to Kotlin | 13 | #112 | Done (PR #122) |
 | 3 | Complete Date/Calendar migration | ~7 | #113 | Done (PR #125) |
-| 4 | Migrate xmlpull/kxml2 consumers | 9 | #114 | Open |
+| 4 | Migrate xmlpull/kxml2 consumers | 9 | #114 | Done (PR #128) |
 | 5 | Abstract org.json to PlatformJson | 8 | #115 | Done (PR #124) |
-| 6 | Abstract io.reactivex and tracing | 7 | #116 | Done (PR #124) |
-| 7 | Abstract java.io and java.net | ~18 | #117 | In Progress (PR #126 partial) |
-| 8 | KClass conversion for serialization | ~16 | #118 | Open |
+| 6 | Abstract io.reactivex and tracing | 7 | #116 | Done (PR #123) |
+| 7 | Abstract java.io and java.net | ~18 | #117 | Done (PRs #126, #127) |
+| 8 | KClass conversion for serialization | ~16 | #118 | Done (PR #129) |
 | 9 | Move HTTP/network files to jvmMain | 7 | #119 | Done (PR #124) |
-| 10 | Bulk migration to commonMain | 390+ | #120 | Open |
+| 10 | Bulk migration to commonMain | 390+ | #120 | Done (PR #130) |
 
-**Next**: Waves 4 (xmlpull/kxml2), 7 (java.io/net remaining), 8 (KClass). Wave 10 depends on all.
-
-**Plan**: `docs/plans/2026-03-11-phase4-deep-migration-plan.md`
+**Phase 4 Complete.** All 10 waves done. 204 files in commonMain (+20 from Phase 3). Bulk migration hit ceiling: ~450 files blocked by ExtUtil/ExtWrap* serialization framework's deep `Class<*>` dependency. See `docs/plans/2026-03-11-phase4-completion-report.md`.
 
 ## Key Docs
 
 **Plans:**
 - **Design**: `docs/plans/2026-03-07-commcare-ios-design.md` — full architecture, phasing, verification strategy
+- **Phase 4 completion**: `docs/plans/2026-03-11-phase4-completion-report.md` — 204 commonMain files, ExtUtil serialization ceiling, options for Phase 5
 - **Phase 4 plan**: `docs/plans/2026-03-11-phase4-deep-migration-plan.md` — targeted JVM dep removal from 67 blocker files, wave details
 - **Phase 3 completion**: `docs/plans/2026-03-11-phase3-completion-report.md` — 184 commonMain files, blocker analysis, remaining JVM deps
 - **Phase 3 plan**: `docs/plans/2026-03-10-phase3-engine-on-ios-plan.md` — wave details, dependency analysis, serialization framework strategy
@@ -135,6 +134,7 @@ commcare-ios/
 - **iOS CI learnings**: `docs/learnings/2026-03-10-ios-ci-learnings.md` — iOS-specific API differences, commonMain visibility from app module, CI strategy
 - **Phase 3 Wave 1 learnings**: `docs/learnings/2026-03-10-wave1-collection-replacement-learnings.md` — Hashtable nullable get(), OrderedHashtable→LinkedHashMap, reversed arg order, .keys() vs .keys, exception subclass changes
 - **Phase 3 Wave 4 learnings**: `docs/learnings/2026-03-11-wave4-serialization-framework-learnings.md` — Class<*> as fundamental blocker, extension function shadowing, ExtUtil inlining workaround, PrototypeFactory expect/actual pattern
+- **Phase 4 deep migration learnings**: `docs/learnings/2026-03-11-phase4-deep-migration-learnings.md` — ExtUtil ceiling, iterative compiler-validated migration, platformSynchronized, TypeTokenUtils bridge, XFormConstants extraction
 
 ## Kotlin Conversion Checklist
 

--- a/docs/learnings/2026-03-11-phase4-deep-migration-learnings.md
+++ b/docs/learnings/2026-03-11-phase4-deep-migration-learnings.md
@@ -1,0 +1,86 @@
+# Phase 4: Deep Migration — Learnings
+
+**Date:** 2026-03-11
+
+---
+
+## 1. ExtUtil/ExtWrap* Creates an Insurmountable commonMain Ceiling
+
+**Problem:** Nearly every model class implements `Externalizable` and delegates serialization to `ExtUtil`, which uses `Class<*>`, `Class.forName()`, and `newInstance()` — all JVM-only APIs. The `ExtWrap*` family (ExtWrapList, ExtWrapMap, ExtWrapTagged) uses `Class<out List<*>>` type tokens that trigger Kotlin compiler internal errors when compiled for Kotlin/Native.
+
+**Impact:** Even files with zero direct JVM imports can't move to commonMain because they import types that transitively depend on ExtUtil. ~420 files are blocked by this single dependency chain.
+
+**Lesson:** In a large codebase migration to KMP, the serialization framework is the critical path blocker. It should be addressed early, not last. The iterative bulk migration approach (move all → compile → rollback failures) is effective at *discovering* the ceiling but can't *break through* it.
+
+## 2. Iterative Compiler-Validated Migration Is Effective but Limited
+
+**Pattern:** Move N files to commonMain → run `compileCommonMainKotlinMetadata` → files that error get moved back → repeat until stable.
+
+**Pros:** Safely identifies which files can move without manual dependency analysis. Each round resolves the outermost layer of failures.
+
+**Cons:** Required 6 rounds for 445 files, and only 9 survived. The approach discovers *that* there's a ceiling but doesn't help *break through* it. Each round takes ~30 seconds of compile time.
+
+**Lesson:** Use this approach for the final "sweep" after targeted refactoring, not as the primary migration strategy.
+
+## 3. platformSynchronized: Inline Expect/Actual for Zero-Cost Abstraction
+
+**Pattern:**
+```kotlin
+// commonMain
+expect inline fun <R> platformSynchronized(lock: Any, block: () -> R): R
+
+// jvmMain
+actual inline fun <R> platformSynchronized(lock: Any, block: () -> R): R =
+    kotlin.synchronized(lock, block)
+
+// iosMain - no-op (single-threaded K/N default)
+actual inline fun <R> platformSynchronized(lock: Any, block: () -> R): R = block()
+```
+
+**Why inline:** Avoids function call overhead on the hot JVM path. The iOS no-op compiles away entirely.
+
+**Why not @Synchronized:** `@Synchronized` is `kotlin.jvm.Synchronized` — available in commonMain with explicit import but generates no code on non-JVM targets. `platformSynchronized` wraps code blocks rather than methods, which is what most call sites need.
+
+**Lesson:** For JVM threading primitives, inline expect/actual is the cleanest KMP pattern. Don't try to make `@Synchronized` work cross-platform.
+
+## 4. TypeTokenUtils: Bridging KClass and Class in Mixed Codebases
+
+**Problem:** `IFunctionHandler.getPrototypes()` returns `ArrayList<Array<Any>>` where each `Any` is a type token (originally `Class<*>`). Some handlers now return `KClass<*>` tokens, others still return `Class<*>`. The matching code needs to handle both.
+
+**Solution:** `TypeTokenUtils` expect/actual with two functions:
+- `isInstanceOfTypeToken(token: Any, value: Any): Boolean` — checks if value is instance of type described by token
+- `isTypeTokenEqual(token: Any, target: KClass<*>): Boolean` — checks if token represents the same type as target
+
+JVM implementation handles both `KClass<*>` and `Class<*>`. iOS only handles `KClass<*>`.
+
+**Lesson:** During migration, type token systems need a bridge layer that accepts both old (Class) and new (KClass) token types. Don't force all callers to convert at once.
+
+## 5. XFormParseException: String Location Instead of kxml2 Element
+
+**Problem:** `XFormParseException` stored a kxml2 `Element` reference, making it JVM-only. But the exception is thrown from dozens of places in cross-platform code.
+
+**Solution:** Changed from `Element?` to `String?` (element location). Created `getVagueLocation(element: Element): String` helper in XFormParser to convert at throw sites. The string contains element name and attributes — enough for debugging.
+
+**Lesson:** Exception classes are high-value migration targets because they're imported widely. Making them cross-platform unblocks many transitive dependents. Replace platform-specific objects with String descriptions where the object is only used for error messages.
+
+## 6. XFormConstants: Breaking Import Cycles with Constant Extraction
+
+**Problem:** Many files import XFormParser just for string constants like `LABEL_ELEMENT`, `VALUE_ELEMENT`. XFormParser itself is deeply JVM-bound (kxml2, java.io). These imports create false transitive dependencies.
+
+**Solution:** Extracted constants to a standalone `XFormConstants` object in commonMain. Changed imports in consumer files.
+
+**Lesson:** Look for "false dependency" patterns where files import a large class just for constants. Extracting constants to a standalone object breaks import cycles and enables migration of consumer files.
+
+## 7. Kotlin Compiler Internal Error with Class<out List<*>>
+
+**Problem:** When `ExtWrapList` (which uses `Class<out List<*>>` constructor parameter) was compiled for commonMain/Kotlin Native, the compiler crashed with "Shouldn't be here" internal error.
+
+**Lesson:** Some JVM generic patterns using `Class<*>` with variance are fundamentally incompatible with Kotlin/Native compilation. This isn't a missing API — it's a compiler limitation. Don't attempt to move files with these patterns; refactor them first.
+
+## 8. .initCause() Is JVM-Only
+
+**Problem:** `Throwable.initCause()` exists in JVM but not in Kotlin common. Files using it can't move to commonMain.
+
+**Solution:** Remove `initCause()` calls. If the cause information is needed, include it in the exception message string or use a constructor that accepts `cause` parameter.
+
+**Lesson:** Check for JVM-only `Throwable` methods: `initCause()`, `getStackTrace()`, `setStackTrace()`, `getSuppressed()`. These have no common Kotlin equivalents.

--- a/docs/plans/2026-03-11-phase4-completion-report.md
+++ b/docs/plans/2026-03-11-phase4-completion-report.md
@@ -1,0 +1,159 @@
+# Phase 4: Deep Migration — Completion Report
+
+**Date:** 2026-03-11
+**Status:** Complete (ceiling reached)
+
+---
+
+## Summary
+
+Phase 4 targeted the 67 Kotlin files and 13 Java files with direct JVM imports that were blocking ~390 transitively-dependent files from moving to commonMain. All 10 waves completed. The phase successfully removed JVM dependencies from most blocker files and moved 20 net new files to commonMain, but the bulk migration attempt (Wave 10) revealed that deep transitive dependency chains through the serialization framework (ExtUtil/ExtWrap*/PrototypeFactory) prevent the remaining ~450 files from moving without a fundamental serialization framework refactoring.
+
+---
+
+## What Was Done
+
+### Wave 1: Quick wins (PR #122)
+- Replaced `java.lang.Math` → `kotlin.math`, `Objects.equals()` → `==`, `java.util.Locale` → expect/actual
+- Removed `synchronized` blocks or replaced with expect/actual where needed
+
+### Wave 2: Convert remaining Java files to Kotlin (PR #122)
+- Converted all 13 remaining `.java` files to Kotlin
+- **Zero Java source files remain** in the codebase (test files excluded)
+
+### Wave 3: Complete Date/Calendar migration (PR #125)
+- Replaced remaining `java.util.Date`, `java.util.Calendar`, `java.util.TimeZone`, `java.text.SimpleDateFormat`
+- Extended PlatformDate abstractions with formatting and calendar operations
+
+### Wave 4: Migrate xmlpull/kxml2 consumers (PR #128)
+- Isolated kxml2 from cross-platform code
+- Extracted `XFormConstants` (string constants like LABEL_ELEMENT) from XFormParser to commonMain
+- Refactored `XFormParseException` to use `String?` location instead of kxml2 `Element` → moved to commonMain
+- Wrapped 31+ XFormParser call sites with `getVagueLocation(element)` conversion
+
+### Wave 5: Abstract org.json to PlatformJson (PR #124)
+- Created PlatformJson abstraction for JSON parsing
+- Migrated graph config and JsonUtils
+
+### Wave 6: Abstract io.reactivex and tracing (PR #123)
+- Replaced `io.reactivex.Single` with callback/interface pattern
+- Replaced `datadog`/`opentracing` tracing with no-op interface abstraction
+
+### Wave 7: Abstract java.io and java.net (PRs #126, #127)
+- Moved JVM-only files to jvmMain
+- Created platform abstractions for remaining java.io/java.net patterns
+- Extended PlatformFile, PlatformIO, PlatformUrl abstractions
+
+### Wave 8: KClass conversion (PR #129)
+- Replaced `Class<*>` and `.javaClass` with `KClass<*>` and `this::class` in 8 commonMain-candidate files
+- Created `TypeTokenUtils` expect/actual for cross-platform type token matching (KClass on common, supporting both KClass and Class on JVM)
+- Refactored `XPathCustomRuntimeFunc.matchPrototype` to use `isInstanceOfTypeToken`/`isTypeTokenEqual` helpers
+- Changed `FormDef.getExtension()` from reflection-based to factory lambda pattern
+
+### Wave 9: Move HTTP/network files to jvmMain (PR #124)
+- Moved okhttp3/retrofit2 consumers to jvmMain where they belong
+
+### Wave 10: Bulk migration attempt (PR #130)
+- Attempted to move all ~445 remaining files to commonMain
+- Required 6 iterative rounds of compiler-validated migration (move → compile → rollback failures → repeat)
+- **9 net new files moved to commonMain**: XFormParseException, XFormConstants, Reference, ReferenceFactory, ReleasedOnTimeSupportedReference, Localizer, TimezoneProvider, SimpleNode
+- Created `platformSynchronized()` expect/actual abstraction (JVM → `kotlin.synchronized`, iOS → no-op)
+- Removed `@Synchronized` from 8 files for commonMain compatibility
+- Removed `.initCause()` (JVM-only) from 6 files
+
+---
+
+## File Distribution
+
+| Source Set | Files | Change from Phase 3 |
+|-----------|-------|---------------------|
+| commonMain | 204 .kt | +20 from 184 |
+| jvmMain | 59 .kt | +38 from 21 |
+| iosMain | 33 .kt | +12 from 21 |
+| commonTest | 6 .kt | unchanged |
+| src/main/java | 450 .kt, 0 .java | -20 .kt, -13 .java |
+
+---
+
+## Why 450 Files Remain in src/main/java
+
+The bulk migration attempt (Wave 10) was the key test. After moving all 445 files and iteratively rolling back those with compilation errors, only 9 could stay. The root cause:
+
+### The ExtUtil/ExtWrap Dependency Chain
+
+Nearly every model class implements `Externalizable` and uses `ExtUtil` for serialization. `ExtUtil` has deep dependencies on `Class<*>` (JVM reflection):
+
+```
+EvaluationContext → DataInstance → ExtUtil → Class<*>
+TreeReference → ExtUtil → Class<*>
+FormDef → ExtUtil → Class<*>
+ResourceTable → ExtUtil → Class<*>
+```
+
+The `ExtWrap*` family (ExtWrapList, ExtWrapMap, ExtWrapTagged, etc.) uses `Class<out List<*>>`, `Class.forName()`, and `Class.newInstance()` extensively. When `ExtWrapList` was moved to commonMain, it triggered a **Kotlin compiler internal error** ("Shouldn't be here"), indicating these patterns are fundamentally incompatible with Kotlin/Native compilation.
+
+### Transitive Cascade
+
+Because `ExtUtil` is used by ~131 classes, and those classes are imported by ~300+ others, the entire dependency graph collapses when ExtUtil can't move. Files with zero direct JVM imports still fail because they import types that import types that use ExtUtil.
+
+### What Would Unblock Further Migration
+
+1. **Replace ExtUtil serialization framework** with KClass-based alternatives (no `Class.forName()`, no `newInstance()`)
+2. **Replace ExtWrap* classes** with Kotlin-native serialization patterns
+3. **Or**: Accept a hybrid architecture where serialization stays JVM-only and iOS uses a separate serialization layer (e.g., kotlinx-serialization)
+
+---
+
+## New Platform Abstractions Created
+
+| Abstraction | commonMain | jvmMain | iosMain |
+|------------|-----------|---------|---------|
+| `platformSynchronized()` | expect fun | `kotlin.synchronized()` | no-op (single-threaded) |
+| `TypeTokenUtils` | expect funs | Handles both KClass and Class | KClass-only |
+| `XFormConstants` | String constants | — | — |
+
+---
+
+## Key Technical Decisions
+
+1. **platformSynchronized as inline expect/actual**: Preserves zero-cost synchronization on JVM while being a no-op on iOS (single-threaded Kotlin/Native default).
+2. **TypeTokenUtils bridge**: Allows `IFunctionHandler.getPrototypes()` to return `Array<Any>` containing either `KClass<*>` (new code) or `Class<*>` (legacy code), checked at runtime.
+3. **Factory lambda over reflection**: `FormDef.getExtension(KClass<X>, factory: () -> X)` replaces `getExtension(Class<X>)` which used `newInstance()`.
+4. **Iterative compiler-validated migration**: Move all candidates → `compileCommonMainKotlinMetadata` → rollback failures → repeat. Discovered the ExtUtil ceiling efficiently.
+
+---
+
+## Tests
+
+- **710+ JVM tests passing** (`./gradlew test` — BUILD SUCCESSFUL)
+- **21 cross-platform tests passing** (commonTest)
+- No regressions introduced across any wave
+
+---
+
+## PRs
+
+| PR | Wave(s) | Description |
+|----|---------|-------------|
+| #122 | 1-2 | JVM pattern removal + Java→Kotlin conversion |
+| #125 | 3 | Date/Calendar/TimeZone abstractions |
+| #128 | 4 | kxml2 isolation |
+| #124 | 5, 9 | org.json abstraction + HTTP/graph to jvmMain |
+| #123 | 6 | io.reactivex and tracing abstractions |
+| #126 | 7 (partial) | JVM-only file moves + simple pattern fixes |
+| #127 | 7 | java.io/net/text/concurrent platform abstractions |
+| #129 | 8 | KClass conversion |
+| #130 | 10 | Bulk migration + platformSynchronized |
+
+---
+
+## Assessment
+
+Phase 4 achieved its goal of removing direct JVM dependencies from blocker files, but discovered that the serialization framework (ExtUtil/ExtWrap*) creates an insurmountable ceiling for bulk migration. The ~450 files in src/main/java are transitively locked by this dependency.
+
+**Options for further progress:**
+1. **Serialization framework rewrite** — Replace ExtUtil/ExtWrap* with KClass-based registration factory (large scope, ~131 classes affected)
+2. **Hybrid architecture** — Accept that serialization stays JVM-only; iOS uses kotlinx-serialization independently
+3. **Interface extraction** — Create commonMain interfaces for core engine types, with JVM implementations staying in main/java
+
+The current 204 commonMain files + 59 jvmMain + 33 iosMain represent a stable KMP architecture. The core question for Phase 5 is which approach to the serialization framework yields the best path to iOS engine functionality.


### PR DESCRIPTION
## Summary
- Phase 4 completion report documenting all 10 waves, final file distribution (204 commonMain, 450 main/java), and ExtUtil serialization ceiling analysis
- Phase 4 learnings covering: iterative compiler-validated migration, platformSynchronized pattern, TypeTokenUtils bridge, XFormConstants extraction, compiler internal error with Class<out List<*>>
- CLAUDE.md updates: Phase 4 status table marked complete, file counts updated, new docs linked

## Test plan
- [ ] Doc-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)