### PR TITLE
docs: Phase 5 serialization migration learnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,15 +106,13 @@ commcare-ios/
 
 | Wave | Group | Files | Issue | Status |
 |------|-------|-------|-------|--------|
-| 1 | Refactor ExtUtil | 1 | | Open |
-| 2 | Refactor ExtWrapBase | 1 | | Open |
-| 3 | Refactor ExtWrapList | 1 | | Open |
-| 4 | Refactor ExtWrapTagged + Hasher | 3 | | Open |
-| 5 | Refactor remaining ExtWrap* | 4 | | Open |
-| 6 | Refactor PrototypeFactory + PrototypeManager | 3 | | Open |
-| 7 | Move ExtUtil/ExtWrap* consumers to commonMain | ~50-100 | | Open |
-| 8 | Bulk migration sweep | ~300+ | | Open |
-| 9 | Validation and cleanup | ~5 new | | Open |
+| 1-3 | Refactor ExtUtil, ExtWrapBase, ExtWrapList | 3 | #133-#135 | Done (PR #142) |
+| 4 | Refactor ExtWrapTagged + Hasher | 3 | #136 | Done (PR #142) |
+| 5 | Refactor remaining ExtWrap* | 4 | #137 | Done (PR #142) |
+| 6 | Refactor PrototypeFactory + PrototypeManager | 3 | #138 | Done (PR #142) |
+| 7 | Migrate pure Kotlin files to commonMain | 23 moved | #139 | Done (PR #142) |
+| 8 | Move serialization framework + cluster to commonMain | ~400 | #140 | Open |
+| 9 | Validation and cleanup | ~5 new | #141 | Open |
 
 **Plan**: `docs/plans/2026-03-11-phase5-serialization-refactor-plan.md`
 
@@ -144,6 +142,7 @@ commcare-ios/
 - **Wave 3 XPath learnings**: `docs/learnings/2026-03-09-wave3-xpath-conversion-learnings.md` — KDoc `*/` hazard, abstract preservation, nullable threading, protected→internal
 - **Wave 4 XForm parser learnings**: `docs/learnings/2026-03-09-wave4-xform-parser-learnings.md` — companion method inheritance, `@JvmField` vs `open`, companion `protected` limitation, smart cast on `var`, `const val` auto-inline
 - **J2K vs AI conversion**: `docs/learnings/2026-03-09-j2k-converter-vs-ai-conversion.md` — why we chose AI-driven conversion over IntelliJ's J2K converter
+- **Phase 5 serialization migration**: `docs/learnings/2026-03-11-phase5-serialization-migration-learnings.md` — LiveHasher side effects, qualifiedName vs Class.getName(), iterative migration cascading, serialization framework as root blocker
 - **Wave 5 case-management learnings**: `docs/learnings/2026-03-09-wave5-case-management-learnings.md` — JVM signature clashes (constructor `val` vs interface method, field vs getter), Java boxed types in generics, Kotlin-to-Kotlin method calls
 - **Wave 6 suite-session learnings**: `docs/learnings/2026-03-10-wave6-suite-session-learnings.md` — `internal` hides from Java in other source sets, property getter/setter clashes, nullable return types Java silently allowed
 - **Wave 8 core-services learnings**: `docs/learnings/2026-03-10-wave8-core-services-learnings.md` — `@JvmField protected` for cross-source-set Java subclasses, OkHttp 4/Okio 2 API migration, `const val` requires compile-time constants

--- a/docs/learnings/2026-03-11-phase5-serialization-migration-learnings.md
+++ b/docs/learnings/2026-03-11-phase5-serialization-migration-learnings.md
@@ -1,0 +1,43 @@
+# Phase 5 Serialization Framework Migration Learnings
+
+**Date:** 2026-03-11
+**Context:** Phase 5 Waves 1-7 — Refactoring serialization framework from Class<*> to KClass<*> and attempting bulk migration to commonMain.
+
+## Learning 1: LiveHasher has side effects in getHash()
+
+**Problem:** `LivePrototypeFactory.LiveHasher.getHash(c: Class<*>)` registers classes in the factory as a side effect. When `Hasher.getClassHashValue()` was changed to delegate to `getClassHashValueByName(type.name)` (string-based path), it bypassed `getHash()` and broke registration.
+
+**Fix:** Keep `getClassHashValue(type: Class<*>)` calling `getHash(c)` directly. Add `getClassHashValueByName(className: String)` as a SEPARATE path that calls `getHashByName(className)`. Don't unify them — the Class path has side effects the String path must not have.
+
+## Learning 2: KClass.qualifiedName differs from Class.getName() for inner classes
+
+**Problem:** Java's `Class.getName()` uses `$` for inner classes (`Outer$Inner`), while Kotlin's `KClass.qualifiedName` uses `.` (`Outer.Inner`). Using `qualifiedName` for hash computation produces different hashes than the factory registered with `Class.getName()`.
+
+**Fix:** For JVM code that must match existing serialized data, always use `javaClass.name` or `type.java.name`, never `::class.qualifiedName`. The string-based cross-platform path should use qualified names, but JVM backward-compat code must use Java names.
+
+## Learning 3: ExtUtil.read(Class<*>) uses Class.newInstance(), not PrototypeFactory
+
+**Problem:** The original `ExtUtil.read(in, type: Class<*>, pf)` creates instances via `type.newInstance()` directly — no PrototypeFactory needed. The new KClass-based `read` tried to use factory-based creation, which fails when tests pass `pf = null` and the default PrototypeManager doesn't have the class registered.
+
+**Fix:** Keep two separate read paths:
+- `read(in, type: Class<*>, pf)` — JVM path using `PrototypeFactory.getInstance(type)` (reflection)
+- `read(in, type: KClass<*>, pf)` — Cross-platform path using `createExternalizableInstance(type)` (expect/actual)
+
+## Learning 4: Only 23 of 419 "clean" files could actually migrate
+
+**Problem:** Of 450 files in main/java, only 31 had direct JVM-only imports. The other 419 appeared clean. But when moved to commonMain, they fail because they reference other main/java files transitively. The tight coupling between model classes (TreeElement ↔ FormDef ↔ EvaluationContext ↔ XPathExpression) means they must move as a cluster, and the cluster depends on ExtUtil/ExtWrap* which have Class<*>.
+
+**Key insight:** The serialization framework (10 files with Class<*>) is the ROOT BLOCKER. Moving it to commonMain would unblock ~400 files, but it requires:
+1. `expect fun createExternalizableInstance(type: KClass<*>)` for instance creation
+2. Restructuring ExtWrapTagged.writeTag/readTag for cross-platform use
+3. All consumers calling `new ExtWrapBase(SomeClass.class)` need JVM-compat constructors
+
+## Learning 5: Consumer files don't import ExtUtil directly
+
+**Discovery:** All 91 files using serialization go through `SerializationHelpers` (already in commonMain). Zero files outside the externalizable package import ExtUtil or ExtWrap* directly. The serialization framework is self-contained — but it blocks the model classes that implement `Externalizable` and call `ExtUtil.read/write` in their `readExternal/writeExternal` methods.
+
+## Learning 6: Iterative compiler-validated migration works but cascades
+
+**Process:** Moved all 419 candidate files → compiled → got 48 failures → moved them back → compiled → got 102 more failures (new dependencies exposed) → moved back → got 188 more → moved back → got 47 → moved back → got 11 → moved back → 0 errors. Each round exposes files that depended on what was just moved back.
+
+**Result:** Only 23 files survived all iterations. The remaining 396 form one big transitive dependency cluster that must move together.


### PR DESCRIPTION
## Summary
- Add Phase 5 serialization migration learnings doc with 6 key findings
- Update CLAUDE.md Phase 5 status table (Waves 1-7 Done via PR #142)
- Link new learnings doc in Key Docs section

## Key learnings documented
- LiveHasher has side effects in `getHash()` that must be preserved
- `KClass.qualifiedName` differs from `Class.getName()` for inner classes
- `ExtUtil.read(Class<*>)` uses reflection, not PrototypeFactory
- Only 23 of 419 "clean" files could actually migrate to commonMain
- Consumer files use SerializationHelpers, not ExtUtil directly
- Iterative compiler-validated migration works but cascades

🤖 Generated with [Claude Code](https://claude.com/claude-code)