### PR TITLE
docs: Phase 5 Wave 8 learnings + status update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,10 @@ commcare-ios/
 | 5 | Refactor remaining ExtWrap* | 4 | #137 | Done (PR #142) |
 | 6 | Refactor PrototypeFactory + PrototypeManager | 3 | #138 | Done (PR #142) |
 | 7 | Migrate pure Kotlin files to commonMain | 23 moved | #139 | Done (PR #142) |
-| 8 | Move serialization framework + cluster to commonMain | ~400 | #140 | Open |
+| 8 | Move serialization framework + cluster to commonMain | 23 moved | #140 | Done (PR #145) |
 | 9 | Validation and cleanup | ~5 new | #141 | Open |
+
+**Wave 8 result:** Moved ExtUtil + ExtWrap* (12 files) + 11 additional files to commonMain. commonMain: 227 files. Remaining ~430 files blocked by core model classes (TreeReference, TreeElement, FormDef) with deep JVM deps (DateUtils, OrderedHashtable, ThreadLocal). See `docs/learnings/2026-03-12-phase5-wave8-serialization-commonmain-learnings.md`.
 
 **Plan**: `docs/plans/2026-03-11-phase5-serialization-refactor-plan.md`
 
@@ -151,6 +153,7 @@ commcare-ios/
 - **Phase 3 Wave 1 learnings**: `docs/learnings/2026-03-10-wave1-collection-replacement-learnings.md` — Hashtable nullable get(), OrderedHashtable→LinkedHashMap, reversed arg order, .keys() vs .keys, exception subclass changes
 - **Phase 3 Wave 4 learnings**: `docs/learnings/2026-03-11-wave4-serialization-framework-learnings.md` — Class<*> as fundamental blocker, extension function shadowing, ExtUtil inlining workaround, PrototypeFactory expect/actual pattern
 - **Phase 4 deep migration learnings**: `docs/learnings/2026-03-11-phase4-deep-migration-learnings.md` — ExtUtil ceiling, iterative compiler-validated migration, platformSynchronized, TypeTokenUtils bridge, XFormConstants extraction
+- **Phase 5 Wave 8 learnings**: `docs/learnings/2026-03-12-phase5-wave8-serialization-commonmain-learnings.md` — LinkedHashMap final in Native, top-level functions vs Java constructors, Class<*>→KClass<*> pattern, @Throws filter strictness
 
 ## Kotlin Conversion Checklist
 

--- a/docs/learnings/2026-03-12-phase5-wave8-serialization-commonmain-learnings.md
+++ b/docs/learnings/2026-03-12-phase5-wave8-serialization-commonmain-learnings.md
@@ -1,0 +1,60 @@
+# Phase 5 Wave 8: Serialization Framework to commonMain — Learnings
+
+## Date: 2026-03-12
+
+## Context
+Moved ExtUtil, ExtWrap*, and related serialization classes from `main/java` to `commonMain` to unblock transitive dependency migration.
+
+## Key Learnings
+
+### 1. LinkedHashMap is final in Kotlin/Native
+OrderedHashtable extends `LinkedHashMap`, which is **final** in Kotlin/Native. This means:
+- OrderedHashtable cannot be moved to commonMain directly
+- Solution: Keep in main/java + create `expect/actual` functions (`createOrderedHashMap()`, `isOrderedHashMap()`) for cross-platform map creation/checking
+- JVM actual uses OrderedHashtable, iOS actual uses LinkedHashMap (which is inherently ordered)
+
+### 2. Top-level Kotlin functions can't replace Java constructors
+When moving classes to commonMain and removing `Class<*>` constructors, Java callers that use `new ExtWrapFoo(SomeType.class)` cannot simply call top-level Kotlin factory functions — Java requires `new` for constructors.
+
+**Solution:** Define top-level factory functions in jvmMain with `@file:JvmName("ExtWrapJvmCompat")`, then Java callers use `static import`:
+```java
+import static org.javarosa.core.util.externalizable.ExtWrapJvmCompat.*;
+// Then: ExtWrapList(Integer.class) — no `new` keyword
+```
+
+### 3. Class<*>→KClass<*> migration pattern for serialization
+When converting serialization code from JVM-specific `Class<*>` to cross-platform `KClass<*>`:
+
+1. **Constructor access**: `Class.newInstance()` → `PrototypeFactory.createInstance(KClass<*>)` (expect/actual)
+2. **Hash computation**: `PrototypeFactory.getClassHash(Class<*>)` → `PrototypeFactory.getClassHashForType(KClass<*>)` (expect/actual)
+3. **Default factory**: `PrototypeManager.getDefault()` → `defaultPrototypeFactory()` (expect/actual)
+4. **Class name lookup**: `Class.forName(name).kotlin` → `classNameToKClass(name)` (expect/actual)
+5. **Runtime type**: `obj.javaClass` → `obj::class` (built-in Kotlin)
+6. **KClass property access**: `kclass.java` (JVM-only) → not needed in commonMain
+
+### 4. Backward-compat layer structure
+For JVM backward compatibility with Class<*> APIs:
+- `ExtUtilJvm` — contains `read(Class<*>)` and `deserialize(Class<*>)` overloads
+- `ExtWrapJvmCompat` — contains factory functions for all ExtWrap* Class<*> constructors
+- Both in `jvmMain`, not `commonMain`
+
+### 5. @Throws filter must EXACTLY match in commonMain
+On JVM, a mismatched `@Throws` is a warning. On Kotlin/Native (commonMain metadata compilation), it's an **error**:
+```
+Member overrides different '@Throws' filter from 'interface Externalizable : Any'
+```
+If the interface declares `@Throws(A::class, B::class)`, the override MUST have both — not just `@Throws(A::class)`.
+
+### 6. Serialization framework alone doesn't unblock bulk migration
+Moving ExtUtil/ExtWrap* to commonMain unblocked only ~11 additional files (beyond the 12 serialization files themselves). The remaining ~430 files are blocked by **core model classes** (TreeReference, TreeElement, FormDef, EvaluationContext) which have deeper JVM dependencies:
+- DateUtils (PlatformDate property patterns)
+- OrderedHashtable (final LinkedHashMap)
+- ThreadLocal singletons
+- System/Runtime APIs
+
+The next migration wave needs to target these core model classes directly.
+
+## File Distribution After Wave 8
+- commonMain: 227 .kt files (was 204)
+- main/java: 430 .kt files (was 449)
+- jvmMain: ~65 .kt files (includes new compat files)


### PR DESCRIPTION
## Summary
- Add learnings from serialization framework → commonMain migration
- Update CLAUDE.md with Wave 8 completion status (227 commonMain files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)