### PR TITLE
docs: Phase 5 completion report + Phase 6 plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,16 +112,31 @@ commcare-ios/
 | 6 | Refactor PrototypeFactory + PrototypeManager | 3 | #138 | Done (PR #142) |
 | 7 | Migrate pure Kotlin files to commonMain | 23 moved | #139 | Done (PR #142) |
 | 8 | Move serialization framework + cluster to commonMain | 23 moved | #140 | Done (PR #145) |
-| 9 | Validation and cleanup | ~5 new | #141 | Open |
+| 9 | Validation and cleanup | ~5 new | #141 | Deferred to Phase 6 |
 
-**Wave 8 result:** Moved ExtUtil + ExtWrap* (12 files) + 11 additional files to commonMain. commonMain: 227 files. Remaining ~430 files blocked by core model classes (TreeReference, TreeElement, FormDef) with deep JVM deps (DateUtils, OrderedHashtable, ThreadLocal). See `docs/learnings/2026-03-12-phase5-wave8-serialization-commonmain-learnings.md`.
+**Phase 5 Complete.** Serialization framework (ExtUtil, ExtWrap*, 12 files) moved to commonMain + 11 additional files. commonMain: 227 files. Bulk migration attempted but 430 remaining files form one connected component blocked by 16 files with direct JVM deps (java.io, ThreadLocal, System.getProperty, gavaghan). See `docs/plans/2026-03-12-phase5-completion-report.md`.
 
-**Plan**: `docs/plans/2026-03-11-phase5-serialization-refactor-plan.md`
+**Phase 6: Deep Platform Abstraction** — Remove JVM dependencies from 16 direct blocker files to unblock bulk migration of 430 remaining files.
+
+| Wave | Group | Files | Issue | Status |
+|------|-------|-------|-------|--------|
+| 1 | FormDef — System.getProperty removal | 1 | #147 | Open |
+| 2 | ThreadLocal abstraction | 3 | #148 | Open |
+| 3 | java.io Reader/Writer abstraction | 6 | #149 | Open |
+| 4 | ResourceTable — FileNotFoundException | 1 | #150 | Open |
+| 5 | XFormParserReporter — PrintStream | 1 | #151 | Open |
+| 6 | Gavaghan geodesy replacement | 4 | #152 | Open |
+| 7 | Bulk migration sweep | ~380+ | #153 | Open |
+| 8 | Validation and cleanup | ~5 new | #154 | Open |
+
+**Plan**: `docs/plans/2026-03-12-phase6-deep-platform-abstraction-plan.md`
 
 ## Key Docs
 
 **Plans:**
 - **Design**: `docs/plans/2026-03-07-commcare-ios-design.md` — full architecture, phasing, verification strategy
+- **Phase 6 plan**: `docs/plans/2026-03-12-phase6-deep-platform-abstraction-plan.md` — 16 JVM blocker files, Reader/ThreadLocal/SystemProperty abstractions, bulk migration
+- **Phase 5 completion**: `docs/plans/2026-03-12-phase5-completion-report.md` — 227 commonMain files, serialization framework moved, 16 remaining JVM blockers
 - **Phase 5 plan**: `docs/plans/2026-03-11-phase5-serialization-refactor-plan.md` — ExtUtil/ExtWrap* KClass refactoring, 9 waves, bulk migration strategy
 - **Phase 4 completion**: `docs/plans/2026-03-11-phase4-completion-report.md` — 204 commonMain files, ExtUtil serialization ceiling, options for Phase 5
 - **Phase 4 plan**: `docs/plans/2026-03-11-phase4-deep-migration-plan.md` — targeted JVM dep removal from 67 blocker files, wave details

--- a/docs/plans/2026-03-12-phase5-completion-report.md
+++ b/docs/plans/2026-03-12-phase5-completion-report.md
@@ -1,0 +1,154 @@
+# Phase 5: Serialization Framework Refactor — Completion Report
+
+**Date:** 2026-03-12
+**Status:** Complete
+**Duration:** 1 day (2026-03-12)
+
+---
+
+## Goal
+
+Replace `Class<*>` reflection patterns in the serialization framework (ExtUtil, ExtWrap*, PrototypeFactory) with `KClass<*>` + factory lambdas. Move the framework to commonMain to unblock transitively-dependent files.
+
+---
+
+## Results
+
+| Metric | Target | Actual |
+|--------|--------|--------|
+| commonMain files | 400+ | 227 (+23 from Phase 4's 204) |
+| JVM tests passing | 710+ | 800+ |
+| iOS build | Pass | Pass |
+| ExtUtil/ExtWrap* in commonMain | All | All 12 files moved |
+| Zero `Class<*>` in commonMain | Yes | Yes |
+| Core engine types in commonMain | Yes | No — blocked by non-serialization JVM deps |
+
+### Phase-level Acceptance Criteria
+
+- [x] All ExtUtil, ExtWrap*, Hasher, ClassNameHasher in commonMain — **12 serialization files moved**
+- [ ] 400+ total files in commonMain — **227 files** (blocker: non-serialization JVM deps in 16 files)
+- [ ] Core engine types in commonMain — **Blocked** by FormDef (System.getProperty), ThreadLocal singletons, java.io
+- [x] All 710+ JVM tests pass — **800+ tests pass**
+- [x] `compileCommonMainKotlinMetadata` succeeds
+- [ ] Cross-platform serialization round-trip tests — **Deferred to Phase 6**
+- [x] Zero `Class<*>` imports in commonMain files
+
+---
+
+## What Was Done
+
+### Waves 1-7: Serialization Framework Refactor (PR #145)
+
+Refactored and moved 12 serialization files from `src/main/java` to `src/commonMain`:
+
+| File | Key Changes |
+|------|-------------|
+| ExtUtil.kt | `KClass<*>` dispatch, `defaultPrototypeFactory()`, `PlatformDate.getTime()` |
+| ExtWrapBase.kt | `type: KClass<*>?` field, `Class<*>` constructor removed |
+| ExtWrapList.kt | `KClass<*>` constructors, `LIST_FACTORIES` internal |
+| ExtWrapListPoly.kt | No changes needed |
+| ExtWrapMap.kt | `createOrderedHashMap()`/`isOrderedHashMap()` abstractions |
+| ExtWrapMapPoly.kt | Same OrderedHashtable abstraction |
+| ExtWrapMultiMap.kt | `Class<*>` constructor removed |
+| ExtWrapNullable.kt | `KClass<*>` constructor |
+| ExtWrapTagged.kt | `obj::class`, `getClassHashForType(KClass)`, `classNameToKClass()`, `WRAPPER_CODES` KClass keys |
+| SerializationLimitationException.kt | Moved as dependency |
+| ExtWrapIntEncodingSmall.kt | Moved as dependency |
+| Persistable.kt | Moved as dependency |
+
+### New Abstractions Created
+
+| File | Location | Purpose |
+|------|----------|---------|
+| ExtUtilJvm.kt | jvmMain | `Class<*>` backward-compat overloads for `read`/`deserialize` |
+| ExtWrapJvmCompat.kt | jvmMain | Factory functions for Java callers: `ExtWrapBase(Class)`, `ExtWrapList(Class)`, etc. |
+| ClassNameToKClass.kt | commonMain (expect) + jvmMain/iosMain (actual) | `classNameToKClass(String): KClass<*>` |
+| OrderedMap.kt | commonMain (expect) + jvmMain/iosMain (actual) | `createOrderedHashMap()`, `isOrderedHashMap()` |
+| DefaultPrototypeFactory.kt | commonMain (expect) + jvmMain/iosMain (actual) | `defaultPrototypeFactory(): PrototypeFactory` |
+
+### Wave 8: Bulk Migration Attempt (PR not created — 0 files moved)
+
+Applied iterative compiler-validated migration to all 430 remaining files in `src/main/java`. Result: **0 additional files could move**. All 430 files form a single tightly-coupled connected component, blocked by 16 files with direct JVM imports.
+
+### Wave 9: Additional Files Moved
+
+11 additional files moved to commonMain that were unblocked by the serialization framework move:
+ColorUtils.kt, IDataPointer.kt, StreamsUtil.kt, IAnswerDataSerializer.kt, PointerAnswerData.kt, ByteArrayPayload.kt, DataPointerPayload.kt, IDataPayload.kt, IDataPayloadVisitor.kt, MultiMessagePayload.kt, MD5.kt
+
+---
+
+## File Distribution (Final)
+
+| Source Set | Files | Change |
+|-----------|-------|--------|
+| commonMain | 227 .kt | +23 from Phase 4 |
+| jvmMain | 65 .kt | +6 new abstractions |
+| iosMain | 36 .kt | +3 new actuals |
+| src/main/java | 430 .kt | -23 moved out |
+| src/main/java | 0 .java | — |
+
+---
+
+## Why 400+ Target Was Not Met
+
+The Phase 5 plan assumed that `Class<*>` in the serialization framework was the **sole** blocker for bulk migration. In reality, 16 files in `src/main/java` have direct JVM dependencies that are **not** serialization-related:
+
+### Direct JVM Blocker Files (16 total)
+
+**Group 1: java.io imports (8 files)**
+- XFormParser.kt — `java.io.InputStreamReader`, `java.io.Reader`
+- XFormParserFactory.kt — `java.io.Reader`
+- XFormParserReporter.kt — `java.io.PrintStream`
+- XFormSerializer.kt — `java.io.DataOutputStream`, `java.io.OutputStreamWriter`
+- XFormUtils.kt — `java.io.InputStreamReader`
+- XFormInstaller.kt — `java.io.InputStreamReader`
+- LocalizationUtils.kt — `java.io.BufferedReader`, `java.io.InputStreamReader`
+- ResourceTable.kt — `java.io.FileNotFoundException`
+
+**Group 2: ThreadLocal (3 files)**
+- PrototypeManager.kt — `ThreadLocal<PrototypeFactory?>`
+- ReferenceHandler.kt — `ThreadLocal<ReferenceManager>`
+- LocalizerManager.kt — `ThreadLocal<Localizer?>`
+
+**Group 3: System.getProperty (1 file)**
+- FormDef.kt — `System.getProperty("...enableOpenTracing")`
+
+**Group 4: External libraries (4 files)**
+- GeoPointUtils.kt — `org.gavaghan.geodesy.GlobalCoordinates`
+- PolygonUtils.kt — `org.gavaghan.geodesy.*`
+- XPathClosestPointOnPolygonFunc.kt — `org.gavaghan.geodesy.GlobalCoordinates`
+- XPathIsPointInsidePolygonFunc.kt — `org.gavaghan.geodesy.GlobalCoordinates`
+
+These 16 files block everything because the 430 files form one connected dependency graph — removing even one blocker from the graph can cascade and unlock many files.
+
+---
+
+## PRs
+
+| PR | Description | Status |
+|----|-------------|--------|
+| #144 | iOS fix: Property.kt @Throws mismatch | Merged |
+| #145 | Phase 5 Wave 8: Serialization framework to commonMain | Merged |
+| #146 | Phase 5 Wave 8 learnings doc | Merged |
+
+---
+
+## Key Learnings
+
+1. **LinkedHashMap is final in Kotlin/Native** — OrderedHashtable can't move to commonMain. Solved with `createOrderedHashMap()`/`isOrderedHashMap()` expect/actual.
+2. **Top-level factory functions replace Java constructors** — Java callers use `import static` and call without `new`.
+3. **@Throws must exactly match parent interface** — iOS metadata compilation catches mismatches JVM ignores.
+4. **Serialization was necessary but not sufficient** — Moving ExtUtil/ExtWrap* unblocked the framework itself but the transitive dependency cluster remains blocked by java.io, ThreadLocal, System.getProperty, and gavaghan.
+
+---
+
+## Next Steps → Phase 6
+
+Phase 6 should target the 16 direct JVM blocker files using expect/actual abstractions, then re-attempt bulk migration. The highest-ROI targets:
+
+1. **FormDef.kt** (1 line change, unblocks 17+ files directly)
+2. **ThreadLocal managers** (3 files, simple expect/actual)
+3. **java.io Reader/Writer abstractions** (8 files)
+4. **gavaghan replacement** (4 files)
+
+See `docs/plans/2026-03-12-phase6-deep-platform-abstraction-plan.md`.

--- a/docs/plans/2026-03-12-phase6-deep-platform-abstraction-plan.md
+++ b/docs/plans/2026-03-12-phase6-deep-platform-abstraction-plan.md
@@ -1,0 +1,248 @@
+# Phase 6: Deep Platform Abstraction — Implementation Plan
+
+**Date:** 2026-03-12
+**Status:** Draft
+**Prerequisite:** Phase 5 complete (227 commonMain files, serialization framework in commonMain). 430 .kt files remain in main/java, blocked by 16 files with direct JVM dependencies.
+
+---
+
+## Goal
+
+Remove JVM dependencies from the 16 direct blocker files (or move them to jvmMain) to unblock bulk migration of 430 remaining files to commonMain.
+
+**Exit criteria:** 500+ total files in commonMain. Core engine types (FormDef, TreeElement, EvaluationContext, TreeReference) in commonMain. All 800+ JVM tests pass. `compileCommonMainKotlinMetadata` succeeds.
+
+---
+
+## Current State
+
+| Source Set | Files |
+|-----------|-------|
+| commonMain | 227 .kt |
+| jvmMain | 65 .kt |
+| iosMain | 36 .kt |
+| src/main/java | 430 .kt |
+
+### The 16 Direct Blocker Files
+
+| # | File | JVM Dependency | Direct Importers (in main/java) |
+|---|------|---------------|-------------------------------|
+| 1 | FormDef.kt | `System.getProperty()` | 17 files |
+| 2 | PrototypeManager.kt | `ThreadLocal` | 1 file (CommCareSession) |
+| 3 | ReferenceHandler.kt | `ThreadLocal` | ReferenceManager |
+| 4 | LocalizerManager.kt | `ThreadLocal` | Localization |
+| 5 | LocalizationUtils.kt | `java.io.BufferedReader`, `InputStreamReader` | 2 files |
+| 6 | ResourceTable.kt | `java.io.FileNotFoundException` | 12 files |
+| 7 | XFormParser.kt | `java.io.InputStreamReader`, `java.io.Reader` | ~2 files (same-package) |
+| 8 | XFormParserFactory.kt | `java.io.Reader` | ~2 files |
+| 9 | XFormParserReporter.kt | `java.io.PrintStream` | ~1 file |
+| 10 | XFormSerializer.kt | `java.io.DataOutputStream`, `OutputStreamWriter` | ~3 files |
+| 11 | XFormUtils.kt | `java.io.InputStreamReader` | ~4 files |
+| 12 | XFormInstaller.kt | `java.io.InputStreamReader` | ~1 file |
+| 13 | GeoPointUtils.kt | `org.gavaghan.geodesy.GlobalCoordinates` | ~5 files |
+| 14 | PolygonUtils.kt | `org.gavaghan.geodesy.*` | ~3 files |
+| 15 | XPathClosestPointOnPolygonFunc.kt | `org.gavaghan.geodesy.GlobalCoordinates` | 0 (registered in factory) |
+| 16 | XPathIsPointInsidePolygonFunc.kt | `org.gavaghan.geodesy.GlobalCoordinates` | 0 (registered in factory) |
+
+### Key Dependency Chains
+
+The 430 files form one connected component. Critical chains:
+
+```
+FormDef → FormEntryModel → FormEntryPrompt → ...20+ files
+FormDef → Triggerable → Condition/Recalculate → ...
+FormDef → ActionController → Action → ...
+
+LocalizerManager → Localization → Text → ...50+ files
+ReferenceHandler → ReferenceManager → ReferenceDataSource → Localization → ...
+
+ResourceTable → ResourceManager → CommCarePlatform → ...
+ResourceTable → *Installer → ...
+
+XFormParser → XFormUtils → ... (but these are parser-specific, less cascade)
+```
+
+### Existing Abstractions Available
+
+- `PlatformInputStream` / `PlatformOutputStream` — commonMain stream abstractions
+- `PlatformDataInputStream` / `PlatformDataOutputStream` — for serialization
+- `platformSynchronized()` — replaces `synchronized` keyword
+- `PlatformIOException` — replaces `IOException`
+- `PlatformXmlParser` — replaces kxml2 XmlPullParser
+- `PlatformDate` / `PlatformCalendar` / `PlatformTimeZone` — date abstractions
+
+---
+
+## Wave Plan
+
+### Wave 1: FormDef — System.getProperty removal (highest ROI)
+
+**Files:** 1 (FormDef.kt)
+**JVM dep:** `System.getProperty("src.main.java.org.javarosa.enableOpenTracing")` — one line
+**What:**
+- Create `expect fun platformGetSystemProperty(key: String): String?` in commonMain
+- JVM actual: `System.getProperty(key)`
+- iOS actual: returns `null` (no system properties on iOS)
+- Replace the single call in FormDef.kt
+- Move FormDef.kt to commonMain
+
+**Impact:** Unblocks 17 direct importers + their transitive dependents. FormDef is referenced by FormEntryModel, Triggerable, ActionController, and many more.
+
+**Acceptance criteria:**
+- [ ] FormDef.kt compiles in commonMain
+- [ ] `compileCommonMainKotlinMetadata` succeeds
+- [ ] All 800+ JVM tests pass
+
+### Wave 2: ThreadLocal abstraction (3 files)
+
+**Files:** 3 (PrototypeManager.kt, ReferenceHandler.kt, LocalizerManager.kt)
+**JVM dep:** `ThreadLocal<T>` for multi-tenant thread isolation
+**What:**
+- Create `expect class PlatformThreadLocal<T>(initialValue: () -> T)` in commonMain with `get()` and `set()` methods
+- JVM actual: wraps `java.lang.ThreadLocal<T>`
+- iOS actual: simple property (single-threaded on iOS, no thread isolation needed)
+- Replace `ThreadLocal<T>` usage in all 3 files
+- All 3 files already have `useThreadLocal` strategy flags — keep these
+
+**Impact:** PrototypeManager → CommCareSession; ReferenceHandler → ReferenceManager → Localization; LocalizerManager → Localization. These are critical singletons.
+
+**Acceptance criteria:**
+- [ ] All 3 files compile in commonMain
+- [ ] Thread-local strategy still works on JVM
+- [ ] All 800+ JVM tests pass
+
+### Wave 3: java.io Reader/Writer abstraction (6 files)
+
+**Files:** 6 (LocalizationUtils.kt, XFormParser.kt, XFormParserFactory.kt, XFormUtils.kt, XFormInstaller.kt, XFormSerializer.kt)
+**JVM deps:** `java.io.Reader`, `InputStreamReader`, `BufferedReader`, `DataOutputStream`, `OutputStreamWriter`, `PrintStream`
+**What:**
+- Create `expect class PlatformReader` in commonMain with `readLine(): String?`, `close()`
+- Create `expect fun createInputStreamReader(input: PlatformInputStream, charset: String = "UTF-8"): PlatformReader`
+- Create `expect fun createBufferedReader(reader: PlatformReader): PlatformReader`
+- JVM actual: wraps `java.io.Reader` / `InputStreamReader` / `BufferedReader`
+- iOS actual: NSString-based reading from NSData
+- For XFormSerializer: use existing `PlatformOutputStream` + `expect fun createOutputStreamWriter(output: PlatformOutputStream, charset: String): PlatformWriter`
+- Replace java.io usages in all 6 files
+
+**Strategy note:** XFormParser and XFormParserFactory are complex files (1500+ lines). Consider:
+- Option A: Move to commonMain by abstracting Reader (preferred if feasible)
+- Option B: Move to jvmMain if too many JVM deps (XFormParser uses kxml2 via PlatformXmlParser already)
+
+**Impact:** LocalizationUtils is the highest-value target here — it unblocks the Localization → Text chain.
+
+**Acceptance criteria:**
+- [ ] LocalizationUtils.kt compiles in commonMain (minimum)
+- [ ] `compileCommonMainKotlinMetadata` succeeds
+- [ ] All 800+ JVM tests pass
+
+### Wave 4: ResourceTable — FileNotFoundException (1 file)
+
+**Files:** 1 (ResourceTable.kt)
+**JVM dep:** `java.io.FileNotFoundException`
+**What:**
+- Replace `catch (e: FileNotFoundException)` with `catch (e: PlatformIOException)` or create a specific `expect class PlatformFileNotFoundException : PlatformIOException`
+- ResourceTable already uses platform abstractions for most operations
+- Move ResourceTable.kt to commonMain
+
+**Impact:** Unblocks 12 installer/resource files.
+
+**Acceptance criteria:**
+- [ ] ResourceTable.kt compiles in commonMain
+- [ ] All 800+ JVM tests pass
+
+### Wave 5: XFormParserReporter — PrintStream (1 file)
+
+**Files:** 1 (XFormParserReporter.kt)
+**JVM dep:** `java.io.PrintStream`
+**What:**
+- Replace `PrintStream` with a simple `(String) -> Unit` callback or `expect class PlatformPrintStream`
+- This is a logging/reporting class — the abstraction is straightforward
+
+**Acceptance criteria:**
+- [ ] XFormParserReporter.kt compiles in commonMain
+- [ ] All 800+ JVM tests pass
+
+### Wave 6: Gavaghan geodesy replacement (4 files)
+
+**Files:** 4 (GeoPointUtils.kt, PolygonUtils.kt, XPathClosestPointOnPolygonFunc.kt, XPathIsPointInsidePolygonFunc.kt)
+**JVM dep:** `org.gavaghan.geodesy.*` (GlobalCoordinates, Ellipsoid, GeodeticCalculator)
+**What:**
+- Option A (preferred): Create a simple `GeoCoordinate` data class in commonMain, implement Vincenty's formula in pure Kotlin to replace GeodeticCalculator
+- Option B: Move gavaghan-dependent code to jvmMain, create expect/actual for geo calculations
+- GeoPointUtils already has haversine math in pure Kotlin — extend this
+
+**Impact:** Low (5 downstream files), but removes last external library dep.
+
+**Acceptance criteria:**
+- [ ] All 4 files compile in commonMain (option A) or jvmMain (option B)
+- [ ] Geo calculations produce same results
+- [ ] All 800+ JVM tests pass
+
+### Wave 7: Bulk migration sweep
+
+**Files:** remaining ~380+
+**What:**
+- With all 16 blockers resolved, re-run iterative compiler-validated migration
+- Move all candidates → compile → rollback failures → repeat
+- Move any remaining JVM-only files to jvmMain
+- Identify any new blockers not visible before
+
+**Acceptance criteria:**
+- [ ] 500+ total files in commonMain
+- [ ] Core engine types (FormDef, TreeElement, EvaluationContext, TreeReference) in commonMain
+- [ ] `compileCommonMainKotlinMetadata` succeeds
+- [ ] All 800+ JVM tests pass
+
+### Wave 8: Validation and cleanup
+
+**Files:** ~5 new
+**What:**
+- Add cross-platform tests in commonTest for moved engine types
+- Verify iOS builds with real engine types available
+- Clean up any unused JVM backward-compat shims
+- Update jvmMain/iosMain expect/actual inventory
+
+**Acceptance criteria:**
+- [ ] Cross-platform tests pass on both JVM and iOS
+- [ ] iOS build succeeds
+- [ ] All 800+ JVM tests pass
+
+---
+
+## Dependency Graph
+
+```
+Wave 1 (FormDef) ──────────────┐
+Wave 2 (ThreadLocal) ──────────┤
+Wave 3 (java.io Reader/Writer) ┼→ Wave 7 (bulk migration) → Wave 8 (validation)
+Wave 4 (ResourceTable) ────────┤
+Wave 5 (PrintStream) ──────────┤
+Wave 6 (gavaghan) ─────────────┘
+```
+
+Waves 1-6 are independent and can be done in any order. Waves 1 and 2 have the highest cascade impact and should be prioritized.
+
+---
+
+## Risk Analysis
+
+| Risk | Mitigation |
+|------|-----------|
+| FormDef has hidden JVM deps beyond System.getProperty | Read file carefully first. It's 1200+ lines. Check for java.util.Collections, ArrayIndexOutOfBoundsException, etc. |
+| PlatformThreadLocal performance on JVM | Wrap actual java.lang.ThreadLocal — zero overhead |
+| Reader abstraction too leaky | Keep it minimal: readLine(), read(buf), close(). XFormParser may need more complex reading. |
+| XFormParser too complex to move | Fall back to jvmMain. XFormParser is a parser implementation — it's okay for it to be platform-specific. |
+| Bulk migration still blocked by same-package references | Use iterative compiler-validated approach (proven in Phase 3/4). |
+| New blockers emerge during bulk migration | Handle them ad-hoc in Wave 7 as they appear. |
+
+---
+
+## Acceptance Criteria (Phase-level)
+
+- [ ] All 16 direct JVM blocker files resolved (moved to commonMain or jvmMain)
+- [ ] 500+ total files in commonMain
+- [ ] Core engine types (FormDef, TreeElement, EvaluationContext, TreeReference) in commonMain
+- [ ] All 800+ JVM tests pass
+- [ ] `compileCommonMainKotlinMetadata` succeeds
+- [ ] Cross-platform tests for engine types pass on JVM and iOS
+- [ ] Zero `java.*` imports in commonMain files (excluding kotlin.jvm)


### PR DESCRIPTION
## Summary
- Phase 5 completion report documenting serialization framework migration results (227 commonMain files)
- Phase 6 implementation plan targeting 16 direct JVM blocker files across 8 waves
- Created issues #147-#154 for Phase 6 waves
- Updated CLAUDE.md with Phase 6 status table

## Phase 6 Overview
16 files with direct JVM dependencies block all 430 remaining files:
- **Wave 1**: FormDef (System.getProperty) — highest ROI
- **Wave 2**: ThreadLocal abstraction (3 singleton managers)
- **Waves 3-5**: java.io Reader/Writer/PrintStream
- **Wave 6**: Gavaghan geodesy replacement
- **Waves 7-8**: Bulk migration + validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)