### PR TITLE
Phase 8 Wave 2: iOS networking & JSON platform adapters

### DIFF
--- a/commcare-core/src/commonTest/kotlin/org/commcare/core/interfaces/PlatformUrlTest.kt
+++ b/commcare-core/src/commonTest/kotlin/org/commcare/core/interfaces/PlatformUrlTest.kt
@@ -1,0 +1,43 @@
+package org.commcare.core.interfaces
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlatformUrlTest {
+
+    @Test
+    fun testBasicHttpUrl() {
+        val url = PlatformUrl("https://www.commcarehq.org/a/demo/apps")
+        assertEquals("https", url.scheme)
+        assertEquals("www.commcarehq.org", url.host)
+        assertEquals("/a/demo/apps", url.path)
+        assertEquals(-1, url.port)
+    }
+
+    @Test
+    fun testUrlWithPort() {
+        val url = PlatformUrl("http://localhost:8000/api/v1")
+        assertEquals("http", url.scheme)
+        assertEquals("localhost", url.host)
+        assertEquals(8000, url.port)
+        assertEquals("/api/v1", url.path)
+    }
+
+    @Test
+    fun testUrlWithQuery() {
+        val url = PlatformUrl("https://example.com/search?q=test&page=1")
+        assertEquals("https", url.scheme)
+        assertEquals("example.com", url.host)
+        assertEquals("/search", url.path)
+        assertEquals("q=test&page=1", url.query)
+    }
+
+    @Test
+    fun testIsValidUrl() {
+        assertTrue(isValidUrl("https://example.com"))
+        assertTrue(isValidUrl("http://localhost:8000/path"))
+        assertFalse(isValidUrl("not a url"))
+    }
+}

--- a/commcare-core/src/commonTest/kotlin/org/commcare/util/PlatformJsonTest.kt
+++ b/commcare-core/src/commonTest/kotlin/org/commcare/util/PlatformJsonTest.kt
@@ -1,0 +1,47 @@
+package org.commcare.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PlatformJsonTest {
+
+    @Test
+    fun testJsonGetStringBasic() {
+        val json = """{"name": "CommCare", "version": "2.53"}"""
+        assertEquals("CommCare", jsonGetString(json, "name"))
+        assertEquals("2.53", jsonGetString(json, "version"))
+    }
+
+    @Test
+    fun testJsonGetStringMissingKey() {
+        val json = """{"name": "CommCare"}"""
+        assertNull(jsonGetString(json, "missing"))
+    }
+
+    @Test
+    fun testJsonGetStringEmptyObject() {
+        assertNull(jsonGetString("{}", "key"))
+    }
+
+    @Test
+    fun testJsonGetStringInvalidJson() {
+        assertNull(jsonGetString("not json", "key"))
+    }
+
+    @Test
+    fun testJsonArrayToStringListBasic() {
+        val json = """["alpha", "beta", "gamma"]"""
+        assertEquals(listOf("alpha", "beta", "gamma"), jsonArrayToStringList(json))
+    }
+
+    @Test
+    fun testJsonArrayToStringListEmpty() {
+        assertEquals(emptyList(), jsonArrayToStringList("[]"))
+    }
+
+    @Test
+    fun testJsonArrayToStringListInvalid() {
+        assertEquals(emptyList(), jsonArrayToStringList("not an array"))
+    }
+}

--- a/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformHttpClient.kt
+++ b/commcare-core/src/iosMain/kotlin/org/commcare/core/interfaces/PlatformHttpClient.kt
@@ -1,13 +1,107 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package org.commcare.core.interfaces
 
+import kotlinx.cinterop.*
+import platform.Foundation.*
+import platform.darwin.*
+import platform.posix.memcpy
+
 /**
- * iOS HTTP client.
- * Will use NSURLSession via Kotlin/Native interop.
+ * iOS HTTP client using NSURLSession.
+ *
+ * Uses synchronous semaphore-based approach since the PlatformHttpClient
+ * interface requires synchronous execute(). All calls should be made
+ * from a background thread to avoid blocking the main thread.
  */
 class IosHttpClient : PlatformHttpClient {
     override fun execute(request: HttpRequest): HttpResponse {
-        TODO("iOS HTTP client requires Foundation NSURLSession cinterop")
+        val url = NSURL.URLWithString(request.url)
+            ?: throw RuntimeException("Invalid URL: ${request.url}")
+
+        val urlRequest = NSMutableURLRequest(uRL = url).apply {
+            setHTTPMethod(request.method)
+            setCachePolicy(NSURLRequestReloadIgnoringLocalCacheData)
+            setTimeoutInterval(60.0)
+
+            for ((key, value) in request.headers) {
+                setValue(value, forHTTPHeaderField = key)
+            }
+
+            if (request.body != null) {
+                setHTTPBody(request.body.toNSData())
+                if (request.contentType != null) {
+                    setValue(request.contentType, forHTTPHeaderField = "Content-Type")
+                }
+            }
+        }
+
+        // Synchronous request using semaphore
+        val semaphore = dispatch_semaphore_create(0)
+        var responseData: NSData? = null
+        var urlResponse: NSHTTPURLResponse? = null
+        var requestError: NSError? = null
+
+        NSURLSession.sharedSession.dataTaskWithRequest(urlRequest) { data, response, error ->
+            responseData = data
+            urlResponse = response as? NSHTTPURLResponse
+            requestError = error
+            dispatch_semaphore_signal(semaphore)
+        }.resume()
+
+        dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER)
+
+        if (requestError != null) {
+            throw RuntimeException("HTTP request failed: ${requestError!!.localizedDescription}")
+        }
+
+        val httpResponse = urlResponse
+            ?: throw RuntimeException("No HTTP response received")
+
+        val statusCode = httpResponse.statusCode.toInt()
+        val responseHeaders = mutableMapOf<String, String>()
+        val allHeaders = httpResponse.allHeaderFields
+        for (key in allHeaders.keys) {
+            val headerName = key.toString()
+            val headerValue = allHeaders[key]?.toString() ?: ""
+            responseHeaders[headerName] = headerValue
+        }
+
+        val bodyBytes = responseData?.toByteArray()
+
+        return if (statusCode in 200..299) {
+            HttpResponse(
+                code = statusCode,
+                headers = responseHeaders,
+                body = bodyBytes,
+                errorBody = null
+            )
+        } else {
+            HttpResponse(
+                code = statusCode,
+                headers = responseHeaders,
+                body = null,
+                errorBody = bodyBytes
+            )
+        }
     }
 }
 
 actual fun createHttpClient(): PlatformHttpClient = IosHttpClient()
+
+private fun ByteArray.toNSData(): NSData {
+    if (this.isEmpty()) return NSData()
+    return this.usePinned { pinned ->
+        NSData.create(bytes = pinned.addressOf(0), length = this.size.toULong())
+    }
+}
+
+private fun NSData.toByteArray(): ByteArray {
+    val size = this.length.toInt()
+    if (size == 0) return ByteArray(0)
+    val bytes = ByteArray(size)
+    bytes.usePinned { pinned ->
+        memcpy(pinned.addressOf(0), this.bytes, this.length)
+    }
+    return bytes
+}

--- a/commcare-core/src/iosMain/kotlin/org/commcare/util/PlatformJson.kt
+++ b/commcare-core/src/iosMain/kotlin/org/commcare/util/PlatformJson.kt
@@ -1,42 +1,28 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
+
 package org.commcare.util
 
+import platform.Foundation.*
+
 actual fun jsonGetString(jsonString: String, propertyName: String): String? {
-    // Simple JSON property extraction without full parser
-    // TODO: Use Foundation JSONSerialization for production
     return try {
-        // Minimal implementation for basic JSON objects
-        val trimmed = jsonString.trim()
-        if (!trimmed.startsWith("{")) return null
-        // Find the property key
-        val keyPattern = "\"$propertyName\""
-        val keyIndex = trimmed.indexOf(keyPattern)
-        if (keyIndex < 0) return null
-        val afterKey = trimmed.substring(keyIndex + keyPattern.length).trimStart()
-        if (!afterKey.startsWith(":")) return null
-        val afterColon = afterKey.substring(1).trimStart()
-        if (afterColon.startsWith("\"")) {
-            val endQuote = afterColon.indexOf('"', 1)
-            if (endQuote < 0) return null
-            afterColon.substring(1, endQuote)
-        } else {
-            // Non-string value
-            val endIndex = afterColon.indexOfFirst { it == ',' || it == '}' || it == ' ' }
-            if (endIndex < 0) afterColon else afterColon.substring(0, endIndex)
-        }
+        val data = (jsonString as NSString).dataUsingEncoding(NSUTF8StringEncoding)
+            ?: return null
+        val obj = NSJSONSerialization.JSONObjectWithData(data, 0u, null) as? Map<*, *>
+            ?: return null
+        obj[propertyName]?.toString()
     } catch (e: Exception) {
         null
     }
 }
 
 actual fun jsonArrayToStringList(jsonArrayString: String): List<String> {
-    // Simple JSON array parsing
-    // TODO: Use Foundation JSONSerialization for production
     return try {
-        val trimmed = jsonArrayString.trim()
-        if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return emptyList()
-        val content = trimmed.substring(1, trimmed.length - 1).trim()
-        if (content.isEmpty()) return emptyList()
-        content.split(",").map { it.trim().removeSurrounding("\"") }
+        val data = (jsonArrayString as NSString).dataUsingEncoding(NSUTF8StringEncoding)
+            ?: return emptyList()
+        val arr = NSJSONSerialization.JSONObjectWithData(data, 0u, null) as? List<*>
+            ?: return emptyList()
+        arr.mapNotNull { it?.toString() }
     } catch (e: Exception) {
         emptyList()
     }


### PR DESCRIPTION
## Summary
- Implement `IosHttpClient` using `NSURLSession` with `dispatch_semaphore` for synchronous HTTP execution
- Upgrade `PlatformJson` from regex-based parsing to `NSJSONSerialization`
- Add cross-platform tests for JSON parsing and URL handling
- `PlatformUrl` already fully implemented — verified, no changes needed

## Changes
| File | Action |
|------|--------|
| `src/iosMain/.../PlatformHttpClient.kt` | Full NSURLSession implementation replacing TODO stub |
| `src/iosMain/.../PlatformJson.kt` | NSJSONSerialization replacing regex parser |
| `src/commonTest/.../PlatformJsonTest.kt` | New cross-platform JSON tests (7 tests) |
| `src/commonTest/.../PlatformUrlTest.kt` | New cross-platform URL tests (4 tests) |

## Technical Decisions
- **Synchronous semaphore pattern**: `PlatformHttpClient.execute()` is synchronous. Uses `dispatch_semaphore_create`/`wait`/`signal` to block until `NSURLSession.dataTaskWithRequest` callback fires. Callers must invoke from background thread.
- **NSJSONSerialization**: Replaces fragile regex-based JSON parsing. Handles edge cases (nested objects, special characters) that regex couldn't.
- **NSData↔ByteArray helpers**: Duplicated from PlatformFiles.kt as private helpers (no shared iOS utility module yet).

## Test plan
- [x] `./gradlew jvmTest` passes locally (710+ tests including new JSON/URL tests)
- [ ] `iosSimulatorArm64Test` passes (CI — verifies NSURLSession and NSJSONSerialization compile and execute)
- [ ] iOS build CI passes

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)