### PR TITLE
Phase 8 Wave 4: Login UI and app state machine

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/App.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/App.kt
@@ -1,41 +1,34 @@
 package org.commcare.app
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import org.commcare.app.state.AppState
+import org.commcare.app.ui.HomeScreen
+import org.commcare.app.ui.InstallErrorScreen
+import org.commcare.app.ui.InstallScreen
+import org.commcare.app.ui.LoginScreen
+import org.commcare.app.viewmodel.LoginViewModel
 
 @Composable
 fun App() {
+    val loginViewModel = remember { LoginViewModel() }
+
     MaterialTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
-            EngineStatusScreen()
+            when (val state = loginViewModel.appState) {
+                is AppState.LoggedOut,
+                is AppState.LoginError -> LoginScreen(loginViewModel)
+                is AppState.LoggingIn -> LoginScreen(loginViewModel)
+                is AppState.Installing -> InstallScreen(state)
+                is AppState.InstallError -> InstallErrorScreen(state) {
+                    loginViewModel.resetError()
+                }
+                is AppState.Ready -> HomeScreen()
+            }
         }
-    }
-}
-
-@Composable
-fun EngineStatusScreen() {
-    Column(
-        modifier = Modifier.fillMaxSize().padding(24.dp)
-    ) {
-        Text(
-            text = "CommCare iOS",
-            style = MaterialTheme.typography.headlineLarge
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = "Engine Status",
-            style = MaterialTheme.typography.titleMedium
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(text = "CommCare Core linked successfully")
     }
 }

--- a/app/src/commonMain/kotlin/org/commcare/app/state/AppState.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/state/AppState.kt
@@ -1,0 +1,14 @@
+package org.commcare.app.state
+
+/**
+ * Top-level app state machine.
+ * LoggedOut → LoggingIn → Installing → Ready → InSession
+ */
+sealed class AppState {
+    data object LoggedOut : AppState()
+    data class LoggingIn(val serverUrl: String, val username: String) : AppState()
+    data class LoginError(val message: String) : AppState()
+    data class Installing(val progress: Float, val statusMessage: String) : AppState()
+    data class InstallError(val message: String) : AppState()
+    data object Ready : AppState()
+}

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
@@ -1,0 +1,44 @@
+package org.commcare.app.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun HomeScreen() {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "CommCare",
+            style = MaterialTheme.typography.headlineLarge,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Application installed successfully",
+            style = MaterialTheme.typography.bodyLarge
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Ready for form entry",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/InstallScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/InstallScreen.kt
@@ -1,0 +1,75 @@
+package org.commcare.app.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.commcare.app.state.AppState
+
+@Composable
+fun InstallScreen(state: AppState.Installing) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Installing Application",
+            style = MaterialTheme.typography.headlineMedium
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        LinearProgressIndicator(
+            progress = { state.progress },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = state.statusMessage,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+fun InstallErrorScreen(state: AppState.InstallError, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Installation Failed",
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.error
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = state.message,
+            style = MaterialTheme.typography.bodyMedium
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(onClick = onRetry) {
+            Text("Retry")
+        }
+    }
+}

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/LoginScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/LoginScreen.kt
@@ -1,0 +1,103 @@
+package org.commcare.app.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import org.commcare.app.state.AppState
+import org.commcare.app.viewmodel.LoginViewModel
+
+@Composable
+fun LoginScreen(viewModel: LoginViewModel) {
+    val isLoggingIn = viewModel.appState is AppState.LoggingIn
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "CommCare",
+            style = MaterialTheme.typography.headlineLarge,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        OutlinedTextField(
+            value = viewModel.serverUrl,
+            onValueChange = { viewModel.serverUrl = it },
+            label = { Text("Server URL") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+            enabled = !isLoggingIn
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        OutlinedTextField(
+            value = viewModel.username,
+            onValueChange = { viewModel.username = it },
+            label = { Text("Username") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = !isLoggingIn
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        OutlinedTextField(
+            value = viewModel.password,
+            onValueChange = { viewModel.password = it },
+            label = { Text("Password") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            enabled = !isLoggingIn
+        )
+
+        if (viewModel.appState is AppState.LoginError) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = (viewModel.appState as AppState.LoginError).message,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall
+            )
+            TextButton(onClick = { viewModel.resetError() }) {
+                Text("Try Again")
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        if (isLoggingIn) {
+            CircularProgressIndicator()
+        } else {
+            Button(
+                onClick = { viewModel.login() },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = viewModel.username.isNotBlank() && viewModel.password.isNotBlank()
+            ) {
+                Text("Log In")
+            }
+        }
+    }
+}

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/LoginViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/LoginViewModel.kt
@@ -1,0 +1,107 @@
+package org.commcare.app.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import org.commcare.app.state.AppState
+import org.commcare.core.interfaces.HttpRequest
+import org.commcare.core.interfaces.createHttpClient
+
+/**
+ * Manages login state and HQ authentication.
+ */
+class LoginViewModel {
+    var serverUrl by mutableStateOf("https://www.commcarehq.org")
+    var username by mutableStateOf("")
+    var password by mutableStateOf("")
+    var appState by mutableStateOf<AppState>(AppState.LoggedOut)
+        private set
+
+    private val httpClient = createHttpClient()
+
+    fun login() {
+        if (username.isBlank() || password.isBlank()) {
+            appState = AppState.LoginError("Username and password are required")
+            return
+        }
+
+        appState = AppState.LoggingIn(serverUrl, username)
+
+        try {
+            // CommCare HQ login endpoint
+            val loginUrl = "${serverUrl.trimEnd('/')}/a/${getDomain()}/phone/restore/"
+            val credentials = encodeBasicAuth(username, password)
+
+            val response = httpClient.execute(
+                HttpRequest(
+                    url = loginUrl,
+                    method = "GET",
+                    headers = mapOf(
+                        "Authorization" to "Basic $credentials",
+                        "X-CommCareHQ-LastSyncToken" to ""
+                    )
+                )
+            )
+
+            when {
+                response.code in 200..299 -> {
+                    appState = AppState.Installing(0f, "Login successful, preparing install...")
+                }
+                response.code == 401 -> {
+                    appState = AppState.LoginError("Invalid username or password")
+                }
+                response.code == 404 -> {
+                    appState = AppState.LoginError("Domain not found. Check your server URL.")
+                }
+                else -> {
+                    appState = AppState.LoginError("Server error (${response.code})")
+                }
+            }
+        } catch (e: Exception) {
+            appState = AppState.LoginError("Connection failed: ${e.message}")
+        }
+    }
+
+    fun resetError() {
+        appState = AppState.LoggedOut
+    }
+
+    private fun getDomain(): String {
+        // Extract domain from username (user@domain format) or use default
+        return if (username.contains("@")) {
+            username.substringAfter("@")
+        } else {
+            "demo" // fallback
+        }
+    }
+
+    private fun encodeBasicAuth(user: String, pass: String): String {
+        val raw = "$user:$pass"
+        return base64Encode(raw.encodeToByteArray())
+    }
+
+    private fun base64Encode(data: ByteArray): String {
+        val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+        val sb = StringBuilder()
+        var i = 0
+        while (i < data.size) {
+            val b0 = data[i].toInt() and 0xFF
+            val b1 = if (i + 1 < data.size) data[i + 1].toInt() and 0xFF else 0
+            val b2 = if (i + 2 < data.size) data[i + 2].toInt() and 0xFF else 0
+            sb.append(chars[(b0 shr 2) and 0x3F])
+            sb.append(chars[((b0 shl 4) or (b1 shr 4)) and 0x3F])
+            if (i + 1 < data.size) {
+                sb.append(chars[((b1 shl 2) or (b2 shr 6)) and 0x3F])
+            } else {
+                sb.append('=')
+            }
+            if (i + 2 < data.size) {
+                sb.append(chars[b2 and 0x3F])
+            } else {
+                sb.append('=')
+            }
+            i += 3
+        }
+        return sb.toString()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `AppState` sealed class for app state machine (LoggedOut → LoggingIn → Installing → Ready)
- Add `LoginViewModel` with HQ Basic Auth authentication
- Add Compose Material3 screens: Login, Install progress, Home
- Wire up state-driven navigation in `App.kt`

## Changes
| File | Purpose |
|------|---------|
| `app/.../state/AppState.kt` | Sealed class state machine |
| `app/.../viewmodel/LoginViewModel.kt` | Auth logic, base64 encoding, state management |
| `app/.../ui/LoginScreen.kt` | Username/password/URL input with Material3 |
| `app/.../ui/InstallScreen.kt` | Progress indicator for installation |
| `app/.../ui/HomeScreen.kt` | Post-install ready screen |
| `app/.../App.kt` | State-driven navigation between screens |

## Technical Decisions
- **Compose `remember` for ViewModel**: No DI framework yet; simple `remember { LoginViewModel() }`
- **Pure Kotlin base64**: No external dependencies; custom encoder for Basic Auth
- **HQ restore endpoint for login**: Uses `GET /a/{domain}/phone/restore/` with Basic Auth to verify credentials
- **Synchronous login call**: Acceptable for initial implementation; will move to coroutines later

## Test plan
- [ ] iOS build CI passes (Compose screens compile for iOS target)
- [x] JVM tests pass (no regressions)
- [ ] Manual: Login screen renders with fields and button

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)