### PR TITLE
Phase 8 Wave 5: Menu navigation ViewModel and UI

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/ui/MenuScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/MenuScreen.kt
@@ -1,0 +1,104 @@
+package org.commcare.app.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.commcare.app.viewmodel.MenuItem
+import org.commcare.app.viewmodel.MenuViewModel
+
+@Composable
+fun MenuScreen(viewModel: MenuViewModel, onBack: (() -> Unit)? = null) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Header
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (onBack != null) {
+                Text(
+                    text = "<",
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = Modifier.clickable { onBack() }.padding(end = 8.dp)
+                )
+            }
+            Text(
+                text = viewModel.title,
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+
+        HorizontalDivider()
+
+        if (viewModel.errorMessage != null) {
+            Text(
+                text = viewModel.errorMessage!!,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+
+        if (viewModel.menuItems.isEmpty()) {
+            Text(
+                text = "No menu items available",
+                modifier = Modifier.padding(16.dp),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        } else {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(viewModel.menuItems) { item ->
+                    MenuItemRow(item = item, onClick = { viewModel.selectItem(item) })
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun MenuItemRow(item: MenuItem, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clickable { onClick() }
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = item.displayText,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            }
+            if (item.isMenu) {
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = ">",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/MenuViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/MenuViewModel.kt
@@ -1,0 +1,131 @@
+package org.commcare.app.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import org.commcare.session.CommCareSession
+import org.commcare.session.SessionFrame
+import org.commcare.util.CommCarePlatform
+
+/**
+ * Manages menu navigation state.
+ * Loads menus from CommCarePlatform and handles user selections.
+ */
+class MenuViewModel(
+    private val platform: CommCarePlatform,
+    private val session: CommCareSession
+) {
+    var menuItems by mutableStateOf<List<MenuItem>>(emptyList())
+        private set
+    var title by mutableStateOf("CommCare")
+        private set
+    var errorMessage by mutableStateOf<String?>(null)
+        private set
+    var navigationState by mutableStateOf<NavigationState>(NavigationState.Menu)
+        private set
+
+    fun loadMenus(menuId: String? = null) {
+        try {
+            navigationState = NavigationState.Menu
+            errorMessage = null
+            loadMenuItems(menuId)
+        } catch (e: Exception) {
+            errorMessage = "Failed to load menus: ${e.message}"
+        }
+    }
+
+    private fun loadMenuItems(menuId: String?) {
+        val items = mutableListOf<MenuItem>()
+        val targetId = menuId ?: "root"
+
+        for (suite in platform.getInstalledSuites()) {
+            // Get menus at this level
+            val menus = suite.getMenusWithId(targetId)
+            if (menus != null) {
+                for (menu in menus) {
+                    // Set title from menu
+                    val menuTitle = try {
+                        menu.getName()?.evaluate()
+                    } catch (e: Exception) {
+                        null
+                    }
+                    if (menuTitle != null) {
+                        title = menuTitle
+                    }
+
+                    // Add entries from this menu
+                    for (cmdId in menu.getCommandIds()) {
+                        val entry = suite.getEntry(cmdId)
+                        if (entry != null) {
+                            val displayText = try {
+                                entry.getText()?.evaluate() ?: cmdId
+                            } catch (e: Exception) {
+                                cmdId
+                            }
+                            items.add(MenuItem(
+                                commandId = cmdId,
+                                displayText = displayText,
+                                imageUri = entry.getImageURI(),
+                                isMenu = false
+                            ))
+                        }
+                    }
+                }
+            }
+
+            // Add sub-menus that have this menu as root
+            for (subMenu in suite.getMenusWithRoot(targetId)) {
+                val displayText = try {
+                    subMenu.getName()?.evaluate() ?: (subMenu.getId() ?: "Menu")
+                } catch (e: Exception) {
+                    subMenu.getId() ?: "Menu"
+                }
+                items.add(MenuItem(
+                    commandId = subMenu.getId() ?: "",
+                    displayText = displayText,
+                    imageUri = subMenu.getImageURI(),
+                    isMenu = true
+                ))
+            }
+        }
+
+        menuItems = items
+    }
+
+    fun selectItem(item: MenuItem) {
+        try {
+            if (item.isMenu) {
+                // Navigate into sub-menu
+                loadMenus(item.commandId)
+            } else {
+                // Select a form entry command
+                session.setCommand(item.commandId)
+                navigationState = NavigationState.FormEntry
+            }
+        } catch (e: Exception) {
+            errorMessage = "Navigation error: ${e.message}"
+        }
+    }
+
+    fun goBack() {
+        try {
+            loadMenus()
+            title = "CommCare"
+        } catch (e: Exception) {
+            loadMenus()
+        }
+    }
+}
+
+data class MenuItem(
+    val commandId: String,
+    val displayText: String,
+    val imageUri: String? = null,
+    val isMenu: Boolean = false
+)
+
+sealed class NavigationState {
+    data object Menu : NavigationState()
+    data object EntitySelect : NavigationState()
+    data object FormEntry : NavigationState()
+}


### PR DESCRIPTION
## Summary
- Add `MenuViewModel` for loading and navigating CommCare menus from installed suites
- Add `MenuScreen` Compose UI with Material3 cards and lazy list
- Add `MenuItem` data class and `NavigationState` sealed class

## Changes
| File | Purpose |
|------|---------|
| `app/.../viewmodel/MenuViewModel.kt` | Menu loading from CommCarePlatform, selection handling, back nav |
| `app/.../ui/MenuScreen.kt` | Material3 menu list with cards, header, error display |

## Technical Decisions
- **Text.evaluate() without EvaluationContext**: For flat text and locale strings, `evaluate()` works without context. XPath-based display text will need an EvaluationContext when a full session wrapper is available.
- **Direct suite traversal**: Instead of using `MenuLoader` (which requires `SessionWrapperInterface`), directly iterates suites/menus for simplicity in this initial implementation.
- **Not yet wired into App.kt**: MenuViewModel needs a `CommCarePlatform` instance from app installation. Will be integrated when Wave 4's login flow actually installs an app.

## Test plan
- [ ] iOS build CI passes
- [x] No regressions (app module only)

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)