### PR TITLE
Wave 9: Settings, debug info & polish

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/ui/DebugInfoScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/DebugInfoScreen.kt
@@ -1,0 +1,106 @@
+package org.commcare.app.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Developer debug info screen showing app and engine diagnostics.
+ */
+@Composable
+fun DebugInfoScreen(
+    appVersion: String,
+    engineVersion: String,
+    commonMainFileCount: Int,
+    storageInfo: Map<String, Int>,
+    onBack: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "<",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.clickable { onBack() }.padding(end = 8.dp)
+            )
+            Text(
+                text = "Debug Info",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // App info
+        SectionHeader("Application")
+        InfoRow("App Version", appVersion)
+        InfoRow("Engine Version", engineVersion)
+        InfoRow("CommonMain Files", commonMainFileCount.toString())
+
+        Spacer(modifier = Modifier.height(16.dp))
+        HorizontalDivider()
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Storage info
+        SectionHeader("Storage")
+        for ((name, count) in storageInfo) {
+            InfoRow(name, "$count records")
+        }
+
+        if (storageInfo.isEmpty()) {
+            Text(
+                "No storage data available",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+}
+
+@Composable
+private fun InfoRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(0.4f)
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(0.6f)
+        )
+    }
+}

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/SettingsScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/SettingsScreen.kt
@@ -1,0 +1,159 @@
+package org.commcare.app.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.commcare.app.viewmodel.SettingsViewModel
+
+@Composable
+fun SettingsScreen(
+    viewModel: SettingsViewModel,
+    onBack: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "<",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.clickable { onBack() }.padding(end = 8.dp)
+            )
+            Text(
+                text = "Settings",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Server section
+        Text("Server", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            value = viewModel.serverUrl,
+            onValueChange = { viewModel.serverUrl = it },
+            label = { Text("Server URL") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+        HorizontalDivider()
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Sync section
+        Text("Sync", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+
+        CheckboxRow(
+            label = "Auto-sync",
+            checked = viewModel.autoSync,
+            onCheckedChange = { viewModel.autoSync = it }
+        )
+
+        OutlinedTextField(
+            value = viewModel.syncFrequencyMinutes.toString(),
+            onValueChange = {
+                val parsed = it.toIntOrNull()
+                if (parsed != null && parsed > 0) {
+                    viewModel.syncFrequencyMinutes = parsed
+                }
+            },
+            label = { Text("Sync frequency (minutes)") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            enabled = viewModel.autoSync
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+        HorizontalDivider()
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Developer section
+        Text("Developer", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+
+        CheckboxRow(
+            label = "Developer mode",
+            checked = viewModel.developerMode,
+            onCheckedChange = { viewModel.developerMode = it }
+        )
+
+        if (viewModel.developerMode) {
+            CheckboxRow(
+                label = "Show debug info",
+                checked = viewModel.showDebugInfo,
+                onCheckedChange = { viewModel.showDebugInfo = it }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        if (viewModel.savedMessage != null) {
+            Text(
+                text = viewModel.savedMessage!!,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+
+        // Action buttons
+        Button(
+            onClick = { viewModel.save() },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Save")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        OutlinedButton(
+            onClick = { viewModel.resetToDefaults() },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Reset to Defaults")
+        }
+    }
+}
+
+@Composable
+private fun CheckboxRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyLarge)
+        Checkbox(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/SettingsViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/SettingsViewModel.kt
@@ -1,0 +1,36 @@
+package org.commcare.app.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+/**
+ * Manages app settings — server URL, sync frequency, developer options.
+ */
+class SettingsViewModel {
+    var serverUrl by mutableStateOf("https://www.commcarehq.org")
+    var syncFrequencyMinutes by mutableStateOf(15)
+    var developerMode by mutableStateOf(false)
+    var showDebugInfo by mutableStateOf(false)
+    var autoSync by mutableStateOf(true)
+    var savedMessage by mutableStateOf<String?>(null)
+        private set
+
+    fun save() {
+        // In full implementation: persist to platform key-value storage
+        savedMessage = "Settings saved"
+    }
+
+    fun clearSavedMessage() {
+        savedMessage = null
+    }
+
+    fun resetToDefaults() {
+        serverUrl = "https://www.commcarehq.org"
+        syncFrequencyMinutes = 15
+        developerMode = false
+        showDebugInfo = false
+        autoSync = true
+        savedMessage = "Settings reset to defaults"
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SettingsViewModel` — server URL, sync frequency, developer mode, auto-sync toggle
- Add `SettingsScreen` — Material3 settings form with save/reset
- Add `DebugInfoScreen` — developer diagnostics showing app version, engine info, storage stats

## Details
- Settings include server URL configuration, sync frequency (minutes), auto-sync toggle
- Developer mode enables debug info display toggle
- DebugInfoScreen shows app version, engine version, commonMain file count, storage record counts
- Settings persistence is stubbed (will use platform key-value store)

Closes #176

## Test plan
- [ ] CI passes (Compose compilation)
- [ ] Settings screen renders with all fields
- [ ] Developer mode toggle shows/hides debug options
- [ ] Debug info screen renders diagnostic data

🤖 Generated with [Claude Code](https://claude.com/claude-code)