### PR TITLE
docs: Phase 3 planning learnings and CLAUDE.md update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,15 +39,19 @@ commcare-ios/
 
 ## Current Status
 
-**All phases complete.** The Java→Kotlin conversion, KMP multiplatform migration, and iOS app shell are finished. All 65 GitHub issues closed, 8 phases delivered across 187 PRs.
+**Phases 1-8 complete.** The Java→Kotlin conversion, KMP multiplatform migration, and iOS app shell are finished. All 65 GitHub issues closed, 8 phases delivered across 187 PRs.
 
-- **commcare-core**: 643 commonMain, 100 jvmMain, 45 iosMain .kt files. 1 Java compat file remains (StorageManagerCompat.java). Gavaghan geodesy replaced with pure Kotlin Vincenty (PR #163).
+- **commcare-core**: 643 commonMain, 100 jvmMain, 45 iosMain .kt files. 1 Java compat file remains (StorageManagerCompat.java). Gavaggan geodesy replaced with pure Kotlin Vincenty (PR #163).
 - **iOS app** (`app/`): Compose Multiplatform shell with login, menus, cases, forms, sync, settings. See `docs/plans/2026-03-12-phase8-completion-report.md`.
+
+**Phase 3: Feature Implementation** — Planned. Full feature parity with commcare-android (90-125 tasks across 4 tiers). Vertical slice approach: Tier 1 (MVP) → Tier 2 (daily field worker) → Tier 3 (advanced) → Tier 4 (Connect, PersonalID). Both Android and iOS targets from day one, SQLDelight storage, oracle test harness. See design and Tier 1 plan in Key Docs.
 
 ## Key Docs
 
 **Plans:**
 - **Design**: `docs/plans/2026-03-07-commcare-ios-design.md` — full architecture, phasing, verification strategy
+- **Phase 3 design**: `docs/plans/2026-03-12-phase3-feature-implementation-design.md` — full parity spec from commcare-android audit (90-125 tasks, 4 tiers)
+- **Phase 3 Tier 1 plan**: `docs/plans/2026-03-12-phase3-tier1-implementation-plan.md` — 14 tasks: Android target, SQLDelight, auth, install, menu, form entry, sync, oracle tests
 - **Phase 8 completion**: `docs/plans/2026-03-12-phase8-completion-report.md` — iOS app shell: 17 UI/ViewModel files, 5 platform implementations, 9 waves
 - **Phase 1-7 completion reports**: `docs/plans/2026-03-1{0,1,2}-phase{1..7}-completion-report.md` — progressive migration from 611 .kt files (Phase 1) to 643 commonMain (Phase 7)
 - **Performance testing**: `docs/plans/2026-03-11-performance-testing-design.md` — kotlinx-benchmark infrastructure for JVM/Native comparison
@@ -56,7 +60,7 @@ commcare-ios/
 - **Kotlin conversion**: `kotlin-conversion-pitfalls`, `wave3-xpath-conversion-learnings`, `wave4-xform-parser-learnings`, `wave5-case-management-learnings`, `wave6-suite-session-learnings`, `wave8-core-services-learnings`, `wave1-collection-replacement-learnings`
 - **KMP migration**: `wave6-7-kmp-migration-learnings`, `ios-ci-learnings`, `commonmain-migration-blockers`, `phase4-deep-migration-learnings`, `phase6-deep-migration-learnings`, `phase7-bulk-migration-learnings`, `wave6-xpath-migration-learnings`, `wave7-commonmain-dependency-inversion`, `wave7-commonmain-migration-learnings`
 - **Serialization**: `wave4-serialization-framework-learnings`, `phase5-serialization-migration-learnings`, `phase5-wave8-serialization-commonmain-learnings`, `wave7-serialization-migration-learnings`, `ios-xml-serializer-namespace-learnings`
-- **Process**: `pr-discipline`, `issue-closure-discipline`, `claude-md-importance`, `monorepo-for-agentic-development`
+- **Process**: `pr-discipline`, `issue-closure-discipline`, `claude-md-importance`, `monorepo-for-agentic-development`, `phase3-planning-learnings`
 - **Architecture**: `abstract-tree-element-degenerify`, `j2k-converter-vs-ai-conversion`, `gavaghan-replacement-learnings`
 - **iOS app**: `phase8-ios-app-learnings`, `phase8-wave1-cinterop-learnings` — NSURLSession sync, NSJSONSerialization, cinterop patterns (CommonCrypto, SecureRandom, file system)
 
@@ -168,7 +172,9 @@ Do not skip straight to code. The plan is the first deliverable of every phase.
 
 ## AI Agent Guidelines
 
+- **Always `git pull` before starting work** — local main can silently fall behind remote, leading to decisions based on stale project state
 - **Check the Phase Transition Checklist** when a phase completes — plan before code
+- **For feature parity work**: derive the feature list from the target app's codebase + docs, not from design doc estimates. See `docs/learnings/2026-03-12-phase3-planning-learnings.md`.
 - Read the relevant issue's full description before starting work — it contains "Files to Read", "What to Do", and "Tests That Must Pass"
 - Read `docs/learnings/` files before starting a conversion wave — they document real failures
 - Follow the Kotlin Conversion Checklist above for every file

--- a/docs/learnings/2026-03-12-phase3-planning-learnings.md
+++ b/docs/learnings/2026-03-12-phase3-planning-learnings.md
@@ -1,0 +1,70 @@
+# Learning: Phase 3 Planning — Feature Parity Requires Systematic Audit
+
+**Date**: 2026-03-12
+**Context**: Planning Phase 3 (Feature Implementation) for CommCare cross-platform app
+**Status**: Active
+
+## Problem
+
+The original design doc estimated Phase 3 at 55-85 tasks across 10 feature groups. When we began planning, we initially proposed a wave breakdown based on those estimates. The user correctly pointed out that we can't guess at features — we need to be 100% sure of feature parity with the current Android app.
+
+## Root Cause
+
+The design doc's Phase 3 feature list was written at a high level before the project started. It missed:
+
+- **30+ form widget types** (including Ethiopian/Nepali calendars, combobox with fuzzy search, signature, document upload)
+- **13+ external app integrations** via Android Intents (Simprints biometrics, ABHA, RDT, NFC)
+- **CommCare Connect** — an entire sub-application (jobs, learning, delivery, payments, messaging)
+- **PersonalID** — identity verification system (phone, biometric, photo)
+- **Graphing** — D3/C3 charts in case details
+- **Content Provider API** — external apps querying case/fixture data
+- **Report modules** — server-defined reports on mobile
+- **Remote case search and claim** — server-side ElasticSearch queries
+
+The real scope is 90-125+ tasks — roughly double the original estimate.
+
+## Fix / Key Takeaway
+
+**Never derive a feature list from a design doc alone.** For feature parity projects, the spec must come from:
+
+1. **Codebase audit of the target app** — crawl all Activities, Fragments, widgets, services, receivers, and manifest declarations. Use `gh api repos/{owner}/{repo}/git/trees/{branch}?recursive=1` to get the full file tree without cloning.
+2. **Documentation audit** — cross-reference official user docs for features that may be configured server-side rather than visible in code.
+3. **Both sources together** — code shows what's implemented; docs show what users expect. Neither alone is sufficient.
+
+The resulting inventory becomes the **definitive parity checklist** — no feature ships without a corresponding item, no item is added without evidence.
+
+## Additional Learnings
+
+### Local repo can silently fall behind remote
+
+The local `main` was 106 commits behind `origin/main`. CLAUDE.md on disk was frozen at Wave 3 of Phase 1 while the remote had completed all 8 phases. Always run `git pull` before starting any planning or analysis session. An agent that reads stale CLAUDE.md will make decisions based on wrong project state.
+
+### Design doc phasing doesn't map 1:1 to execution
+
+The design doc defined 5 phases (0-4). Actual execution used 8 phases (1-8) that covered the design doc's Phases 0-2. The mapping:
+- Design Phase 0 (Scaffold) → Execution Phase 0
+- Design Phase 1 (Core Port) → Execution Phases 1-7
+- Design Phase 2 (App Shell) → Execution Phase 8
+- Design Phase 3 (Feature Implementation) → Not started
+- Design Phase 4 (Polish) → Not started
+
+This is fine — plans should adapt. But the design doc should be updated to reflect the actual phase numbering, or future agents will be confused by the mismatch.
+
+### Skipped Phase 0 deliverables propagate as gaps
+
+Phase 0 called for an oracle test harness (FormPlayer comparison framework) that was never built. This gap propagated — Phase 3's exit criteria requires "all oracle tests pass" but the infrastructure doesn't exist. Skipping "nice to have" infrastructure in early phases creates hard blockers in later phases. The oracle harness is now a Tier 1 task in Phase 3.
+
+### The app module was iOS-only despite the design doc
+
+The design doc says "a single Kotlin codebase produces both the Android and iOS apps," but `app/build.gradle.kts` only configured iOS targets. This gap should have been caught during Phase 8 (iOS App Implementation) — the Phase Transition Checklist should verify that architectural invariants from the design doc are maintained. Adding a "verify design doc invariants" step to the checklist would prevent this.
+
+### Android-only patterns need cross-platform alternatives
+
+Android Intent callouts (13+ integrations) have no direct iOS equivalent. These need to be mapped to iOS alternatives:
+- Android Intents → iOS URL schemes / Universal Links / SDK integrations
+- Content Providers → iOS App Groups (or drop)
+- WorkManager → BGTaskScheduler
+- FCM push → APNs
+- Android print framework → iOS UIPrintInteractionController
+
+This mapping should be done once and documented, not rediscovered per-feature.


### PR DESCRIPTION
## Summary

- New learning doc capturing key findings from Phase 3 planning session
- CLAUDE.md updated with Phase 3 status, plan references, and new agent guidelines

## Changes

**New file: `docs/learnings/2026-03-12-phase3-planning-learnings.md`**
- Feature parity requires systematic codebase + docs audit (design doc estimated 55-85 tasks, real scope is 90-125+)
- Local repo can silently fall behind remote (was 106 commits behind during this session)
- Skipped Phase 0 deliverables (oracle test harness) propagate as hard blockers in later phases
- App module was iOS-only despite design doc calling for both platforms
- Android Intent patterns (13+ integrations) need documented cross-platform alternatives

**Modified: `CLAUDE.md`**
- Current Status: added Phase 3 planned status with scope summary
- Key Docs: added Phase 3 design and Tier 1 plan references
- Learnings: added `phase3-planning-learnings` to Process category
- AI Agent Guidelines: added "always git pull" and "audit target app for feature parity" rules

## Test plan

- [ ] Verify all referenced docs exist on disk
- [ ] Verify CLAUDE.md is under 200 lines
- [ ] Verify no code changes mixed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)