### PR TITLE
fix: Wave 0 — foundation bug fixes

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/storage/InMemoryStorage.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/storage/InMemoryStorage.kt
@@ -116,7 +116,7 @@ class InMemoryStorage<T : Persistable>(
 
     override fun getNumRecords(): Int = data.size
 
-    override fun isEmpty(): Boolean = data.size > 0
+    override fun isEmpty(): Boolean = data.isEmpty()
 
     override fun exists(id: Int): Boolean = data.containsKey(DataUtil.integer(id))
 

--- a/commcare-core/src/commonTest/kotlin/org/javarosa/core/util/externalizable/PrototypeFactoryHashTest.kt
+++ b/commcare-core/src/commonTest/kotlin/org/javarosa/core/util/externalizable/PrototypeFactoryHashTest.kt
@@ -1,0 +1,97 @@
+package org.javarosa.core.util.externalizable
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Cross-platform test verifying PrototypeFactory hash computation
+ * produces identical results on JVM and iOS.
+ */
+class PrototypeFactoryHashTest {
+
+    @Test
+    fun hashSizeIs32() {
+        assertEquals(32, PrototypeFactory.getClassHashSize())
+    }
+
+    @Test
+    fun hashByNameProducesExpectedBytes() {
+        val className = "org.javarosa.core.model.data.UncastData"
+        val hash = PrototypeFactory.getClassHashByName(className)
+
+        assertEquals(32, hash.size)
+
+        // Hash should be first 32 bytes of reversed class name encoded as UTF-8
+        val reversed = StringBuilder(className).reverse().toString()
+        val expectedBytes = reversed.encodeToByteArray()
+        for (i in 0 until minOf(32, expectedBytes.size)) {
+            assertEquals(expectedBytes[i], hash[i], "Byte mismatch at index $i")
+        }
+        // Remaining bytes should be zero-padded
+        for (i in expectedBytes.size until 32) {
+            assertEquals(0, hash[i].toInt(), "Expected zero padding at index $i")
+        }
+    }
+
+    @Test
+    fun hashByNameDeterministic() {
+        val className = "org.javarosa.core.model.data.UncastData"
+        val hash1 = PrototypeFactory.getClassHashByName(className)
+        val hash2 = PrototypeFactory.getClassHashByName(className)
+        assertTrue(PrototypeFactory.compareHash(hash1, hash2))
+    }
+
+    @Test
+    fun differentClassesDifferentHashes() {
+        val hash1 = PrototypeFactory.getClassHashByName("org.javarosa.core.model.data.UncastData")
+        val hash2 = PrototypeFactory.getClassHashByName("org.javarosa.core.model.data.StringData")
+        assertFalse(PrototypeFactory.compareHash(hash1, hash2))
+    }
+
+    @Test
+    fun compareHashWorks() {
+        val a = ByteArray(32) { it.toByte() }
+        val b = ByteArray(32) { it.toByte() }
+        val c = ByteArray(32) { (it + 1).toByte() }
+
+        assertTrue(PrototypeFactory.compareHash(a, b))
+        assertFalse(PrototypeFactory.compareHash(a, c))
+    }
+
+    @Test
+    fun compareHashDifferentSizeReturnsFalse() {
+        val a = ByteArray(32)
+        val b = ByteArray(16)
+        assertFalse(PrototypeFactory.compareHash(a, b))
+    }
+
+    @Test
+    fun wrapperTagIsAllFF() {
+        val tag = PrototypeFactory.getWrapperTag()
+        assertEquals(32, tag.size)
+        for (i in tag.indices) {
+            assertEquals(0xff.toByte(), tag[i], "Wrapper tag byte $i should be 0xFF")
+        }
+    }
+
+    @Test
+    fun wrapperTagNotEqualToAnyClassHash() {
+        val tag = PrototypeFactory.getWrapperTag()
+        val hash = PrototypeFactory.getClassHashByName("org.javarosa.core.model.data.UncastData")
+        assertFalse(PrototypeFactory.compareHash(tag, hash))
+    }
+
+    @Test
+    fun shortClassNamePadsWithZeros() {
+        val className = "A"
+        val hash = PrototypeFactory.getClassHashByName(className)
+        assertEquals(32, hash.size)
+        // "A" reversed is "A", UTF-8 is [65]
+        assertEquals(65, hash[0].toInt())
+        for (i in 1 until 32) {
+            assertEquals(0, hash[i].toInt(), "Expected zero padding at index $i")
+        }
+    }
+}

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/core/util/externalizable/ClassNameToKClass.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/core/util/externalizable/ClassNameToKClass.kt
@@ -2,11 +2,26 @@ package org.javarosa.core.util.externalizable
 
 import kotlin.reflect.KClass
 
+/**
+ * Global registry mapping class names to KClass instances for iOS.
+ * On JVM this uses Class.forName().kotlin; on iOS we maintain a manual registry.
+ */
+object KClassRegistry {
+    private val registry = mutableMapOf<String, KClass<*>>()
+
+    fun register(className: String, kClass: KClass<*>) {
+        registry[className] = kClass
+    }
+
+    fun lookup(className: String): KClass<*>? {
+        return registry[className]
+    }
+}
+
 actual fun classNameToKClass(className: String): KClass<*> {
-    // On iOS, class lookup is done through the PrototypeFactory registry.
-    // This is a fallback that throws if the class isn't registered.
-    throw UnsupportedOperationException(
-        "Direct class name to KClass lookup not supported on iOS. " +
-        "Register classes with PrototypeFactory instead."
-    )
+    return KClassRegistry.lookup(className)
+        ?: throw IllegalArgumentException(
+            "Class '$className' not registered in KClassRegistry. " +
+            "Register it at app startup via KClassRegistry.register()."
+        )
 }

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/core/util/externalizable/PrototypeFactory.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/core/util/externalizable/PrototypeFactory.kt
@@ -10,15 +10,19 @@ import kotlin.reflect.KClass
  * pre-registered factory functions keyed by class name hash.
  *
  * All serializable types must be registered at app startup via [registerFactory].
+ *
+ * Hash algorithm matches JVM ClassNameHasher + Hasher:
+ * 1. Reverse the class name string
+ * 2. Encode to UTF-8 bytes
+ * 3. Copy first 32 bytes into a 32-byte array (pad with zeros if shorter)
  */
 actual open class PrototypeFactory actual constructor() {
 
     private val factories = mutableMapOf<String, () -> Externalizable>()
     private val hashToName = mutableMapOf<List<Byte>, String>()
+    private val nameToKClass = mutableMapOf<String, KClass<*>>()
 
     actual constructor(classNames: HashSet<String>) : this() {
-        // On iOS, class names alone can't create instances — factory lambdas must be
-        // registered via registerFactory(). This constructor exists for API compatibility.
         for (name in classNames) {
             val hash = computeHash(name)
             hashToName[hash.toList()] = name
@@ -34,6 +38,22 @@ actual open class PrototypeFactory actual constructor() {
         factories[className] = factory
         val hash = computeHash(className)
         hashToName[hash.toList()] = className
+    }
+
+    /**
+     * Register a factory function with its KClass for reverse lookup support.
+     */
+    fun registerFactory(className: String, kClass: KClass<*>, factory: () -> Externalizable) {
+        registerFactory(className, factory)
+        nameToKClass[className] = kClass
+    }
+
+    /**
+     * Look up a KClass by class name from the registry.
+     * Returns null if not registered.
+     */
+    fun getKClassForName(className: String): KClass<*>? {
+        return nameToKClass[className]
     }
 
     /**
@@ -64,20 +84,24 @@ actual open class PrototypeFactory actual constructor() {
         return getInstance(name)
     }
 
-    /**
-     * Simple hash computation matching Java's ClassNameHasher behavior.
-     */
-    private fun computeHash(className: String): ByteArray {
-        val bytes = className.encodeToByteArray()
-        val hash = ByteArray(DEFAULT_HASH_SIZE)
-        for (i in bytes.indices) {
-            hash[i % DEFAULT_HASH_SIZE] = (hash[i % DEFAULT_HASH_SIZE].toInt() xor bytes[i].toInt()).toByte()
-        }
-        return hash
-    }
-
     actual companion object {
-        private const val DEFAULT_HASH_SIZE = 4
+        private const val DEFAULT_HASH_SIZE = 32
+
+        /**
+         * Compute hash matching JVM ClassNameHasher + Hasher behavior:
+         * 1. Reverse the class name
+         * 2. Encode reversed string to UTF-8
+         * 3. Copy first min(32, length) bytes into a 32-byte array
+         */
+        private fun computeHash(className: String): ByteArray {
+            val reversed = StringBuilder(className).reverse().toString()
+            val bytes = reversed.encodeToByteArray()
+            val hash = ByteArray(DEFAULT_HASH_SIZE)
+            for (i in 0 until minOf(hash.size, bytes.size)) {
+                hash[i] = bytes[i]
+            }
+            return hash
+        }
 
         actual fun compareHash(a: ByteArray, b: ByteArray): Boolean {
             if (a.size != b.size) return false
@@ -98,21 +122,11 @@ actual open class PrototypeFactory actual constructor() {
         actual fun getClassHashSize(): Int = DEFAULT_HASH_SIZE
 
         actual fun getClassHashByName(className: String): ByteArray {
-            return computeHashStatic(className)
+            return computeHash(className)
         }
 
         actual fun getClassHashForType(type: KClass<*>): ByteArray {
             return getClassHashByName(type.qualifiedName ?: throw IllegalArgumentException("No name for $type"))
-        }
-
-        private fun computeHashStatic(className: String): ByteArray {
-            val reversed = StringBuilder(className).reverse().toString()
-            val bytes = reversed.encodeToByteArray()
-            val hash = ByteArray(DEFAULT_HASH_SIZE)
-            for (i in bytes.indices) {
-                hash[i % DEFAULT_HASH_SIZE] = (hash[i % DEFAULT_HASH_SIZE].toInt() xor bytes[i].toInt()).toByte()
-            }
-            return hash
         }
     }
 }

--- a/commcare-core/src/iosMain/kotlin/org/javarosa/core/util/externalizable/SerializationHelpers.kt
+++ b/commcare-core/src/iosMain/kotlin/org/javarosa/core/util/externalizable/SerializationHelpers.kt
@@ -79,28 +79,14 @@ actual object SerializationHelpers {
     }
 
     actual fun readTagged(`in`: PlatformDataInputStream, pf: PrototypeFactory): Any {
-        val tag = ByteArray(PrototypeFactory.getClassHashSize())
-        `in`.read(tag, 0, tag.size)
-
-        if (PrototypeFactory.compareHash(tag, PrototypeFactory.getWrapperTag())) {
-            throw DeserializationException(
-                "Wrapper tags in tagged serialization not yet supported on iOS"
-            )
+        return ExtWrapTagged.readTag(`in`, pf).let { type ->
+            ExtUtil.read(`in`, type, pf)
         }
-
-        val obj = pf.getInstance(tag)
-        if (obj is Externalizable) {
-            obj.readExternal(`in`, pf)
-        }
-        return obj
     }
 
     actual fun writeTagged(out: PlatformDataOutputStream, obj: Any) {
-        // On iOS, we need the PrototypeFactory to compute the class hash
-        // For now, throw — tagged writes require platform-specific hash computation
-        throw UnsupportedOperationException(
-            "Tagged serialization writes not yet supported on iOS"
-        )
+        ExtWrapTagged.writeTag(out, obj)
+        ExtUtil.write(out, obj)
     }
 
     actual fun readListPoly(`in`: PlatformDataInputStream, pf: PrototypeFactory): ArrayList<Any?> {


### PR DESCRIPTION
## Summary
- **Fix InMemoryStorage.isEmpty()** — inverted logic (`data.size > 0` → `data.isEmpty()`)
- **Fix iOS PrototypeFactory hash divergence** — was using 4-byte XOR hash with inconsistent name reversal; now matches JVM ClassNameHasher (reverse name → UTF-8 → first 32 bytes, zero-padded)
- **Implement iOS writeTagged/readTagged** — replaced `throw UnsupportedOperationException` with delegation to `ExtWrapTagged.writeTag()` + `ExtUtil.write()` / `ExtWrapTagged.readTag()` + `ExtUtil.read()`
- **Implement iOS classNameToKClass** — replaced `throw UnsupportedOperationException` with `KClassRegistry` global lookup (iOS equivalent of JVM's `Class.forName().kotlin`)
- **Add cross-platform hash test** — `PrototypeFactoryHashTest` with 8 test methods verifying hash size, determinism, correctness, wrapper tag, and padding

## Test plan
- [x] `./gradlew compileCommonMainKotlinMetadata` — commonMain compiles
- [x] `./gradlew compileKotlinJvm compileJava` — JVM compiles
- [x] `./gradlew jvmTest` — all JVM tests pass (including new PrototypeFactoryHashTest)
- [x] `./gradlew compileTestKotlinIosSimulatorArm64` — iOS test compilation succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)