### PR TITLE
feat: Wave 1 — cross-platform engine tests

### DIFF
--- a/commcare-core/src/commonTest/kotlin/org/commcare/cases/CaseCrossPlatformTest.kt
+++ b/commcare-core/src/commonTest/kotlin/org/commcare/cases/CaseCrossPlatformTest.kt
@@ -1,0 +1,101 @@
+package org.commcare.cases
+
+import org.commcare.cases.model.Case
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Cross-platform tests for the Case model — core data object for CommCare case management.
+ */
+class CaseCrossPlatformTest {
+
+    @Test
+    fun testCreateEmptyCase() {
+        val c = Case()
+        assertNull(c.getTypeId())
+        assertNull(c.getName())
+    }
+
+    @Test
+    fun testCreateNamedCase() {
+        val c = Case("John Doe", "patient")
+        assertEquals("John Doe", c.getName())
+        assertEquals("patient", c.getTypeId())
+    }
+
+    @Test
+    fun testSetCaseId() {
+        val c = Case("Test", "type")
+        c.setCaseId("abc-123")
+        assertEquals("abc-123", c.getCaseId())
+    }
+
+    @Test
+    fun testCaseClosedFlag() {
+        val c = Case("Test", "type")
+        assertFalse(c.isClosed())
+
+        c.setClosed(true)
+        assertTrue(c.isClosed())
+
+        c.setClosed(false)
+        assertFalse(c.isClosed())
+    }
+
+    @Test
+    fun testSetAndGetProperty() {
+        val c = Case("Test", "type")
+        c.setProperty("color", "blue")
+        assertEquals("blue", c.getPropertyString("color"))
+    }
+
+    @Test
+    fun testMultipleProperties() {
+        val c = Case("Test", "type")
+        c.setProperty("first_name", "Alice")
+        c.setProperty("last_name", "Smith")
+        c.setProperty("age", "30")
+
+        assertEquals("Alice", c.getPropertyString("first_name"))
+        assertEquals("Smith", c.getPropertyString("last_name"))
+        assertEquals("30", c.getPropertyString("age"))
+    }
+
+    @Test
+    fun testOverwriteProperty() {
+        val c = Case("Test", "type")
+        c.setProperty("status", "open")
+        assertEquals("open", c.getPropertyString("status"))
+
+        c.setProperty("status", "closed")
+        assertEquals("closed", c.getPropertyString("status"))
+    }
+
+    @Test
+    fun testCaseIdMetaProperty() {
+        val c = Case("Test", "type")
+        c.setCaseId("xyz-789")
+
+        // "case-id" is a special meta property
+        assertEquals("xyz-789", c.getProperty("case-id"))
+    }
+
+    @Test
+    fun testCaseTypeMetaData() {
+        val c = Case("Test", "patient")
+        assertEquals("patient", c.getMetaData("case-type"))
+    }
+
+    @Test
+    fun testCaseStatusMetaData() {
+        val c = Case("Test", "type")
+        assertEquals("open", c.getMetaData("case-status"))
+
+        c.setClosed(true)
+        assertEquals("closed", c.getMetaData("case-status"))
+    }
+}

--- a/commcare-core/src/commonTest/kotlin/org/javarosa/core/model/instance/TreeElementCrossPlatformTest.kt
+++ b/commcare-core/src/commonTest/kotlin/org/javarosa/core/model/instance/TreeElementCrossPlatformTest.kt
@@ -1,0 +1,160 @@
+package org.javarosa.core.model.instance
+
+import org.javarosa.core.model.data.IntegerData
+import org.javarosa.core.model.data.StringData
+import org.javarosa.core.model.data.UncastData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Cross-platform tests for TreeElement — core data model of CommCare forms.
+ */
+class TreeElementCrossPlatformTest {
+
+    @Test
+    fun testCreateEmptyTreeElement() {
+        val te = TreeElement()
+        assertNull(te.getName())
+        assertEquals(0, te.getMult())
+    }
+
+    @Test
+    fun testCreateNamedTreeElement() {
+        val te = TreeElement("question1")
+        assertEquals("question1", te.getName())
+        assertEquals(0, te.getMult())
+    }
+
+    @Test
+    fun testCreateWithMultiplicity() {
+        val te = TreeElement("repeat", 3)
+        assertEquals("repeat", te.getName())
+        assertEquals(3, te.getMult())
+    }
+
+    @Test
+    fun testAddAndGetChild() {
+        val parent = TreeElement("data")
+        val child1 = TreeElement("name")
+        val child2 = TreeElement("age")
+
+        parent.addChild(child1)
+        parent.addChild(child2)
+
+        assertEquals(2, parent.getNumChildren())
+        assertNotNull(parent.getChild("name", 0))
+        assertNotNull(parent.getChild("age", 0))
+        assertNull(parent.getChild("missing", 0))
+    }
+
+    @Test
+    fun testGetChildAt() {
+        val parent = TreeElement("data")
+        val child1 = TreeElement("first")
+        val child2 = TreeElement("second")
+
+        parent.addChild(child1)
+        parent.addChild(child2)
+
+        assertEquals("first", parent.getChildAt(0)?.getName())
+        assertEquals("second", parent.getChildAt(1)?.getName())
+    }
+
+    @Test
+    fun testSetAndGetValue() {
+        val te = TreeElement("answer")
+        assertNull(te.getValue())
+
+        te.setValue(StringData("hello"))
+        assertNotNull(te.getValue())
+        assertEquals("hello", te.getValue()!!.getDisplayText())
+    }
+
+    @Test
+    fun testSetIntegerValue() {
+        val te = TreeElement("count")
+        te.setValue(IntegerData(42))
+        assertEquals("42", te.getValue()!!.getDisplayText())
+    }
+
+    @Test
+    fun testSetAndGetAttribute() {
+        val te = TreeElement("node")
+        te.setAttribute(null, "id", "abc123")
+
+        val attr = te.getAttribute(null, "id")
+        assertNotNull(attr)
+        assertEquals("abc123", attr.getValue()?.getDisplayText())
+    }
+
+    @Test
+    fun testRemoveChild() {
+        val parent = TreeElement("data")
+        val child = TreeElement("temp")
+        parent.addChild(child)
+        assertEquals(1, parent.getNumChildren())
+
+        parent.removeChild(child)
+        assertEquals(0, parent.getNumChildren())
+    }
+
+    @Test
+    fun testGetRef() {
+        val parent = TreeElement("data")
+        val child = TreeElement("question")
+        parent.addChild(child)
+
+        val ref = child.getRef()
+        assertNotNull(ref)
+    }
+
+    @Test
+    fun testDeepCopy() {
+        val original = TreeElement("data")
+        val child = TreeElement("name")
+        child.setValue(StringData("Alice"))
+        original.addChild(child)
+
+        val copy = original.deepCopy(true)
+        assertEquals("data", copy.getName())
+        assertEquals(1, copy.getNumChildren())
+        assertEquals("Alice", copy.getChildAt(0)?.getValue()?.getDisplayText())
+
+        // Verify it's a deep copy — modifying copy doesn't affect original
+        copy.getChildAt(0)?.setValue(StringData("Bob"))
+        assertEquals("Alice", original.getChildAt(0)?.getValue()?.getDisplayText())
+    }
+
+    @Test
+    fun testLeafDetection() {
+        val parent = TreeElement("group")
+        assertTrue(parent.isLeaf)
+
+        parent.addChild(TreeElement("child"))
+        assertTrue(!parent.isLeaf)
+    }
+
+    @Test
+    fun testMultipleChildrenSameName() {
+        val parent = TreeElement("data")
+        parent.addChild(TreeElement("item", 0))
+        parent.addChild(TreeElement("item", 1))
+        parent.addChild(TreeElement("item", 2))
+
+        assertEquals(3, parent.getNumChildren())
+        val items = parent.getChildrenWithName("item")
+        assertEquals(3, items.size)
+    }
+
+    @Test
+    fun testRelevantFlag() {
+        val te = TreeElement("q")
+        assertTrue(te.isRelevant)
+
+        te.setRelevant(false)
+        assertTrue(!te.isRelevant)
+    }
+}

--- a/commcare-core/src/commonTest/kotlin/org/javarosa/core/model/instance/TreeReferenceCrossPlatformTest.kt
+++ b/commcare-core/src/commonTest/kotlin/org/javarosa/core/model/instance/TreeReferenceCrossPlatformTest.kt
@@ -1,0 +1,184 @@
+package org.javarosa.core.model.instance
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Cross-platform tests for TreeReference — the path system for form data.
+ */
+class TreeReferenceCrossPlatformTest {
+
+    @Test
+    fun testRootRef() {
+        val root = TreeReference.rootRef()
+        assertNotNull(root)
+        assertEquals(0, root.size())
+    }
+
+    @Test
+    fun testSelfRef() {
+        val self = TreeReference.selfRef()
+        assertNotNull(self)
+        assertEquals(0, self.size())
+    }
+
+    @Test
+    fun testAddNameAndSize() {
+        val ref = TreeReference.rootRef()
+        ref.add("data", 0)
+        ref.add("question", 0)
+
+        assertEquals(2, ref.size())
+        assertEquals("data", ref.getName(0))
+        assertEquals("question", ref.getName(1))
+    }
+
+    @Test
+    fun testMultiplicity() {
+        val ref = TreeReference.rootRef()
+        ref.add("item", 0)
+        ref.add("item", 1)
+        ref.add("item", 2)
+
+        assertEquals(3, ref.size())
+        assertEquals(0, ref.getMultiplicity(0))
+        assertEquals(1, ref.getMultiplicity(1))
+        assertEquals(2, ref.getMultiplicity(2))
+    }
+
+    @Test
+    fun testClone() {
+        val original = TreeReference.rootRef()
+        original.add("data", 0)
+        original.add("name", 0)
+
+        val clone = original.clone()
+        assertEquals(original.size(), clone.size())
+        assertEquals(original.getName(0), clone.getName(0))
+        assertEquals(original.getName(1), clone.getName(1))
+
+        // Verify independence
+        clone.add("extra", 0)
+        assertEquals(2, original.size())
+        assertEquals(3, clone.size())
+    }
+
+    @Test
+    fun testEquality() {
+        val ref1 = TreeReference.rootRef()
+        ref1.add("data", 0)
+        ref1.add("name", 0)
+
+        val ref2 = TreeReference.rootRef()
+        ref2.add("data", 0)
+        ref2.add("name", 0)
+
+        assertEquals(ref1, ref2)
+        assertEquals(ref1.hashCode(), ref2.hashCode())
+    }
+
+    @Test
+    fun testInequality() {
+        val ref1 = TreeReference.rootRef()
+        ref1.add("data", 0)
+
+        val ref2 = TreeReference.rootRef()
+        ref2.add("other", 0)
+
+        assertFalse(ref1 == ref2)
+    }
+
+    @Test
+    fun testGenericize() {
+        val ref = TreeReference.rootRef()
+        ref.add("data", 0)
+        ref.add("item", 5)
+
+        val generic = ref.genericize()
+        assertEquals(2, generic.size())
+        assertEquals(TreeReference.INDEX_UNBOUND, generic.getMultiplicity(1))
+    }
+
+    @Test
+    fun testParentRef() {
+        val ref = TreeReference.rootRef()
+        ref.add("data", 0)
+        ref.add("group", 0)
+        ref.add("question", 0)
+
+        val parent = ref.getParentRef()
+        assertNotNull(parent)
+        assertEquals(2, parent.size())
+        assertEquals("group", parent.getName(1))
+    }
+
+    @Test
+    fun testToString() {
+        val ref = TreeReference.rootRef()
+        ref.add("data", 0)
+        ref.add("name", 0)
+
+        val str = ref.toString()
+        assertNotNull(str)
+        assertTrue(str.contains("data"), "toString should contain 'data': $str")
+        assertTrue(str.contains("name"), "toString should contain 'name': $str")
+    }
+
+    @Test
+    fun testIntersect() {
+        val ref1 = TreeReference.rootRef()
+        ref1.add("data", 0)
+        ref1.add("group", 0)
+        ref1.add("name", 0)
+
+        val ref2 = TreeReference.rootRef()
+        ref2.add("data", 0)
+        ref2.add("group", 0)
+        ref2.add("age", 0)
+
+        val intersection = ref1.intersect(ref2)
+        assertNotNull(intersection)
+        assertEquals(2, intersection.size())
+        assertEquals("data", intersection.getName(0))
+        assertEquals("group", intersection.getName(1))
+    }
+
+    @Test
+    fun testContextualize() {
+        val ref = TreeReference.rootRef()
+        ref.add("data", TreeReference.INDEX_UNBOUND)
+        ref.add("name", 0)
+
+        val context = TreeReference.rootRef()
+        context.add("data", 3)
+        context.add("name", 0)
+
+        val result = ref.contextualize(context)
+        assertNotNull(result)
+        assertEquals(3, result.getMultiplicity(0))
+    }
+
+    @Test
+    fun testBuildRefFromTreeElement() {
+        val root = TreeElement("data")
+        val child = TreeElement("question")
+        root.addChild(child)
+
+        val ref = TreeReference.buildRefFromTreeElement(child)
+        assertNotNull(ref)
+        assertTrue(ref.size() > 0)
+    }
+
+    @Test
+    fun testInstanceName() {
+        val ref = TreeReference(null, 0)
+        assertNull(ref.getInstanceName())
+
+        val instanceRef = TreeReference("myInstance", 0)
+        assertEquals("myInstance", instanceRef.getInstanceName())
+    }
+}

--- a/commcare-core/src/commonTest/kotlin/org/javarosa/core/util/externalizable/TaggedSerializationTest.kt
+++ b/commcare-core/src/commonTest/kotlin/org/javarosa/core/util/externalizable/TaggedSerializationTest.kt
@@ -1,0 +1,171 @@
+package org.javarosa.core.util.externalizable
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Cross-platform tests for ExternalizableWrapper types.
+ * Tests wrappers that don't require PrototypeFactory class registration.
+ */
+class TaggedSerializationTest {
+
+    @Test
+    fun testExtWrapNullableWithValueRoundTrip() {
+        val original = ExtWrapNullable("hello")
+
+        val out = PlatformDataOutputStream()
+        original.writeExternal(out)
+        val bytes = out.toByteArray()
+
+        val restored = ExtWrapNullable(String::class)
+        val inp = PlatformDataInputStream(bytes)
+        restored.readExternal(inp, PrototypeFactory())
+
+        assertEquals("hello", restored.`val`)
+    }
+
+    @Test
+    fun testExtWrapNullableWithNullRoundTrip() {
+        val original = ExtWrapNullable(null as String?)
+
+        val out = PlatformDataOutputStream()
+        original.writeExternal(out)
+        val bytes = out.toByteArray()
+
+        val restored = ExtWrapNullable(String::class)
+        val inp = PlatformDataInputStream(bytes)
+        restored.readExternal(inp, PrototypeFactory())
+
+        assertNull(restored.`val`)
+    }
+
+    @Test
+    fun testExtWrapListRoundTrip() {
+        val items = ArrayList<Any>()
+        items.add("alpha")
+        items.add("beta")
+        items.add("gamma")
+
+        val original = ExtWrapList(items)
+
+        val out = PlatformDataOutputStream()
+        original.writeExternal(out)
+        val bytes = out.toByteArray()
+
+        val restored = ExtWrapList(String::class)
+        val inp = PlatformDataInputStream(bytes)
+        restored.readExternal(inp, PrototypeFactory())
+
+        val list = restored.`val` as List<*>
+        assertEquals(3, list.size)
+        assertEquals("alpha", list[0])
+        assertEquals("beta", list[1])
+        assertEquals("gamma", list[2])
+    }
+
+    @Test
+    fun testExtWrapListEmptyRoundTrip() {
+        val original = ExtWrapList(ArrayList<Any>())
+
+        val out = PlatformDataOutputStream()
+        original.writeExternal(out)
+        val bytes = out.toByteArray()
+
+        val restored = ExtWrapList(String::class)
+        val inp = PlatformDataInputStream(bytes)
+        restored.readExternal(inp, PrototypeFactory())
+
+        val list = restored.`val` as List<*>
+        assertEquals(0, list.size)
+    }
+
+    @Test
+    fun testExtWrapMapRoundTrip() {
+        val map = LinkedHashMap<Any, Any>()
+        map["key1"] = "value1"
+        map["key2"] = "value2"
+
+        val original = ExtWrapMap(map)
+
+        val out = PlatformDataOutputStream()
+        original.writeExternal(out)
+        val bytes = out.toByteArray()
+
+        val restored = ExtWrapMap(String::class, String::class)
+        val inp = PlatformDataInputStream(bytes)
+        restored.readExternal(inp, PrototypeFactory())
+
+        val result = restored.`val` as Map<*, *>
+        assertEquals(2, result.size)
+        assertEquals("value1", result["key1"])
+        assertEquals("value2", result["key2"])
+    }
+
+    @Test
+    fun testExtWrapIntEncodingUniformNegativeValues() {
+        for (value in listOf(-1L, -100L, -10000L, Long.MIN_VALUE)) {
+            val original = ExtWrapIntEncodingUniform(value)
+
+            val out = PlatformDataOutputStream()
+            original.writeExternal(out)
+            val bytes = out.toByteArray()
+
+            val restored = ExtWrapIntEncodingUniform()
+            val inp = PlatformDataInputStream(bytes)
+            restored.readExternal(inp, PrototypeFactory())
+
+            assertEquals(value, restored.`val`, "Failed for value $value")
+        }
+    }
+
+    @Test
+    fun testExtWrapIntEncodingUniformLargeValues() {
+        for (value in listOf(0L, 1L, 255L, 256L, 65535L, 65536L, Int.MAX_VALUE.toLong(), Long.MAX_VALUE)) {
+            val original = ExtWrapIntEncodingUniform(value)
+
+            val out = PlatformDataOutputStream()
+            original.writeExternal(out)
+            val bytes = out.toByteArray()
+
+            val restored = ExtWrapIntEncodingUniform()
+            val inp = PlatformDataInputStream(bytes)
+            restored.readExternal(inp, PrototypeFactory())
+
+            assertEquals(value, restored.`val`, "Failed for value $value")
+        }
+    }
+
+    @Test
+    fun testWriteTagWritesHashForPlainObject() {
+        // writeTag for a String should write the class hash (32 bytes)
+        val out = PlatformDataOutputStream()
+        ExtWrapTagged.writeTag(out, "test")
+        val bytes = out.toByteArray()
+
+        assertEquals(PrototypeFactory.getClassHashSize(), bytes.size)
+
+        // Verify the tag matches the expected hash
+        val expectedHash = PrototypeFactory.getClassHashForType(String::class)
+        for (i in bytes.indices) {
+            assertEquals(expectedHash[i], bytes[i], "Hash mismatch at byte $i")
+        }
+    }
+
+    @Test
+    fun testWriteTagWritesWrapperTagForWrapper() {
+        // writeTag for an ExtWrapNullable should write the wrapper tag + code
+        val out = PlatformDataOutputStream()
+        ExtWrapTagged.writeTag(out, ExtWrapNullable("test"))
+        val bytes = out.toByteArray()
+
+        // Should start with the wrapper tag (32 bytes of 0xFF)
+        val wrapperTag = PrototypeFactory.getWrapperTag()
+        assertTrue(bytes.size > wrapperTag.size, "Output should be larger than wrapper tag")
+        for (i in wrapperTag.indices) {
+            assertEquals(wrapperTag[i], bytes[i], "Wrapper tag mismatch at byte $i")
+        }
+    }
+}

--- a/commcare-core/src/commonTest/kotlin/org/javarosa/xpath/XPathParseCrossPlatformTest.kt
+++ b/commcare-core/src/commonTest/kotlin/org/javarosa/xpath/XPathParseCrossPlatformTest.kt
@@ -1,0 +1,103 @@
+package org.javarosa.xpath
+
+import org.javarosa.xpath.expr.XPathNumericLiteral
+import org.javarosa.xpath.expr.XPathPathExpr
+import org.javarosa.xpath.expr.XPathStringLiteral
+import org.javarosa.xpath.parser.XPathSyntaxException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Cross-platform tests for XPath parsing via XPathParseTool.
+ */
+class XPathParseCrossPlatformTest {
+
+    @Test
+    fun testParseSimplePath() {
+        val expr = XPathParseTool.parseXPath("/data/name")
+        assertNotNull(expr)
+        assertTrue(expr is XPathPathExpr)
+    }
+
+    @Test
+    fun testParseStringLiteral() {
+        val expr = XPathParseTool.parseXPath("'hello'")
+        assertNotNull(expr)
+        assertTrue(expr is XPathStringLiteral)
+        assertEquals("hello", (expr as XPathStringLiteral).s)
+    }
+
+    @Test
+    fun testParseNumericLiteral() {
+        val expr = XPathParseTool.parseXPath("42")
+        assertNotNull(expr)
+        assertTrue(expr is XPathNumericLiteral)
+        assertEquals(42.0, (expr as XPathNumericLiteral).d)
+    }
+
+    @Test
+    fun testParseNestedPath() {
+        val expr = XPathParseTool.parseXPath("/data/group/question")
+        assertNotNull(expr)
+        assertTrue(expr is XPathPathExpr)
+        val pathExpr = expr as XPathPathExpr
+        assertEquals(3, pathExpr.steps.size)
+    }
+
+    @Test
+    fun testParseRelativePath() {
+        val expr = XPathParseTool.parseXPath("../sibling")
+        assertNotNull(expr)
+        assertTrue(expr is XPathPathExpr)
+    }
+
+    @Test
+    fun testParsePredicatePath() {
+        val expr = XPathParseTool.parseXPath("/data/item[position() = 1]")
+        assertNotNull(expr)
+        assertTrue(expr is XPathPathExpr)
+    }
+
+    @Test
+    fun testParseFunctionCall() {
+        val expr = XPathParseTool.parseXPath("concat('a', 'b')")
+        assertNotNull(expr)
+    }
+
+    @Test
+    fun testParseArithmetic() {
+        val expr = XPathParseTool.parseXPath("1 + 2")
+        assertNotNull(expr)
+    }
+
+    @Test
+    fun testParseComparison() {
+        val expr = XPathParseTool.parseXPath("/data/age > 18")
+        assertNotNull(expr)
+    }
+
+    @Test
+    fun testParseCurrentRef() {
+        val expr = XPathParseTool.parseXPath(".")
+        assertNotNull(expr)
+        assertTrue(expr is XPathPathExpr)
+    }
+
+    @Test
+    fun testParseSyntaxError() {
+        assertFailsWith<XPathSyntaxException> {
+            XPathParseTool.parseXPath("[invalid xpath")
+        }
+    }
+
+    @Test
+    fun testParseEmptyStringLiteral() {
+        val expr = XPathParseTool.parseXPath("''")
+        assertNotNull(expr)
+        assertTrue(expr is XPathStringLiteral)
+        assertEquals("", (expr as XPathStringLiteral).s)
+    }
+}


### PR DESCRIPTION
## Summary
- 5 new commonTest files with 59 test methods covering core engine operations
- Tests run on both JVM and iOS (via commonTest source set)
- Covers: TreeElement, TreeReference, XPath parsing, Case model, ExternalizableWrapper types

## New test files
- `TaggedSerializationTest` (9 tests) — ExtWrapNullable, ExtWrapList, ExtWrapMap, ExtWrapIntEncoding round-trips, writeTag verification
- `TreeElementCrossPlatformTest` (14 tests) — creation, children, values, attributes, deepCopy, relevance
- `TreeReferenceCrossPlatformTest` (14 tests) — rootRef, clone, equality, genericize, intersect, contextualize, instanceName
- `XPathParseCrossPlatformTest` (12 tests) — paths, literals, functions, predicates, relative paths, syntax errors
- `CaseCrossPlatformTest` (10 tests) — creation, properties, caseId, closed flag, metadata fields

## Test plan
- [x] `./gradlew jvmTest` — all 896 tests pass (837 existing + 59 new)
- [x] `./gradlew compileTestKotlinIosSimulatorArm64` — iOS test compilation succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)