### PR TITLE
feat: Wave 4 — getter/setter to Kotlin property conversion

### DIFF
--- a/commcare-core/src/commonMain/kotlin/org/commcare/session/CommCareSession.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/session/CommCareSession.kt
@@ -726,7 +726,7 @@ open class CommCareSession {
      * @return false if current frame was rewound
      */
     private fun processStackOp(op: StackOperation, ec: EvaluationContext, observer: StackObserver): Boolean {
-        when (op.getOp()) {
+        when (op.op) {
             StackOperation.OPERATION_CREATE -> {
                 val createdFrame = SessionFrame()
                 createFrame(createdFrame, op, ec, observer)
@@ -737,7 +737,7 @@ open class CommCareSession {
                 }
             }
             StackOperation.OPERATION_CLEAR -> performClearOperation(op, ec, observer)
-            else -> throw RuntimeException("Undefined stack operation: " + op.getOp())
+            else -> throw RuntimeException("Undefined stack operation: " + op.op)
         }
 
         return true

--- a/commcare-core/src/commonMain/kotlin/org/commcare/session/RemoteQuerySessionManager.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/session/RemoteQuerySessionManager.kt
@@ -62,16 +62,16 @@ class RemoteQuerySessionManager private constructor(
             val promptId = en.next() as String
             val prompt = queryPrompts[promptId]
 
-            if (isPromptSupported(prompt!!) && prompt.getDefaultValueExpr() != null) {
-                var value = FunctionUtils.toString(prompt.getDefaultValueExpr()!!.eval(evaluationContext))
-                if (INPUT_TYPE_DATERANGE == prompt.getInput()) {
+            if (isPromptSupported(prompt!!) && prompt.defaultValueExpr != null) {
+                var value = FunctionUtils.toString(prompt.defaultValueExpr!!.eval(evaluationContext))
+                if (INPUT_TYPE_DATERANGE == prompt.input) {
                     try {
                         value = DateRangeUtils.formatDateRangeAnswer(value)
                     } catch (e: PlatformParseException) {
                         Logger.exception("Error parsing default date range $value for $promptId", e)
                     }
                 }
-                userAnswers[prompt.getKey()!!] = value
+                userAnswers[prompt.key!!] = value
             }
         }
     }
@@ -131,7 +131,7 @@ class RemoteQuerySessionManager private constructor(
                 val key = en.next() as String
                 val value = userAnswers[key]
                 val prompt = queryDatum.getUserQueryPrompts()?.get(key)
-                val excludeExpr = prompt!!.getExclude()
+                val excludeExpr = prompt!!.exclude
                 if (!(params.containsKey(key) && params[key].contains(value))) {
                     if (value != null && (excludeExpr == null || !(excludeExpr.eval(evaluationContext) as Boolean))) {
                         val choices = extractMultipleChoices(value)
@@ -167,7 +167,7 @@ class RemoteQuerySessionManager private constructor(
     }
 
     fun populateItemSetChoices(queryPrompt: QueryPrompt) {
-        queryPrompt.getItemsetBinding()?.let {
+        queryPrompt.itemsetBinding?.let {
             ItemSetUtils.populateDynamicChoices(it, getEvaluationContextWithUserInputInstance())
         }
     }
@@ -215,7 +215,7 @@ class RemoteQuerySessionManager private constructor(
                     val selectedChoices = extractMultipleChoices(answer)
                     val validSelectedChoices = ArrayList<String>()
                     for (selectedChoice in selectedChoices) {
-                        if (queryPrompt.getItemsetBinding() != null && checkForValidSelectValue(queryPrompt.getItemsetBinding()!!, selectedChoice)) {
+                        if (queryPrompt.itemsetBinding != null && checkForValidSelectValue(queryPrompt.itemsetBinding!!, selectedChoice)) {
                             validSelectedChoices.add(selectedChoice)
                         } else {
                             dirty = true
@@ -272,7 +272,7 @@ class RemoteQuerySessionManager private constructor(
     }
 
     fun isPromptSupported(queryPrompt: QueryPrompt): Boolean {
-        return queryPrompt.getInput() == null || supportedPrompts.indexOf(queryPrompt.getInput()) != -1
+        return queryPrompt.input == null || supportedPrompts.indexOf(queryPrompt.input) != -1
     }
 
     // checks if value is one of the select choices given in items

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Action.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Action.kt
@@ -20,12 +20,17 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * @author ctsims
  */
 class Action : Externalizable {
-    private var display: DisplayUnit? = null
-    private var stackOps: ArrayList<StackOperation>? = null
+    var display: DisplayUnit? = null
+        private set
+    var stackOperations: ArrayList<StackOperation>? = null
+        private set
     private var relevantExpr: XPathExpression? = null
-    private var iconReferenceForActionBar: String? = null
-    private var autoLaunchExpr: XPathExpression? = null
-    private var redoLast: Boolean = false
+    var actionBarIconReference: String? = null
+        private set
+    var autoLaunchExpr: XPathExpression? = null
+        private set
+    var isRedoLast: Boolean = false
+        private set
 
     /**
      * Serialization only!!!
@@ -45,24 +50,12 @@ class Action : Externalizable {
         redoLast: Boolean
     ) {
         this.display = display
-        this.stackOps = stackOps
+        this.stackOperations = stackOps
         this.relevantExpr = relevantExpr
-        this.iconReferenceForActionBar = if (iconForActionBar == null) "" else iconForActionBar
+        this.actionBarIconReference = if (iconForActionBar == null) "" else iconForActionBar
         this.autoLaunchExpr = autoLaunchExpr
-        this.redoLast = redoLast
+        this.isRedoLast = redoLast
     }
-
-    /**
-     * @return The Display model for showing this action to the user
-     */
-    fun getDisplay(): DisplayUnit? = display
-
-    /**
-     * @return A vector of the StackOperation models which
-     * should be processed sequentially upon this action
-     * being triggered by the user.
-     */
-    fun getStackOperations(): ArrayList<StackOperation>? = stackOps
 
     fun isRelevant(evalContext: EvaluationContext): Boolean {
         val re = relevantExpr ?: return true
@@ -76,32 +69,26 @@ class Action : Externalizable {
         return "true" == result
     }
 
-    fun getAutoLaunchExpr(): XPathExpression? = autoLaunchExpr
-
-    fun isRedoLast(): Boolean = redoLast
-
-    fun hasActionBarIcon(): Boolean = "" != iconReferenceForActionBar
-
-    fun getActionBarIconReference(): String? = iconReferenceForActionBar
+    fun hasActionBarIcon(): Boolean = "" != actionBarIconReference
 
     @Suppress("UNCHECKED_CAST")
     @Throws(PlatformIOException::class, DeserializationException::class)
     override fun readExternal(`in`: PlatformDataInputStream, pf: PrototypeFactory) {
         display = SerializationHelpers.readExternalizable(`in`, pf) { DisplayUnit() }
-        stackOps = SerializationHelpers.readList(`in`, pf) { StackOperation() }
+        stackOperations = SerializationHelpers.readList(`in`, pf) { StackOperation() }
         autoLaunchExpr = SerializationHelpers.readNullableTagged(`in`, pf) as XPathExpression?
         relevantExpr = SerializationHelpers.readNullableTagged(`in`, pf) as XPathExpression?
-        iconReferenceForActionBar = SerializationHelpers.readString(`in`)
-        redoLast = SerializationHelpers.readBool(`in`)
+        actionBarIconReference = SerializationHelpers.readString(`in`)
+        isRedoLast = SerializationHelpers.readBool(`in`)
     }
 
     @Throws(PlatformIOException::class)
     override fun writeExternal(out: PlatformDataOutputStream) {
         SerializationHelpers.write(out, display as Any)
-        SerializationHelpers.writeList(out, stackOps!!)
+        SerializationHelpers.writeList(out, stackOperations!!)
         SerializationHelpers.writeNullableTagged(out, autoLaunchExpr)
         SerializationHelpers.writeNullableTagged(out, relevantExpr)
-        SerializationHelpers.writeString(out, iconReferenceForActionBar ?: "")
-        SerializationHelpers.writeBool(out, redoLast)
+        SerializationHelpers.writeString(out, actionBarIconReference ?: "")
+        SerializationHelpers.writeBool(out, isRedoLast)
     }
 }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Callout.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Callout.kt
@@ -20,13 +20,19 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * @author wpride1 on 4/14/15.
  */
 class Callout : Externalizable, DetailTemplate {
-    private var actionName: String? = null
-    private var image: String? = null
-    private var displayName: String? = null
+    var actionName: String? = null
+        private set
+    var image: String? = null
+        private set
+    var displayName: String? = null
+        private set
     private var type: String? = null
-    private var extras: MutableMap<String, String>? = null
-    private var responses: ArrayList<String>? = null
-    private var isAutoLaunching: Boolean = false
+    var extras: MutableMap<String, String>? = null
+        private set
+    var responses: ArrayList<String>? = null
+        private set
+    var isAutoLaunching: Boolean = false
+        private set
     private var assumePlainTextValues: Boolean = false
 
     /**
@@ -34,7 +40,8 @@ class Callout : Externalizable, DetailTemplate {
      * is the column header text and 'template' is the key used for mapping a
      * callout result data point to a case, should usually be the case id.
      */
-    internal var responseDetailField: DetailField? = null
+    var responseDetailField: DetailField? = null
+        internal set
 
     /**
      * For externalization
@@ -119,20 +126,6 @@ class Callout : Externalizable, DetailTemplate {
         SerializationHelpers.writeNullable(out, type)
         SerializationHelpers.writeBool(out, isAutoLaunching)
     }
-
-    fun getImage(): String? = image
-
-    fun getActionName(): String? = actionName
-
-    fun getDisplayName(): String? = displayName
-
-    fun getExtras(): MutableMap<String, String>? = extras
-
-    fun getResponses(): ArrayList<String>? = responses
-
-    fun getResponseDetailField(): DetailField? = responseDetailField
-
-    fun isAutoLaunching(): Boolean = isAutoLaunching
 
     fun isSimprintsCallout(): Boolean = "com.simprints.id.IDENTIFY" == actionName
 

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Credential.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Credential.kt
@@ -13,8 +13,10 @@ import org.javarosa.core.util.externalizable.SerializationHelpers
  * Apps use this model to convey the types of credentials it issues
  */
 class Credential : Externalizable {
-    private var level: String? = null
-    private var type: String? = null
+    var level: String? = null
+        private set
+    var type: String? = null
+        private set
 
     /**
      * Serialization Only!!!
@@ -37,10 +39,6 @@ class Credential : Externalizable {
         SerializationHelpers.writeString(out, level!!)
         SerializationHelpers.writeString(out, type!!)
     }
-
-    fun getLevel(): String? = level
-
-    fun getType(): String? = type
 
     override fun toString(): String {
         return "Credential{level='$level', type='$type'}"

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Detail.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Detail.kt
@@ -45,10 +45,14 @@ class Detail : Externalizable {
 
     // id will be null if this is a child detail / tab
     internal var id: String? = null
-    private var nodeset: TreeReference? = null
-    private var title: DisplayUnit? = null
-    private var noItemsText: Text? = null
-    private var selectText: Text? = null
+    var nodeset: TreeReference? = null
+        private set
+    var title: DisplayUnit? = null
+        private set
+    var noItemsText: Text? = null
+        private set
+    var selectText: Text? = null
+        private set
 
     /**
      * Optional and only relevant if this detail has child details. In that
@@ -56,31 +60,41 @@ class Detail : Externalizable {
      */
     private var titleForm: String? = null
 
-    private lateinit var details: Array<Detail>
-    internal lateinit var fields: Array<DetailField>
-    internal var callout: Callout? = null
+    lateinit var details: Array<Detail>
+        private set
+    lateinit var fields: Array<DetailField>
+        internal set
+    var callout: Callout? = null
+        internal set
     private var variables: OrderedHashtable<String, String> = OrderedHashtable()
     private var variablesCompiled: OrderedHashtable<String, XPathExpression>? = null
     private var actions: ArrayList<Action> = ArrayList()
 
     // Force the activity that is showing this detail to show itself in landscape view only
     private var forceLandscapeView: Boolean = false
-    private var focusFunction: XPathExpression? = null
+    var focusFunction: XPathExpression? = null
+        private set
 
     // A button to print this detail should be provided
-    private var printEnabled: Boolean = false
-    private var printTemplatePath: String? = null
+    var printEnabled: Boolean = false
+        private set
+    var printTemplatePath: String? = null
+        private set
     private var parsedRelevancyExpression: XPathExpression? = null
-    private var global: Global? = null
+    var global: Global? = null
+        private set
 
     // REGION -- These fields are only used if this detail is a case tile
-    private var numEntitiesToDisplayPerRow: Int = 0
-    private var useUniformUnitsInCaseTile: Boolean = false
+    var numEntitiesToDisplayPerRow: Int = 0
+        private set
+    var useUniformUnitsInCaseTile: Boolean = false
+        private set
     private var _lazyLoading: Boolean = false
     val isLazyLoading: Boolean get() = _lazyLoading
     private var _cacheEnabled: Boolean = false
     val isCacheEnabled: Boolean get() = _cacheEnabled
-    internal var group: DetailGroup? = null
+    var group: DetailGroup? = null
+        internal set
     // ENDREGION
 
     /**
@@ -152,18 +166,6 @@ class Detail : Externalizable {
         this._cacheEnabled = cacheEnabled
     }
 
-    fun getTitle(): DisplayUnit? = title
-
-    fun getNoItemsText(): Text? = noItemsText
-
-    fun getSelectText(): Text? = selectText
-
-    fun getNodeset(): TreeReference? = nodeset
-
-    fun getFields(): Array<DetailField> = fields
-
-    fun getDetails(): Array<Detail> = details
-
     /**
      * Given a detail, return an array of details that will contain either
      * - all child details
@@ -171,7 +173,7 @@ class Detail : Externalizable {
      */
     fun getFlattenedDetails(): Array<Detail> {
         return if (this.isCompound()) {
-            this.getDetails()
+            this.details
         } else {
             arrayOf(this)
         }
@@ -190,7 +192,7 @@ class Detail : Externalizable {
     @Deprecated("Legacy way to turn on cache and index")
     fun useAsyncStrategy(): Boolean {
         for (f in fields) {
-            if (f.getSortOrder() == DetailField.SORT_ORDER_CACHABLE) {
+            if (f.sortOrder == DetailField.SORT_ORDER_CACHABLE) {
                 return true
             }
         }
@@ -283,7 +285,7 @@ class Detail : Externalizable {
         val cacheAndIndexedIndices = ArrayList<Int>()
         var i = 0
         outer@ while (i < fields.size) {
-            val order = fields[i].getSortOrder()
+            val order = fields[i].sortOrder
             if (order == -2) {
                 cacheAndIndexedIndices.add(i)
             }
@@ -292,7 +294,7 @@ class Detail : Externalizable {
                 continue
             }
             for (j in 0 until indices.size) {
-                if (order < fields[indices[j]].getSortOrder()) {
+                if (order < fields[indices[j]].sortOrder) {
                     indices.add(j, i)
                     i++
                     continue@outer
@@ -311,7 +313,7 @@ class Detail : Externalizable {
     fun getTemplateSizeHints(): Array<String?> {
         val result = arrayOfNulls<String>(fields.size)
         for (i in fields.indices) {
-            result[i] = fields[i].getTemplateWidthHint()
+            result[i] = fields[i].templateWidthHint
         }
         return result
     }
@@ -319,7 +321,7 @@ class Detail : Externalizable {
     val headerForms: Array<String?> get() {
         val result = arrayOfNulls<String>(fields.size)
         for (i in fields.indices) {
-            result[i] = fields[i].getHeaderForm()
+            result[i] = fields[i].headerForm
         }
         return result
     }
@@ -327,7 +329,7 @@ class Detail : Externalizable {
     fun getTemplateForms(): Array<String?> {
         val result = arrayOfNulls<String>(fields.size)
         for (i in fields.indices) {
-            result[i] = fields[i].getTemplateForm()
+            result[i] = fields[i].templateForm
         }
         return result
     }
@@ -335,8 +337,8 @@ class Detail : Externalizable {
     fun usesEntityTileView(): Boolean {
         var usingEntityTile = false
         for (currentField in fields) {
-            if (currentField.getGridX() >= 0 && currentField.getGridY() >= 0 &&
-                currentField.getGridWidth() >= 0 && currentField.getGridHeight() > 0
+            if (currentField.gridX >= 0 && currentField.gridY >= 0 &&
+                currentField.gridWidth >= 0 && currentField.gridHeight > 0
             ) {
                 usingEntityTile = true
             }
@@ -348,11 +350,7 @@ class Detail : Externalizable {
         return numEntitiesToDisplayPerRow > 1 && usesEntityTileView()
     }
 
-    fun getNumEntitiesToDisplayPerRow(): Int = numEntitiesToDisplayPerRow
-
-    fun useUniformUnitsInCaseTile(): Boolean = useUniformUnitsInCaseTile
-
-    fun forcesLandscape(): Boolean = forceLandscapeView
+    val forcesLandscape: Boolean get() = forceLandscapeView
 
     fun getMaxWidthHeight(): Pair<Int, Int> {
         var maxWidth = 0
@@ -360,8 +358,8 @@ class Detail : Externalizable {
 
         for (i in fields.indices) {
             val currentField = fields[i]
-            val currentWidth = currentField.getGridX() + currentField.getGridWidth()
-            val currentHeight = currentField.getGridY() + currentField.getGridHeight()
+            val currentWidth = currentField.gridX + currentField.gridWidth
+            val currentHeight = currentField.gridY + currentField.gridHeight
             maxWidth = if (currentWidth > maxWidth) currentWidth else maxWidth
             maxHeight = if (currentHeight > maxHeight) currentHeight else maxHeight
         }
@@ -373,8 +371,8 @@ class Detail : Externalizable {
         return Array(fields.size) { i ->
             val currentField = fields[i]
             GridCoordinate(
-                currentField.getGridX(), currentField.getGridY(),
-                currentField.getGridWidth(), currentField.getGridHeight()
+                currentField.gridX, currentField.gridY,
+                currentField.gridWidth, currentField.gridHeight
             )
         }
     }
@@ -383,17 +381,15 @@ class Detail : Externalizable {
         return Array(fields.size) { i ->
             val currentField = fields[i]
             GridStyle(
-                currentField.getFontSize(), currentField.getHorizontalAlign(),
-                currentField.getVerticalAlign(), currentField.getCssId()
+                currentField.fontSize, currentField.horizontalAlign,
+                currentField.verticalAlign, currentField.cssID
             )
         }
     }
 
-    fun getCallout(): Callout? = callout
-
     fun hasSortField(): Boolean {
         for (f in fields) {
-            if (f.getSortOrder() > 0) {
+            if (f.sortOrder > 0) {
                 return true
             }
         }
@@ -438,8 +434,6 @@ class Detail : Externalizable {
         return FunctionUtils.toBoolean(value)
     }
 
-    fun getFocusFunction(): XPathExpression? = focusFunction
-
     private fun templatePathValid(templatePathProvided: String?): Boolean {
         if (PRINT_TEMPLATE_PROVIDED_VIA_GLOBAL_SETTING == templatePathProvided) {
             return true
@@ -454,10 +448,6 @@ class Detail : Externalizable {
         }
         return false
     }
-
-    fun isPrintEnabled(): Boolean = this.printEnabled
-
-    fun getPrintTemplatePath(): String? = this.printTemplatePath
 
     fun getKeyValueMapForPrint(
         selectedEntityRef: TreeReference,
@@ -526,10 +516,6 @@ class Detail : Externalizable {
         }
         return FunctionUtils.toBoolean(parsedRelevancyExpression!!.eval(context))
     }
-
-    fun getGlobal(): Global? = global
-
-    fun getGroup(): DetailGroup? = group
 
     companion object {
         const val PRINT_TEMPLATE_PROVIDED_VIA_GLOBAL_SETTING = "provided-globally"

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/DetailField.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/DetailField.kt
@@ -32,38 +32,54 @@ class DetailField : Externalizable {
     internal var sort: Text? = null
     private var relevancy: String? = null
     private var parsedRelevancy: XPathExpression? = null
-    private var headerWidthHint: String? = null  // Something like "500" or "10%"
-    private var templateWidthHint: String? = null
+    var headerWidthHint: String? = null  // Something like "500" or "10%"
+        internal set
+    var templateWidthHint: String? = null
+        internal set
     private var printIdentifier: String? = null
     internal var altText: Text? = null
-    private var endpointAction: EndpointAction? = null
+    var endpointAction: EndpointAction? = null
+        internal set
 
-    private var showBorder: Boolean = false
-    private var showShading: Boolean = false
+    var showBorder: Boolean = false
+        internal set
+    var showShading: Boolean = false
+        internal set
 
     /**
      * Optional hint which provides a hint for whether rich media should be
      * displayed based on `<text>` returning a URI.  May be either 'image' or
      * 'audio'
      */
-    private var headerForm: String? = null
+    var headerForm: String? = null
+        internal set
 
     /**
      * Same as 'headerForm' except can also be set to 'graph'
      */
-    private var templateForm: String? = null
-    private var sortOrder: Int = -1
+    var templateForm: String? = null
+        internal set
+    var sortOrder: Int = -1
+        internal set
     internal var sortDirection: Int = DIRECTION_ASCENDING
     internal var sortType: Int = Constants.DATATYPE_TEXT
     private var showBlanksLastInSort: Boolean = false
-    private var gridX: Int = -1
-    private var gridY: Int = -1
-    private var gridWidth: Int = -1
-    private var gridHeight: Int = -1
-    private var horizontalAlign: String? = null
-    private var verticalAlign: String? = null
-    private var fontSize: String? = null
-    private var cssID: String? = null
+    var gridX: Int = -1
+        internal set
+    var gridY: Int = -1
+        internal set
+    var gridWidth: Int = -1
+        internal set
+    var gridHeight: Int = -1
+        internal set
+    var horizontalAlign: String? = null
+        internal set
+    var verticalAlign: String? = null
+        internal set
+    var fontSize: String? = null
+        internal set
+    var cssID: String? = null
+        internal set
 
     private var _lazyLoading: Boolean = false
     val isLazyLoading: Boolean get() = _lazyLoading
@@ -109,15 +125,6 @@ class DetailField : Externalizable {
         return FunctionUtils.toBoolean(parsedRelevancy!!.eval(context))
     }
 
-    fun getHeaderWidthHint(): String? = headerWidthHint
-
-    fun getTemplateWidthHint(): String? = templateWidthHint
-
-    fun getHeaderForm(): String? = headerForm
-
-    fun getTemplateForm(): String? = templateForm
-
-    fun getSortOrder(): Int = sortOrder
 
     fun showBlanksLastInSort(): Boolean = this.showBlanksLastInSort
 
@@ -196,18 +203,7 @@ class DetailField : Externalizable {
         SerializationHelpers.writeBool(out, _lazyLoading)
     }
 
-    fun getGridX(): Int = gridX
-    fun getGridY(): Int = gridY
-    fun getGridWidth(): Int = gridWidth
-    fun getGridHeight(): Int = gridHeight
-    fun getHorizontalAlign(): String? = horizontalAlign
-    fun getVerticalAlign(): String? = verticalAlign
     // altText is internal property
-    fun getEndpointAction(): EndpointAction? = endpointAction
-    fun getFontSize(): String? = fontSize
-    fun getCssId(): String? = cssID
-    fun getShowBorder(): Boolean = showBorder
-    fun getShowShading(): Boolean = showShading
     // isLazyLoading and isCacheEnabled are public properties
 
     class Builder {

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/DisplayUnit.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/DisplayUnit.kt
@@ -17,11 +17,20 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * @author ctsims
  */
 class DisplayUnit : Externalizable, DetailTemplate {
-    private var name: Text? = null
-    private var imageReference: Text? = null
-    private var audioReference: Text? = null
-    private var badgeFunction: Text? = null
-    private var hintText: Text? = null
+    /**
+     * A Text which should be displayed to the user as
+     * the action which will display this menu.
+     */
+    var text: Text? = null
+        private set
+    var imageURI: Text? = null
+        private set
+    var audioURI: Text? = null
+        private set
+    var badgeText: Text? = null
+        private set
+    var hintText: Text? = null
+        private set
 
     /**
      * Serialization only!!!
@@ -37,10 +46,10 @@ class DisplayUnit : Externalizable, DetailTemplate {
         badge: Text?,
         hintText: Text?
     ) {
-        this.name = name
-        this.imageReference = imageReference
-        this.audioReference = audioReference
-        this.badgeFunction = badge
+        this.text = name
+        this.imageURI = imageReference
+        this.audioURI = audioReference
+        this.badgeText = badge
         this.hintText = hintText
     }
 
@@ -49,42 +58,28 @@ class DisplayUnit : Externalizable, DetailTemplate {
     }
 
     override fun evaluate(ec: EvaluationContext?): DisplayData {
-        val imageRef = imageReference?.evaluate(ec)
-        val audioRef = audioReference?.evaluate(ec)
-        val textForBadge = badgeFunction?.evaluate(ec)
+        val imageRef = imageURI?.evaluate(ec)
+        val audioRef = audioURI?.evaluate(ec)
+        val textForBadge = badgeText?.evaluate(ec)
         val textForHint = hintText?.evaluate(ec)
-        return DisplayData(name!!.evaluate(ec), imageRef, audioRef, textForBadge, textForHint)
+        return DisplayData(text!!.evaluate(ec), imageRef, audioRef, textForBadge, textForHint)
     }
-
-    /**
-     * @return A Text which should be displayed to the user as
-     * the action which will display this menu.
-     */
-    fun getText(): Text? = name
-
-    fun getImageURI(): Text? = imageReference
-
-    fun getAudioURI(): Text? = audioReference
-
-    fun getBadgeText(): Text? = badgeFunction
-
-    fun getHintText(): Text? = hintText
 
     @Throws(PlatformIOException::class, DeserializationException::class)
     override fun readExternal(`in`: PlatformDataInputStream, pf: PrototypeFactory) {
-        name = SerializationHelpers.readExternalizable(`in`, pf) { Text() }
-        imageReference = SerializationHelpers.readNullableExternalizable(`in`, pf) { Text() }
-        audioReference = SerializationHelpers.readNullableExternalizable(`in`, pf) { Text() }
-        badgeFunction = SerializationHelpers.readNullableExternalizable(`in`, pf) { Text() }
+        text = SerializationHelpers.readExternalizable(`in`, pf) { Text() }
+        imageURI = SerializationHelpers.readNullableExternalizable(`in`, pf) { Text() }
+        audioURI = SerializationHelpers.readNullableExternalizable(`in`, pf) { Text() }
+        badgeText = SerializationHelpers.readNullableExternalizable(`in`, pf) { Text() }
         hintText = SerializationHelpers.readNullableExternalizable(`in`, pf) { Text() }
     }
 
     @Throws(PlatformIOException::class)
     override fun writeExternal(out: PlatformDataOutputStream) {
-        SerializationHelpers.write(out, name!!)
-        SerializationHelpers.writeNullable(out, imageReference)
-        SerializationHelpers.writeNullable(out, audioReference)
-        SerializationHelpers.writeNullable(out, badgeFunction)
+        SerializationHelpers.write(out, text!!)
+        SerializationHelpers.writeNullable(out, imageURI)
+        SerializationHelpers.writeNullable(out, audioURI)
+        SerializationHelpers.writeNullable(out, badgeText)
         SerializationHelpers.writeNullable(out, hintText)
     }
 }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Endpoint.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Endpoint.kt
@@ -74,13 +74,13 @@ class Endpoint : Externalizable {
             if (endpointArguments.size > args.size) {
                 val missingArguments = ArrayList<String>()
                 for (i in args.size until endpointArguments.size) {
-                    missingArguments.add(endpointArguments[i].getId()!!)
+                    missingArguments.add(endpointArguments[i].id!!)
                 }
                 throw InvalidEndpointArgumentsException(missingArguments, null)
             }
 
             for (i in 0 until endpointArguments.size) {
-                val argumentName = endpointArguments[i].getId()!!
+                val argumentName = endpointArguments[i].id!!
                 evaluationContext.setVariable(argumentName, args[i])
             }
         }
@@ -95,8 +95,8 @@ class Endpoint : Externalizable {
             val argumentIds = args.keys
             val missingArguments = ArrayList<String>()
             for (endpointArgument in endpointArguments) {
-                if (!argumentIds.contains(endpointArgument.getId())) {
-                    missingArguments.add(endpointArgument.getId()!!)
+                if (!argumentIds.contains(endpointArgument.id)) {
+                    missingArguments.add(endpointArgument.id!!)
                 }
             }
 
@@ -112,7 +112,7 @@ class Endpoint : Externalizable {
             }
 
             for (i in 0 until endpointArguments.size) {
-                val argumentName = endpointArguments[i].getId()!!
+                val argumentName = endpointArguments[i].id!!
                 if (args.containsKey(argumentName)) {
                     evaluationContext.setVariable(argumentName, args[argumentName])
                 }
@@ -124,7 +124,7 @@ class Endpoint : Externalizable {
             argumentId: String
         ): Boolean {
             for (endpointArgument in endpointArguments) {
-                if (endpointArgument.getId()!!.contentEquals(argumentId)) {
+                if (endpointArgument.id!!.contentEquals(argumentId)) {
                     return true
                 }
             }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/EndpointAction.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/EndpointAction.kt
@@ -11,8 +11,10 @@ import org.javarosa.core.util.externalizable.SerializationHelpers
 import org.javarosa.core.util.externalizable.emptyIfNull
 
 class EndpointAction : Externalizable {
-    private var endpointId: String? = null
-    private var isBackground: Boolean = false
+    var endpointId: String? = null
+        private set
+    var isBackground: Boolean = false
+        private set
 
     constructor()
 
@@ -32,8 +34,4 @@ class EndpointAction : Externalizable {
         SerializationHelpers.writeString(out, emptyIfNull(endpointId))
         SerializationHelpers.writeBool(out, isBackground)
     }
-
-    fun getEndpointId(): String? = endpointId
-
-    fun isBackground(): Boolean = isBackground
 }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/EndpointArgument.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/EndpointArgument.kt
@@ -15,9 +15,12 @@ import org.javarosa.core.util.externalizable.emptyIfNull
  * Model class to represent an argument to Endpoint
  */
 class EndpointArgument : Externalizable {
-    private var id: String? = null
-    private var instanceId: String? = null
-    private var instanceSrc: String? = null
+    var id: String? = null
+        private set
+    var instanceId: String? = null
+        private set
+    var instanceSrc: String? = null
+        private set
 
     // for serialization
     constructor()
@@ -41,12 +44,6 @@ class EndpointArgument : Externalizable {
         SerializationHelpers.writeString(out, emptyIfNull(instanceId))
         SerializationHelpers.writeString(out, emptyIfNull(instanceSrc))
     }
-
-    fun getId(): String? = id
-
-    fun getInstanceId(): String? = instanceId
-
-    fun getInstanceSrc(): String? = instanceSrc
 
     /**
      * If the argument should be processed into a external data instance

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Entry.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Entry.kt
@@ -77,7 +77,7 @@ abstract class Entry : Externalizable, MenuDisplayable {
      * @return A text whose evaluated string should be presented to the
      * user as the entry point for this operation
      */
-    fun getText(): Text? = display?.getText()
+    fun getText(): Text? = display?.text
 
     fun getSessionDataReqs(): ArrayList<SessionDatum>? = data
 
@@ -98,28 +98,28 @@ abstract class Entry : Externalizable, MenuDisplayable {
     fun getPostEntrySessionOperations(): ArrayList<StackOperation>? = stackOperations
 
     override fun getImageURI(): String? {
-        val imageUri = display?.getImageURI() ?: return null
+        val imageUri = display?.imageURI ?: return null
         return imageUri.evaluate()
     }
 
     override fun getAudioURI(): String? {
-        val audioUri = display?.getAudioURI() ?: return null
+        val audioUri = display?.audioURI ?: return null
         return audioUri.evaluate()
     }
 
     override fun getDisplayText(ec: EvaluationContext?): String? {
-        val text = display?.getText() ?: return null
+        val text = display?.text ?: return null
         return text.evaluate(ec)
     }
 
     override fun getTextForBadge(ec: EvaluationContext?): PlatformSingle<String> {
-        val badgeText = display?.getBadgeText() ?: return platformSingleJust("")
+        val badgeText = display?.badgeText ?: return platformSingleJust("")
         return badgeText.getDisposableSingleForEvaluation(ec)
     }
 
-    override fun getRawBadgeTextObject(): Text? = display?.getBadgeText()
+    override fun getRawBadgeTextObject(): Text? = display?.badgeText
 
-    override fun getRawText(): Text? = display?.getText()
+    override fun getRawText(): Text? = display?.text
 
     override fun getCommandID(): String? = commandId
 

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/GeoOverlay.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/GeoOverlay.kt
@@ -13,8 +13,10 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * Defines a polygon region to be displayed on a map
  */
 class GeoOverlay : Externalizable {
-    private var coordinates: DisplayUnit? = null
-    private var label: DisplayUnit? = null
+    var coordinates: DisplayUnit? = null
+        private set
+    var label: DisplayUnit? = null
+        private set
 
     /**
      * Serialization Only
@@ -37,8 +39,4 @@ class GeoOverlay : Externalizable {
         SerializationHelpers.writeNullable(out, coordinates)
         SerializationHelpers.writeNullable(out, label)
     }
-
-    fun getCoordinates(): DisplayUnit? = coordinates
-
-    fun getLabel(): DisplayUnit? = label
 }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Menu.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Menu.kt
@@ -74,7 +74,7 @@ class Menu : Externalizable, MenuDisplayable {
      * @return A Text which should be displayed to the user as
      * the action which will display this menu.
      */
-    fun getName(): Text? = display?.getText()
+    fun getName(): Text? = display?.text
 
     /**
      * @return The ID of this menu. If this value is "root"
@@ -174,28 +174,28 @@ class Menu : Externalizable, MenuDisplayable {
     }
 
     override fun getImageURI(): String? {
-        val imageUri = display?.getImageURI() ?: return null
+        val imageUri = display?.imageURI ?: return null
         return imageUri.evaluate()
     }
 
     override fun getAudioURI(): String? {
-        val audioUri = display?.getAudioURI() ?: return null
+        val audioUri = display?.audioURI ?: return null
         return audioUri.evaluate()
     }
 
     override fun getDisplayText(ec: EvaluationContext?): String? {
-        val text = display?.getText() ?: return null
+        val text = display?.text ?: return null
         return text.evaluate(ec)
     }
 
     override fun getTextForBadge(ec: EvaluationContext?): PlatformSingle<String> {
-        val badgeText = display?.getBadgeText() ?: return platformSingleJust("")
+        val badgeText = display?.badgeText ?: return platformSingleJust("")
         return badgeText.getDisposableSingleForEvaluation(ec)
     }
 
-    override fun getRawBadgeTextObject(): Text? = display?.getBadgeText()
+    override fun getRawBadgeTextObject(): Text? = display?.badgeText
 
-    override fun getRawText(): Text? = display?.getText()
+    override fun getRawText(): Text? = display?.text
 
     override fun getCommandID(): String? = _id
 

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/PostRequest.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/PostRequest.kt
@@ -22,7 +22,8 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * @author Phillip Mates (pmates@dimagi.com).
  */
 class PostRequest : Externalizable {
-    private var url: PlatformUrl? = null
+    var url: PlatformUrl? = null
+        private set
     private var relevantExpr: XPathExpression? = null
     private var params: List<QueryData>? = null
 
@@ -33,8 +34,6 @@ class PostRequest : Externalizable {
         this.params = params
         this.relevantExpr = relevantExpr
     }
-
-    fun getUrl(): PlatformUrl? = url
 
     /**
      * Evaluates parameters for post request

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Profile.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Profile.kt
@@ -181,10 +181,10 @@ class Profile : Persistable {
     fun initializeProperties(platform: CommCarePlatform, enableForce: Boolean) {
         val propertyManager = platform.getPropertyManager()!!
         for (setter in properties) {
-            val property = propertyManager.getSingularProperty(setter.getKey())
+            val property = propertyManager.getSingularProperty(setter.key)
             // We only want to set properties which are undefined or are forced
             if (property == null || (enableForce && setter.force)) {
-                propertyManager.setProperty(setter.getKey(), setter.getValue())
+                propertyManager.setProperty(setter.key, setter.value)
             }
         }
     }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/PropertySetter.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/PropertySetter.kt
@@ -18,10 +18,12 @@ import kotlin.jvm.JvmField
  * @author ctsims
  */
 class PropertySetter : Externalizable {
-    private var _key: String = ""
-    private var _value: String = ""
+    var key: String = ""
+        private set
+    var value: String = ""
+        private set
     @JvmField
-    internal var force: Boolean = false
+    var force: Boolean = false
 
     /**
      * Serialization Only!!!
@@ -29,28 +31,22 @@ class PropertySetter : Externalizable {
     constructor()
 
     internal constructor(key: String, value: String, force: Boolean) {
-        this._key = key
-        this._value = value
+        this.key = key
+        this.value = value
         this.force = force
     }
 
-    fun getKey(): String = _key
-
-    fun getValue(): String = _value
-
-    fun isForce(): Boolean = force
-
     @Throws(PlatformIOException::class, DeserializationException::class)
     override fun readExternal(`in`: PlatformDataInputStream, pf: PrototypeFactory) {
-        _key = SerializationHelpers.readString(`in`)
-        _value = SerializationHelpers.readString(`in`)
+        key = SerializationHelpers.readString(`in`)
+        value = SerializationHelpers.readString(`in`)
         force = SerializationHelpers.readBool(`in`)
     }
 
     @Throws(PlatformIOException::class)
     override fun writeExternal(out: PlatformDataOutputStream) {
-        SerializationHelpers.writeString(out, _key)
-        SerializationHelpers.writeString(out, _value)
+        SerializationHelpers.writeString(out, key)
+        SerializationHelpers.writeString(out, value)
         SerializationHelpers.writeBool(out, force)
     }
 
@@ -59,15 +55,15 @@ class PropertySetter : Externalizable {
             return false
         }
 
-        return this._key == other._key &&
-                this._value == other._value &&
+        return this.key == other.key &&
+                this.value == other.value &&
                 force == other.force
     }
 
     override fun hashCode(): Int {
         var result = 11
-        result = 31 * result + _key.hashCode()
-        result = 31 * result + _value.hashCode()
+        result = 31 * result + key.hashCode()
+        result = 31 * result + value.hashCode()
         result = 31 * result + if (force) 0 else 1
         return result
     }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/QueryPrompt.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/QueryPrompt.kt
@@ -17,19 +17,32 @@ import org.javarosa.core.util.externalizable.PlatformIOException
 // Model for <prompt> node
 class QueryPrompt : Externalizable {
 
-    private var _key: String? = null
-    private var appearance: String? = null
-    private var input: String? = null
-    private var receive: String? = null
-    private var hidden: String? = null
-    private var display: DisplayUnit? = null
-    private var defaultValueExpr: XPathExpression? = null
-    private var itemsetBinding: ItemsetBinding? = null
-    private var exclude: XPathExpression? = null
-    private var required: QueryPromptCondition? = null
-    private var allowBlankValue: Boolean = false
-    private var validation: QueryPromptCondition? = null
-    private var groupKey: String? = null
+    var key: String? = null
+        private set
+    var appearance: String? = null
+        private set
+    var input: String? = null
+        private set
+    var receive: String? = null
+        private set
+    var hidden: String? = null
+        private set
+    var display: DisplayUnit? = null
+        private set
+    var defaultValueExpr: XPathExpression? = null
+        private set
+    var itemsetBinding: ItemsetBinding? = null
+        private set
+    var exclude: XPathExpression? = null
+        private set
+    var required: QueryPromptCondition? = null
+        private set
+    var isAllowBlankValue: Boolean = false
+        private set
+    var validation: QueryPromptCondition? = null
+        private set
+    var groupKey: String? = null
+        private set
 
     constructor()
 
@@ -39,7 +52,7 @@ class QueryPrompt : Externalizable {
         defaultValueExpr: XPathExpression?, allowBlankValue: Boolean, exclude: XPathExpression?,
         required: QueryPromptCondition?, validation: QueryPromptCondition?, groupKey: String?
     ) {
-        this._key = key
+        this.key = key
         this.appearance = appearance
         this.input = input
         this.receive = receive
@@ -47,7 +60,7 @@ class QueryPrompt : Externalizable {
         this.display = display
         this.itemsetBinding = itemsetBinding
         this.defaultValueExpr = defaultValueExpr
-        this.allowBlankValue = allowBlankValue
+        this.isAllowBlankValue = allowBlankValue
         this.exclude = exclude
         this.required = required
         this.validation = validation
@@ -56,7 +69,7 @@ class QueryPrompt : Externalizable {
 
     @Throws(PlatformIOException::class, DeserializationException::class)
     override fun readExternal(`in`: PlatformDataInputStream, pf: PrototypeFactory) {
-        _key = SerializationHelpers.readString(`in`)
+        key = SerializationHelpers.readString(`in`)
         appearance = SerializationHelpers.readNullableString(`in`, pf)
         input = SerializationHelpers.readNullableString(`in`, pf)
         receive = SerializationHelpers.readNullableString(`in`, pf)
@@ -64,7 +77,7 @@ class QueryPrompt : Externalizable {
         display = SerializationHelpers.readExternalizable(`in`, pf) { DisplayUnit() }
         itemsetBinding = SerializationHelpers.readNullableExternalizable(`in`, pf) { ItemsetBinding() }
         defaultValueExpr = SerializationHelpers.readNullableTagged(`in`, pf) as XPathExpression?
-        allowBlankValue = SerializationHelpers.readBool(`in`)
+        isAllowBlankValue = SerializationHelpers.readBool(`in`)
         exclude = SerializationHelpers.readNullableTagged(`in`, pf) as XPathExpression?
         validation = SerializationHelpers.readNullableExternalizable(`in`, pf) { QueryPromptCondition() }
         required = SerializationHelpers.readNullableExternalizable(`in`, pf) { QueryPromptCondition() }
@@ -73,7 +86,7 @@ class QueryPrompt : Externalizable {
 
     @Throws(PlatformIOException::class)
     override fun writeExternal(out: PlatformDataOutputStream) {
-        SerializationHelpers.write(out, _key!!)
+        SerializationHelpers.write(out, key!!)
         SerializationHelpers.writeNullable(out, appearance)
         SerializationHelpers.writeNullable(out, input)
         SerializationHelpers.writeNullable(out, receive)
@@ -81,56 +94,30 @@ class QueryPrompt : Externalizable {
         SerializationHelpers.write(out, display!!)
         SerializationHelpers.writeNullable(out, itemsetBinding)
         SerializationHelpers.writeNullableTagged(out, defaultValueExpr)
-        SerializationHelpers.writeBool(out, allowBlankValue)
+        SerializationHelpers.writeBool(out, isAllowBlankValue)
         SerializationHelpers.writeNullableTagged(out, exclude)
         SerializationHelpers.writeNullable(out, validation)
         SerializationHelpers.writeNullable(out, required)
         SerializationHelpers.writeNullable(out, groupKey)
     }
 
-    fun getKey(): String? = _key
-
-    fun getAppearance(): String? = appearance
-
-    fun getInput(): String? = input
-
-    fun getReceive(): String? = receive
-
-    fun getHidden(): String? = hidden
-
-    fun isAllowBlankValue(): Boolean = allowBlankValue
-
-    fun getDisplay(): DisplayUnit? = display
-
-    fun getItemsetBinding(): ItemsetBinding? = itemsetBinding
-
-    fun getDefaultValueExpr(): XPathExpression? = defaultValueExpr
-
-    fun getExclude(): XPathExpression? = exclude
-
-    fun getRequired(): QueryPromptCondition? = required
-
-    fun getValidation(): QueryPromptCondition? = validation
-
-    fun getGroupKey(): String? = groupKey
-
     /**
      * @return whether the prompt has associated choices to select from
      */
-    fun isSelect(): Boolean = getItemsetBinding() != null
+    fun isSelect(): Boolean = itemsetBinding != null
 
     // Evaluates required in the given eval context
     fun isRequired(ec: EvaluationContext): Boolean {
-        if (required != null && required!!.getTest() != null) {
-            return required!!.getTest()!!.eval(ec) as Boolean
+        if (required != null && required!!.test != null) {
+            return required!!.test!!.eval(ec) as Boolean
         }
         return false
     }
 
     // Evaluates required message in the given eval context
     fun getRequiredMessage(ec: EvaluationContext): String? {
-        if (required != null && required!!.getMessage() != null) {
-            return required!!.getMessage()!!.evaluate(ec)
+        if (required != null && required!!.message != null) {
+            return required!!.message!!.evaluate(ec)
         }
 
         return try {
@@ -147,8 +134,8 @@ class QueryPrompt : Externalizable {
      * @return evaluated validation message or a default text if no validation message is defined
      */
     fun getValidationMessage(ec: EvaluationContext): String {
-        if (validation != null && validation!!.getMessage() != null) {
-            return validation!!.getMessage()!!.evaluate(ec)
+        if (validation != null && validation!!.message != null) {
+            return validation!!.message!!.evaluate(ec)
         }
 
         return try {
@@ -165,7 +152,7 @@ class QueryPrompt : Externalizable {
      * @return whether the input is invalid
      */
     fun isInvalidInput(ec: EvaluationContext): Boolean {
-        return validation != null && !(validation!!.getTest()!!.eval(ec) as Boolean)
+        return validation != null && !(validation!!.test!!.eval(ec) as Boolean)
     }
 
     companion object {

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/QueryPromptCondition.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/QueryPromptCondition.kt
@@ -14,8 +14,10 @@ import org.javarosa.core.util.externalizable.PlatformIOException
  * Model for `<validation>` node in [QueryPrompt]
  */
 class QueryPromptCondition : Externalizable {
-    private var test: XPathExpression? = null
-    private var message: Text? = null
+    var test: XPathExpression? = null
+        private set
+    var message: Text? = null
+        private set
 
     constructor()
 
@@ -35,8 +37,4 @@ class QueryPromptCondition : Externalizable {
         SerializationHelpers.writeTagged(out, test!!)
         SerializationHelpers.writeNullable(out, message)
     }
-
-    fun getTest(): XPathExpression? = test
-
-    fun getMessage(): Text? = message
 }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/StackOperation.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/StackOperation.kt
@@ -24,7 +24,8 @@ import kotlin.jvm.JvmStatic
  * @author ctsims
  */
 class StackOperation : Externalizable {
-    private var opType: Int = 0
+    var op: Int = 0
+        private set
     private var ifCondition: String? = null
     private var elements: ArrayList<StackFrameStep> = ArrayList()
 
@@ -35,7 +36,7 @@ class StackOperation : Externalizable {
 
     // Copy Constructor
     constructor(oldStackOp: StackOperation) {
-        this.opType = oldStackOp.opType
+        this.op = oldStackOp.op
         this.ifCondition = oldStackOp.ifCondition
         this.elements = ArrayList(oldStackOp.elements.size)
         for (element in oldStackOp.elements) {
@@ -45,15 +46,13 @@ class StackOperation : Externalizable {
 
     @Throws(XPathSyntaxException::class)
     private constructor(opType: Int, ifCondition: String?, elements: ArrayList<StackFrameStep>) {
-        this.opType = opType
+        this.op = opType
         this.ifCondition = ifCondition
         if (ifCondition != null) {
             XPathParseTool.parseXPath(ifCondition)
         }
         this.elements = elements
     }
-
-    fun getOp(): Int = opType
 
     fun isOperationTriggered(ec: EvaluationContext): Boolean {
         val cond = ifCondition
@@ -77,7 +76,7 @@ class StackOperation : Externalizable {
      * @throws IllegalStateException if this operation do not support stack frame steps
      */
     fun getStackFrameSteps(): ArrayList<StackFrameStep> {
-        if (opType == OPERATION_CLEAR) {
+        if (op == OPERATION_CLEAR) {
             throw IllegalStateException("Clear Operations do not define frame steps")
         }
         return elements
@@ -85,14 +84,14 @@ class StackOperation : Externalizable {
 
     @Throws(PlatformIOException::class, DeserializationException::class)
     override fun readExternal(`in`: PlatformDataInputStream, pf: PrototypeFactory) {
-        opType = SerializationHelpers.readInt(`in`)
+        op = SerializationHelpers.readInt(`in`)
         ifCondition = nullIfEmpty(SerializationHelpers.readString(`in`))
         elements = SerializationHelpers.readList(`in`, pf) { StackFrameStep() }
     }
 
     @Throws(PlatformIOException::class)
     override fun writeExternal(out: PlatformDataOutputStream) {
-        SerializationHelpers.writeNumeric(out, opType.toLong())
+        SerializationHelpers.writeNumeric(out, op.toLong())
         SerializationHelpers.writeString(out, emptyIfNull(ifCondition))
         SerializationHelpers.writeList(out, elements)
     }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Style.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/suite/model/Style.kt
@@ -4,42 +4,49 @@ package org.commcare.suite.model
  * Created by willpride on 4/13/16.
  */
 class Style {
-    private var displayFormats: DisplayFormat? = null
-    private var fontSize: Int = 0
-    private var widthHint: Int = 0
-    private var horizontalAlign: String? = null
-    private var verticalAlign: String? = null
-    private var showBorder: Boolean = false
-    private var showShading: Boolean = false
+    var displayFormat: DisplayFormat? = null
+        private set
+    var fontSize: Int = 0
+        private set
+    var widthHint: Int = 0
+        private set
+    var horizontalAlign: String? = null
+        private set
+    var verticalAlign: String? = null
+        private set
+    var showBorder: Boolean = false
+        private set
+    var showShading: Boolean = false
+        private set
 
     constructor()
 
     constructor(detail: DetailField) {
-        val fontSizeStr = detail.getFontSize()
+        val fontSizeStr = detail.fontSize
         if (fontSizeStr != null) {
             try {
-                setFontSize(fontSizeStr.toInt())
+                fontSize = fontSizeStr.toInt()
             } catch (nfe: NumberFormatException) {
-                setFontSize(12)
+                fontSize = 12
             }
         }
         // For width, default to -1 since '0' is reserved for hidden (Search) fields
-        val widthHintStr = detail.getTemplateWidthHint()
+        val widthHintStr = detail.templateWidthHint
         if (widthHintStr != null) {
             try {
-                setWidthHint(widthHintStr.toInt())
+                widthHint = widthHintStr.toInt()
             } catch (nfe: NumberFormatException) {
-                setWidthHint(-1)
+                widthHint = -1
             }
         } else {
-            setWidthHint(-1)
+            widthHint = -1
         }
-        setDisplayFormatFromString(detail.getTemplateForm())
+        setDisplayFormatFromString(detail.templateForm)
 
-        verticalAlign = detail.getVerticalAlign()
-        horizontalAlign = detail.getHorizontalAlign()
-        showBorder = detail.getShowBorder()
-        showShading = detail.getShowShading()
+        verticalAlign = detail.verticalAlign
+        horizontalAlign = detail.horizontalAlign
+        showBorder = detail.showBorder
+        showShading = detail.showShading
     }
 
     enum class DisplayFormat {
@@ -54,47 +61,21 @@ class Style {
         ClickableIcon,
     }
 
-    fun getDisplayFormat(): DisplayFormat? = displayFormats
-
-    private fun setDisplayFormat(displayFormats: DisplayFormat) {
-        this.displayFormats = displayFormats
-    }
-
-    fun getFontSize(): Int = fontSize
-
-    private fun setFontSize(fontSize: Int) {
-        this.fontSize = fontSize
-    }
-
-    fun getWidthHint(): Int = widthHint
-
-    private fun setWidthHint(widthHint: Int) {
-        this.widthHint = widthHint
-    }
-
     private fun setDisplayFormatFromString(displayFormat: String?) {
         when (displayFormat) {
-            "image", "enum-image" -> setDisplayFormat(DisplayFormat.Image)
-            "audio" -> setDisplayFormat(DisplayFormat.Audio)
-            "text" -> setDisplayFormat(DisplayFormat.Text)
-            "address" -> setDisplayFormat(DisplayFormat.Address)
-            "address-popup" -> setDisplayFormat(DisplayFormat.AddressPopup)
-            "graph" -> setDisplayFormat(DisplayFormat.Graph)
-            "phone" -> setDisplayFormat(DisplayFormat.Phone)
-            "markdown" -> setDisplayFormat(DisplayFormat.Markdown)
-            "clickable-icon" -> setDisplayFormat(DisplayFormat.ClickableIcon)
+            "image", "enum-image" -> this.displayFormat = DisplayFormat.Image
+            "audio" -> this.displayFormat = DisplayFormat.Audio
+            "text" -> this.displayFormat = DisplayFormat.Text
+            "address" -> this.displayFormat = DisplayFormat.Address
+            "address-popup" -> this.displayFormat = DisplayFormat.AddressPopup
+            "graph" -> this.displayFormat = DisplayFormat.Graph
+            "phone" -> this.displayFormat = DisplayFormat.Phone
+            "markdown" -> this.displayFormat = DisplayFormat.Markdown
+            "clickable-icon" -> this.displayFormat = DisplayFormat.ClickableIcon
         }
     }
 
     override fun toString(): String {
-        return "Style: [displayFormat=$displayFormats, fontSize=$fontSize]"
+        return "Style: [displayFormat=$displayFormat, fontSize=$fontSize]"
     }
-
-    fun getHorizontalAlign(): String? = horizontalAlign
-
-    fun getVerticalAlign(): String? = verticalAlign
-
-    fun getShowBorder(): Boolean = showBorder
-
-    fun getShowShading(): Boolean = showShading
 }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/util/FormDataUtil.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/util/FormDataUtil.kt
@@ -75,7 +75,7 @@ object FormDataUtil {
             return null
         }
 
-        val detailText = sessionCopy.getDetail(entityDatum.getLongDetail())?.getTitle()?.getText()
+        val detailText = sessionCopy.getDetail(entityDatum.getLongDetail())?.title?.text
         var isPrettyPrint = true
 
         // CTS: this is... not awesome.

--- a/commcare-core/src/commonMain/kotlin/org/commcare/util/GridCoordinate.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/util/GridCoordinate.kt
@@ -8,20 +8,12 @@ package org.commcare.util
  * @author wspride
  */
 class GridCoordinate(
-    private val gridX: Int,
-    private val gridY: Int,
-    private val gridWidth: Int,
-    private val gridHeight: Int
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int
 ) {
-    fun getX(): Int = gridX
-
-    fun getY(): Int = gridY
-
-    fun getWidth(): Int = gridWidth
-
-    fun getHeight(): Int = gridHeight
-
     override fun toString(): String {
-        return "x: $gridX, y: $gridY, gridWidth: $gridWidth, gridHeight: $gridHeight"
+        return "x: $x, y: $y, gridWidth: $width, gridHeight: $height"
     }
 }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/util/GridStyle.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/util/GridStyle.kt
@@ -7,20 +7,20 @@ package org.commcare.util
  * @author wspride
  */
 class GridStyle(
-    private val fontSize: String?,
-    private val horzAlign: String?,
-    private val vertAlign: String?,
-    private val cssID: String?
+    private val _fontSize: String?,
+    private val _horzAlign: String?,
+    private val _vertAlign: String?,
+    private val _cssID: String?
 ) {
-    fun getFontSize(): String = fontSize ?: "normal"
+    val fontSize: String get() = _fontSize ?: "normal"
 
-    fun getHorzAlign(): String = horzAlign ?: "none"
+    val horzAlign: String get() = _horzAlign ?: "none"
 
-    fun getVertAlign(): String = vertAlign ?: "none"
+    val vertAlign: String get() = _vertAlign ?: "none"
 
-    fun getCssID(): String = cssID ?: "none"
+    val cssID: String get() = _cssID ?: "none"
 
     override fun toString(): String {
-        return "font size: $fontSize, horzAlign: $horzAlign, vertAlign: $vertAlign"
+        return "font size: $_fontSize, horzAlign: $_horzAlign, vertAlign: $_vertAlign"
     }
 }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/xml/EntryParser.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/xml/EntryParser.kt
@@ -135,7 +135,7 @@ class EntryParser private constructor(
         } else if ("display" == tagName) {
             display = parseDisplayBlock()
             //check that we have text to display;
-            if (display.getText() == null) {
+            if (display.text == null) {
                 throw InvalidStructureException("Expected CommandText in Display block", parser)
             }
         }

--- a/commcare-core/src/commonMain/kotlin/org/commcare/xml/MenuParser.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/xml/MenuParser.kt
@@ -50,7 +50,7 @@ class MenuParser(parser: PlatformXmlParser) : CommCareElementParser<Menu>(parser
         } else if (parser.getName() == "display") {
             display = parseDisplayBlock()
             //check that we have a commandText;
-            if (display.getText() == null)
+            if (display.text == null)
                 throw InvalidStructureException("Expected Menu Text in Display block", parser)
         } else {
             throw InvalidStructureException("Expected either <text> or <display> in menu", parser)

--- a/commcare-core/src/test/java/org/commcare/backend/session/test/MarkRewindSessionTests.kt
+++ b/commcare-core/src/test/java/org/commcare/backend/session/test/MarkRewindSessionTests.kt
@@ -28,7 +28,7 @@ class MarkRewindSessionTests {
         val shortDetail = session.getPlatform()!!.getDetail("case-list")!!
         val action = shortDetail.getCustomActions(session.getEvaluationContext())[0]
         // queue up action
-        var didRewindOrNewFrame = session.executeStackOperations(action.getStackOperations()!!, session.getEvaluationContext())
+        var didRewindOrNewFrame = session.executeStackOperations(action.stackOperations!!, session.getEvaluationContext())
         assertFalse(didRewindOrNewFrame)
 
         // test backing out of action
@@ -40,7 +40,7 @@ class MarkRewindSessionTests {
         )
 
         // queue up action again
-        session.executeStackOperations(action.getStackOperations()!!, session.getEvaluationContext())
+        session.executeStackOperations(action.stackOperations!!, session.getEvaluationContext())
 
         // finish action
         didRewindOrNewFrame = session.finishExecuteAndPop(session.getEvaluationContext())

--- a/commcare-core/src/test/java/org/commcare/backend/session/test/SessionStackTests.kt
+++ b/commcare-core/src/test/java/org/commcare/backend/session/test/SessionStackTests.kt
@@ -53,7 +53,7 @@ class SessionStackTests {
         }
         val dblManagement = actions[0]
 
-        session.executeStackOperations(dblManagement.getStackOperations()!!, session.getEvaluationContext())
+        session.executeStackOperations(dblManagement.stackOperations!!, session.getEvaluationContext())
 
         if (session.getNeededData() != null) {
             fail("After executing stack frame steps, session should be redirected")
@@ -340,11 +340,11 @@ class SessionStackTests {
 
         val actionToInspect = actions[1]
         assertTrue(actionToInspect.hasActionBarIcon())
-        assertEquals("Jump to Menu 2 Form 1, with icon", actionToInspect.getDisplay()!!!!.getText()!!.evaluate(ec))
-        assertEquals(1, actionToInspect.getStackOperations()!!.size)
-        assertTrue(actionToInspect.getAutoLaunchExpr() == null)
+        assertEquals("Jump to Menu 2 Form 1, with icon", actionToInspect.display!!.text!!.evaluate(ec))
+        assertEquals(1, actionToInspect.stackOperations!!.size)
+        assertTrue(actionToInspect.autoLaunchExpr == null)
 
-        assertTrue(FunctionUtils.toString(actions[0].getAutoLaunchExpr()!!.eval(ec)).contentEquals("true"))
+        assertTrue(FunctionUtils.toString(actions[0].autoLaunchExpr!!.eval(ec)).contentEquals("true"))
     }
 
     /**

--- a/commcare-core/src/test/java/org/commcare/backend/session/test/StackObserverTest.kt
+++ b/commcare-core/src/test/java/org/commcare/backend/session/test/StackObserverTest.kt
@@ -20,7 +20,7 @@ class StackObserverTest {
         val action = shortDetail.getCustomActions(session.getEvaluationContext())[0]
 
         val observer = StackObserver()
-        session.executeStackOperations(action.getStackOperations()!!, session.getEvaluationContext(), observer)
+        session.executeStackOperations(action.stackOperations!!, session.getEvaluationContext(), observer)
 
         assertEvents(
             observer,

--- a/commcare-core/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.kt
+++ b/commcare-core/src/test/java/org/commcare/backend/suite/model/test/AppStructureTests.kt
@@ -57,7 +57,7 @@ class AppStructureTests {
     @Test
     fun testDetailStructure() {
         // A suite detail can have a lookup block for performing an app callout
-        val callout = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!.getCallout()!!
+        val callout = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!.callout!!
 
         // specifies the callout's intent type
         assertEquals(callout.evaluate(mApp.getSession().getEvaluationContext()).type, "text/plain")
@@ -65,7 +65,7 @@ class AppStructureTests {
         // If the detail block represents an entity list, then the 'lookup' can
         // have a detail field describing the UI for displaying callout result
         // data in the case list.
-        val lookupCalloutDetailField = callout.getResponseDetailField()
+        val lookupCalloutDetailField = callout.responseDetailField
 
         // The header is the data's title
         assertTrue(lookupCalloutDetailField!!.getHeader() != null)
@@ -79,45 +79,45 @@ class AppStructureTests {
 
     @Test
     fun testDetailWithFocusFunction() {
-        val focusFunction = mApp.getSession().getPlatform()!!.getDetail("m1_case_short")!!.getFocusFunction()
+        val focusFunction = mApp.getSession().getPlatform()!!.getDetail("m1_case_short")!!.focusFunction
         assertTrue(focusFunction != null)
     }
 
     @Test
     fun testDetailWithoutFocusFunction() {
-        val focusFunction = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!.getFocusFunction()
+        val focusFunction = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!.focusFunction
         assertTrue(focusFunction == null)
     }
 
     @Test
     fun testDetailGlobalStructure() {
-        val global = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!.getGlobal()!!
+        val global = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!.global!!
         assertEquals(2, global.getGeoOverlays().size)
 
         val geoOverlay1 = global.getGeoOverlays()[0]
-        assertEquals("region1", geoOverlay1.getLabel()!!!!.evaluate().name)
+        assertEquals("region1", geoOverlay1.label!!.evaluate().name)
         assertEquals(
             "25.099143024399652,76.51193084262178 \\n25.09659806293257,76.50851525117463 \\n25.094815052360374,76.51072357910209 \\n25.097369086424337,76.51234989287263",
-            geoOverlay1.getCoordinates()!!!!.evaluate().name
+            geoOverlay1.coordinates!!.evaluate().name
         )
 
         val geoOverlay2 = global.getGeoOverlays()[1]
-        assertEquals("region2", geoOverlay2.getLabel()!!!!.evaluate().name)
+        assertEquals("region2", geoOverlay2.label!!.evaluate().name)
         assertEquals(
             "76.51193084262178,25.099143024399652 \\n76.50851525117463,25.09659806293257 \\n76.51072357910209,25.094815052360374 \\n76.51234989287263,25.097369086424337",
-            geoOverlay2.getCoordinates()!!!!.evaluate().name
+            geoOverlay2.coordinates!!.evaluate().name
         )
     }
 
     @Test
     fun testDetailNoItemsText() {
-        val noItemsText = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!.getNoItemsText()!!
+        val noItemsText = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!.noItemsText!!
         assertEquals("Empty List", noItemsText.evaluate())
     }
 
     @Test
     fun testDetailSelectText() {
-        val selectText = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!.getSelectText()!!
+        val selectText = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!.selectText!!
         assertEquals("Continue With Case", selectText.evaluate())
     }
 
@@ -218,11 +218,11 @@ class AppStructureTests {
     @Test
     fun testDetailWithFieldAction() {
         val detail = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!
-        val field = detail.getFields()[0]
-        val endpointAction = field.getEndpointAction()!!
-        val endpointActionId = endpointAction.getEndpointId()!!
+        val field = detail.fields[0]
+        val endpointAction = field.endpointAction!!
+        val endpointActionId = endpointAction.endpointId!!
         assertEquals("case_list", endpointActionId)
-        assertEquals(true, endpointAction.isBackground())
+        assertEquals(true, endpointAction.isBackground)
 
         val endpoint = mApp.getSession().getPlatform()!!.getEndpoint(endpointActionId)!!
         assertEquals(endpoint.getId(), endpointActionId)
@@ -232,7 +232,7 @@ class AppStructureTests {
     @Test
     fun testDetailWithAltText() {
         val detail = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!
-        val field = detail.getFields()[0]
+        val field = detail.fields[0]
         val altText = field.getAltText()!!
         assertEquals("gold star", altText.evaluate())
     }
@@ -240,15 +240,15 @@ class AppStructureTests {
     @Test
     fun testDetailWithBorder() {
         val detail = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!
-        val field1 = detail.getFields()[0]
-        assertTrue(field1.getShowBorder())
+        val field1 = detail.fields[0]
+        assertTrue(field1.showBorder)
     }
 
     @Test
     fun testDetailWithShading() {
         val detail = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!
-        val field1 = detail.getFields()[0]
-        assertTrue(field1.getShowShading())
+        val field1 = detail.fields[0]
+        assertTrue(field1.showShading)
     }
 
     @Test
@@ -256,10 +256,10 @@ class AppStructureTests {
         val detail = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!
         assertTrue(detail.isLazyLoading)
         assertTrue(detail.isCacheEnabled)
-        assertTrue(detail.getFields()[0].isCacheEnabled)
-        assertFalse(detail.getFields()[0].isLazyLoading)
-        assertTrue(detail.getFields()[1].isLazyLoading)
-        assertFalse(detail.getFields()[1].isCacheEnabled)
+        assertTrue(detail.fields[0].isCacheEnabled)
+        assertFalse(detail.fields[0].isLazyLoading)
+        assertTrue(detail.fields[1].isLazyLoading)
+        assertFalse(detail.fields[1].isCacheEnabled)
 
         val detailNoCaching = mApp.getSession().getPlatform()!!.getDetail("m1_case_short")!!
         assertFalse(detailNoCaching.isCacheEnabled)

--- a/commcare-core/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.kt
+++ b/commcare-core/src/test/java/org/commcare/backend/suite/model/test/CaseClaimModelTests.kt
@@ -81,7 +81,7 @@ class CaseClaimModelTests {
         val districtPrompt = inputDisplays["district"]!!
 
         remoteQuerySessionManager.populateItemSetChoices(districtPrompt)
-        val choices = districtPrompt.getItemsetBinding()!!.getChoices()!!
+        val choices = districtPrompt.itemsetBinding!!.getChoices()!!
             .map { it.value }
         assertEquals(expected, choices)
         return remoteQuerySessionManager

--- a/commcare-core/src/test/java/org/commcare/backend/suite/model/test/EmptyAppElementsTests.kt
+++ b/commcare-core/src/test/java/org/commcare/backend/suite/model/test/EmptyAppElementsTests.kt
@@ -32,7 +32,7 @@ class EmptyAppElementsTests {
 
     @Test
     fun testEmptyGlobal() {
-        val global = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!.getGlobal()!!
+        val global = mApp.getSession().getPlatform()!!.getDetail("m0_case_short")!!.global!!
         Assert.assertEquals(0, global.getGeoOverlays().size)
     }
 

--- a/commcare-core/src/test/java/org/commcare/backend/suite/model/test/StackFrameStepTests.kt
+++ b/commcare-core/src/test/java/org/commcare/backend/suite/model/test/StackFrameStepTests.kt
@@ -140,7 +140,7 @@ class StackFrameStepTests {
         // We're using the second action for this screen which requires us to still need another datum
         val dblManagement = actions[1]
         assertEquals(1, session.getFrame().getSteps().size)
-        session.executeStackOperations(dblManagement.getStackOperations()!!, session.getEvaluationContext())
+        session.executeStackOperations(dblManagement.stackOperations!!, session.getEvaluationContext())
         assertEquals(5, session.getFrame().getSteps().size)
         session.stepBack()
         assertEquals(1, session.getFrame().getSteps().size)

--- a/commcare-core/src/test/java/org/commcare/backend/test/EntitySubnodeDetailTest.kt
+++ b/commcare-core/src/test/java/org/commcare/backend/test/EntitySubnodeDetailTest.kt
@@ -33,10 +33,10 @@ class EntitySubnodeDetailTest {
         assertEquals(entityDatum.getLongDetail(), "reports.my_report.data")
 
         val confirmDetail = session.getDetail(entityDatum.getLongDetail())!!
-        assertNotNull(confirmDetail.getNodeset())
+        assertNotNull(confirmDetail.nodeset)
 
         val detailReference = entityDatum.getNodeset()!!
-        val contextualizedRef = confirmDetail.getNodeset()!!.contextualize(detailReference)!!
+        val contextualizedRef = confirmDetail.nodeset!!.contextualize(detailReference)!!
         val references = session.getEvaluationContext().expandReference(contextualizedRef)!!
         assertEquals(4, references.size)
     }

--- a/commcare-core/src/test/java/org/commcare/xml/EntryParserTest.kt
+++ b/commcare-core/src/test/java/org/commcare/xml/EntryParserTest.kt
@@ -95,7 +95,7 @@ class EntryParserTest {
         val parser = ParserTestUtils.buildParser(xml, EntryParser::buildEntryParser)
         val entry = parser.parse() as FormEntry
         assertEquals(entry.getXFormNamespace(), "http://openrosa.org/formdesigner/2f9")
-        assertEquals(entry.getPostRequest()!!.getUrl().toString(), "https://www.fake.com/claim_patient/")
+        assertEquals(entry.getPostRequest()!!.url.toString(), "https://www.fake.com/claim_patient/")
     }
 
     @Throws(UnfullfilledRequirementsException::class, InvalidStructureException::class,

--- a/commcare-core/src/test/java/org/commcare/xml/QueryDataParserTest.kt
+++ b/commcare-core/src/test/java/org/commcare/xml/QueryDataParserTest.kt
@@ -52,8 +52,8 @@ class QueryDataParserTest {
         val queryData = parser.parse()
 
         val evalContext = EvaluationContext(null, TestInstances.getInstances())
-        assertTrue(queryData.getRequired()!!.getTest()!!.eval(evalContext) as Boolean)
-        assertNull(queryData.getRequired()!!.getMessage())
+        assertTrue(queryData.required!!.test!!.eval(evalContext) as Boolean)
+        assertNull(queryData.required!!.message)
     }
 
     @Test
@@ -67,7 +67,7 @@ class QueryDataParserTest {
         val parser = ParserTestUtils.buildParser(query, QueryPromptParser::class.java)
         val queryData = parser.parse()
         val evalContext = EvaluationContext(null, TestInstances.getInstances())
-        assertTrue(queryData.getRequired()!!.getTest()!!.eval(evalContext) as Boolean)
+        assertTrue(queryData.required!!.test!!.eval(evalContext) as Boolean)
         assertTrue(queryData.getRequiredMessage(evalContext).contentEquals("This field can't be empty"))
     }
 
@@ -146,7 +146,7 @@ class QueryDataParserTest {
         val query = "<prompt key=\"name\" group_key=\"group_header_1\"></prompt>"
         val parser = ParserTestUtils.buildParser(query, QueryPromptParser::class.java)
         val queryData = parser.parse()
-        assertEquals("group_header_1", queryData.getGroupKey())
+        assertEquals("group_header_1", queryData.groupKey)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Convert ~76 getter/setter methods to idiomatic Kotlin properties across 18 suite model classes
- Update 18 call site files (both source and test) to use property access syntax
- Net reduction of 100 lines of boilerplate code
- Skipped high-risk classes per plan (TreeElement, Case, FormDef, EvaluationContext, etc.)

## Classes converted
DetailField (16), Detail (15), QueryPrompt (13), Style (7), Callout (7), Action (5), DisplayUnit (5), GridCoordinate (4), GridStyle (4), EndpointArgument (3), PropertySetter (3), Credential (2), EndpointAction (2), GeoOverlay (2), QueryPromptCondition (2), PostRequest (1), StackOperation (1)

## Test plan
- [x] `compileCommonMainKotlinMetadata` passes
- [x] `compileKotlinJvm` + `compileJava` passes
- [x] 896 JVM tests passing, 0 failures
- [x] Java callers (4 remaining .java files) automatically use generated getters/setters

🤖 Generated with [Claude Code](https://claude.com/claude-code)