### PR TITLE
feat: Wave 2 — repeat groups, field-list, skip logic, constraints

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/ui/FormEntryScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/FormEntryScreen.kt
@@ -88,6 +88,28 @@ fun FormEntryScreen(
                     Text("Submit")
                 }
             }
+        } else if (viewModel.isRepeatPrompt) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(24.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = viewModel.repeatPromptText,
+                    style = MaterialTheme.typography.headlineSmall
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    OutlinedButton(onClick = { viewModel.skipRepeat() }) {
+                        Text("No")
+                    }
+                    Button(onClick = { viewModel.addRepeat() }) {
+                        Text("Yes, add another")
+                    }
+                }
+            }
         } else {
             val questionList = viewModel.questions
             if (questionList.isNotEmpty()) {
@@ -100,16 +122,6 @@ fun FormEntryScreen(
                         for ((index, question) in questionList.withIndex()) {
                             QuestionWidget(question, index, viewModel)
                             Spacer(modifier = Modifier.height(16.dp))
-                        }
-
-                        // Validation message
-                        if (viewModel.validationMessage != null) {
-                            Text(
-                                text = viewModel.validationMessage!!,
-                                color = MaterialTheme.colorScheme.error,
-                                style = MaterialTheme.typography.bodySmall
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
                         }
                     }
 
@@ -270,5 +282,15 @@ private fun QuestionWidget(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
+    }
+
+    // Per-question constraint message
+    if (question.constraintMessage != null) {
+        Text(
+            text = question.constraintMessage,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(top = 4.dp)
+        )
     }
 }

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/FormEntryViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/FormEntryViewModel.kt
@@ -28,9 +28,13 @@ class FormEntryViewModel(
         private set
     var errorMessage by mutableStateOf<String?>(null)
         private set
-    var validationMessage by mutableStateOf<String?>(null)
-        private set
     var isSubmitting by mutableStateOf(false)
+        private set
+
+    /** True when we're at a repeat prompt asking "Add another?" */
+    var isRepeatPrompt by mutableStateOf(false)
+        private set
+    var repeatPromptText by mutableStateOf("")
         private set
 
     private var questionIndex = 0
@@ -53,18 +57,22 @@ class FormEntryViewModel(
             val result = formSession.answerAtIndex(index, answer)
             when (result) {
                 FormEntryController.ANSWER_OK -> {
-                    validationMessage = null
+                    // Clear constraint message for this question
+                    clearConstraint(index)
+                    // Refresh questions — relevancy may have changed (skip logic)
+                    updateQuestions()
                 }
                 FormEntryController.ANSWER_CONSTRAINT_VIOLATED -> {
                     val prompts = formSession.getPrompts()
-                    validationMessage = if (index < prompts.size) {
+                    val msg = if (index < prompts.size) {
                         prompts[index].getConstraintText() ?: "Constraint violated"
                     } else {
                         "Constraint violated"
                     }
+                    setConstraint(index, msg)
                 }
                 FormEntryController.ANSWER_REQUIRED_BUT_EMPTY -> {
-                    validationMessage = "This field is required"
+                    setConstraint(index, "This field is required")
                 }
             }
         } catch (e: Exception) {
@@ -104,8 +112,29 @@ class FormEntryViewModel(
         answerQuestion(index, data)
     }
 
-    fun nextQuestion() {
+    /**
+     * Add a new repeat instance and continue to the first question in it.
+     */
+    fun addRepeat() {
         try {
+            formSession.controller.newRepeat()
+            isRepeatPrompt = false
+            formSession.stepNext() // step into the new repeat
+            advanceToQuestion()
+            questionIndex++
+            progress = (questionIndex.toFloat() / totalQuestions).coerceIn(0f, 1f)
+            updateQuestions()
+        } catch (e: Exception) {
+            errorMessage = "Error adding repeat: ${e.message}"
+        }
+    }
+
+    /**
+     * Skip adding a new repeat and continue past the repeat group.
+     */
+    fun skipRepeat() {
+        try {
+            isRepeatPrompt = false
             val event = formSession.stepNext()
             if (event == FormEntryController.EVENT_END_OF_FORM) {
                 isComplete = true
@@ -120,9 +149,44 @@ class FormEntryViewModel(
         }
     }
 
+    fun nextQuestion() {
+        try {
+            // Validate all visible required questions before stepping
+            val prompts = formSession.getPrompts()
+            for ((i, prompt) in prompts.withIndex()) {
+                if (prompt.isRequired() && prompt.getAnswerValue() == null) {
+                    setConstraint(i, "This field is required")
+                    return
+                }
+            }
+
+            val event = formSession.stepNext()
+            if (event == FormEntryController.EVENT_END_OF_FORM) {
+                isComplete = true
+            } else {
+                advanceToQuestion()
+                if (!isRepeatPrompt) {
+                    questionIndex++
+                    progress = (questionIndex.toFloat() / totalQuestions).coerceIn(0f, 1f)
+                    updateQuestions()
+                }
+            }
+        } catch (e: Exception) {
+            errorMessage = "Navigation error: ${e.message}"
+        }
+    }
+
     fun previousQuestion() {
         try {
+            isRepeatPrompt = false
             formSession.stepPrev()
+            // Skip back past non-question events
+            var event = formSession.currentEvent()
+            while (event != FormEntryController.EVENT_QUESTION &&
+                event != FormEntryController.EVENT_BEGINNING_OF_FORM
+            ) {
+                event = formSession.stepPrev()
+            }
             if (questionIndex > 0) questionIndex--
             progress = (questionIndex.toFloat() / totalQuestions).coerceIn(0f, 1f)
             updateQuestions()
@@ -157,15 +221,36 @@ class FormEntryViewModel(
             event != FormEntryController.EVENT_END_OF_FORM &&
             event != FormEntryController.EVENT_PROMPT_NEW_REPEAT
         ) {
+            // Stop at field-list groups — they display all questions at once
+            if (event == FormEntryController.EVENT_GROUP && isFieldList()) {
+                break
+            }
             event = formSession.stepNext()
         }
-        if (event == FormEntryController.EVENT_END_OF_FORM) {
-            isComplete = true
+        when (event) {
+            FormEntryController.EVENT_END_OF_FORM -> {
+                isComplete = true
+            }
+            FormEntryController.EVENT_PROMPT_NEW_REPEAT -> {
+                isRepeatPrompt = true
+                repeatPromptText = formSession.model.getCaptionPrompt()?.getLongText()
+                    ?: "Add another group?"
+            }
+        }
+    }
+
+    private fun isFieldList(): Boolean {
+        return try {
+            formSession.controller.isHostWithAppearance(
+                formSession.model.getFormIndex(),
+                FormEntryController.FIELD_LIST
+            )
+        } catch (_: Exception) {
+            false
         }
     }
 
     private fun updateQuestions() {
-        validationMessage = null
         questions = try {
             formSession.getPrompts().map { prompt ->
                 QuestionState(
@@ -175,7 +260,6 @@ class FormEntryViewModel(
                     dataType = prompt.getDataType(),
                     answer = prompt.getAnswerValue()?.getDisplayText() ?: "",
                     isRequired = prompt.isRequired(),
-                    isRelevant = true,
                     constraintMessage = null,
                     choices = prompt.getSelectChoices()?.map {
                         it.labelInnerText ?: it.value ?: ""
@@ -185,6 +269,22 @@ class FormEntryViewModel(
             }
         } catch (_: Exception) {
             emptyList()
+        }
+    }
+
+    private fun setConstraint(index: Int, message: String) {
+        if (index < questions.size) {
+            questions = questions.toMutableList().also {
+                it[index] = it[index].copy(constraintMessage = message)
+            }
+        }
+    }
+
+    private fun clearConstraint(index: Int) {
+        if (index < questions.size && questions[index].constraintMessage != null) {
+            questions = questions.toMutableList().also {
+                it[index] = it[index].copy(constraintMessage = null)
+            }
         }
     }
 
@@ -215,7 +315,6 @@ data class QuestionState(
     val dataType: Int = 0,
     val answer: String = "",
     val isRequired: Boolean = false,
-    val isRelevant: Boolean = true,
     val constraintMessage: String? = null,
     val choices: List<String> = emptyList(),
     val appearance: String? = null,

--- a/app/src/jvmTest/kotlin/org/commcare/app/oracle/FormStructureOracleTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/oracle/FormStructureOracleTest.kt
@@ -1,0 +1,234 @@
+package org.commcare.app.oracle
+
+import org.commcare.app.engine.FormEntrySession
+import org.commcare.app.viewmodel.FormEntryViewModel
+import org.javarosa.core.model.data.IntegerData
+import org.javarosa.core.model.data.StringData
+import org.javarosa.form.api.FormEntryController
+import org.javarosa.form.api.FormEntryModel
+import org.javarosa.xform.util.XFormUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Oracle tests for Wave 2: repeat groups, field-list groups, skip logic, constraints.
+ */
+class FormStructureOracleTest {
+
+    private val runner = OracleTestRunner()
+
+    // --- Repeat group tests ---
+
+    @Test
+    fun testRepeatGroupNavigation() {
+        val formDef = loadForm("/test_repeat_and_relevancy.xml")!!
+        formDef.initialize(true, null)
+        val model = FormEntryModel(formDef, FormEntryModel.REPEAT_STRUCTURE_LINEAR)
+        val controller = FormEntryController(model)
+
+        // Step through: BEGINNING -> has_children -> child_count -> repeat prompt
+        controller.stepToNextEvent() // past BEGINNING
+        assertEquals(FormEntryController.EVENT_QUESTION, model.getEvent()) // has_children
+        controller.answerQuestion(StringData("yes"))
+
+        controller.stepToNextEvent()
+        assertEquals(FormEntryController.EVENT_QUESTION, model.getEvent()) // child_count
+        controller.answerQuestion(IntegerData(2))
+
+        // Navigate until we hit repeat prompt or question
+        var event = controller.stepToNextEvent()
+        while (event != FormEntryController.EVENT_PROMPT_NEW_REPEAT &&
+            event != FormEntryController.EVENT_QUESTION &&
+            event != FormEntryController.EVENT_END_OF_FORM
+        ) {
+            event = controller.stepToNextEvent()
+        }
+        assertEquals(FormEntryController.EVENT_PROMPT_NEW_REPEAT, event)
+
+        // Create a repeat instance
+        controller.newRepeat()
+        event = controller.stepToNextEvent()
+        // Should now be at first question in repeat (child/name)
+        assertEquals(FormEntryController.EVENT_QUESTION, event)
+    }
+
+    @Test
+    fun testRepeatSerializesWithChildren() {
+        val result = runner.fillAndSerialize("/test_repeat_and_relevancy.xml") { model, controller ->
+            // Answer has_children = yes
+            controller.answerQuestion(StringData("yes"))
+            controller.stepToNextEvent()
+
+            // Answer child_count = 1
+            controller.answerQuestion(IntegerData(1))
+
+            // Navigate to repeat prompt
+            var event = controller.stepToNextEvent()
+            while (event != FormEntryController.EVENT_PROMPT_NEW_REPEAT &&
+                event != FormEntryController.EVENT_END_OF_FORM
+            ) {
+                event = controller.stepToNextEvent()
+            }
+
+            // Add a repeat
+            controller.newRepeat()
+            controller.stepToNextEvent()
+            // name
+            controller.answerQuestion(StringData("Alice"))
+            controller.stepToNextEvent()
+            // age
+            controller.answerQuestion(IntegerData(5))
+
+            // Step to end
+            event = controller.stepToNextEvent()
+            while (event != FormEntryController.EVENT_END_OF_FORM) {
+                if (event == FormEntryController.EVENT_PROMPT_NEW_REPEAT) {
+                    // skip adding more
+                }
+                event = controller.stepToNextEvent()
+            }
+        }
+
+        assertTrue(result is FormResult.Success, "Serialize should succeed: $result")
+        val xml = (result as FormResult.Success).xml
+        assertTrue(xml.contains("Alice"), "XML should contain child name")
+        assertTrue(xml.contains("<age>5</age>") || xml.contains(">5<"), "XML should contain child age")
+    }
+
+    // --- Skip logic (relevancy) tests ---
+
+    @Test
+    fun testRelevancyHidesQuestion() {
+        val formDef = loadForm("/test_repeat_and_relevancy.xml")!!
+        formDef.initialize(true, null)
+        val model = FormEntryModel(formDef, FormEntryModel.REPEAT_STRUCTURE_LINEAR)
+        val controller = FormEntryController(model)
+
+        controller.stepToNextEvent() // has_children
+        // Answer "no" — child_count should be skipped
+        controller.answerQuestion(StringData("no"))
+
+        val event = controller.stepToNextEvent()
+        // Should skip child_count (not relevant) and go to repeat or notes
+        // The engine automatically skips non-relevant questions during stepToNextEvent
+        assertTrue(
+            event != FormEntryController.EVENT_QUESTION ||
+                model.getQuestionPrompt()?.getQuestion()?.getTextID() != "child_count",
+            "child_count should be skipped when has_children != 'yes'"
+        )
+    }
+
+    @Test
+    fun testViewModelSkipLogic() {
+        val formDef = loadForm("/test_repeat_and_relevancy.xml")!!
+        val session = FormEntrySession(formDef)
+        val vm = FormEntryViewModel(session)
+
+        vm.loadForm()
+        // First question should be has_children
+        assertTrue(vm.questions.isNotEmpty(), "Should have questions loaded")
+        assertEquals(1, vm.questions.size, "Should show one question at a time")
+    }
+
+    // --- Constraint tests ---
+
+    @Test
+    fun testConstraintViolation() {
+        val formDef = loadForm("/test_constraints.xml")!!
+        formDef.initialize(true, null)
+        val model = FormEntryModel(formDef)
+        val controller = FormEntryController(model)
+
+        controller.stepToNextEvent() // into field-list group
+        // In field-list, getQuestionPrompts() returns all prompts
+        val prompts = controller.getQuestionPrompts()
+        assertNotNull(prompts)
+        assertTrue(prompts.size >= 2, "Field-list should have multiple prompts, got ${prompts.size}")
+
+        // Try to set age to invalid value (200)
+        val result = controller.answerQuestion(prompts[0].getIndex()!!, IntegerData(200))
+        assertEquals(FormEntryController.ANSWER_CONSTRAINT_VIOLATED, result)
+
+        // Constraint text should be available
+        val constraintText = prompts[0].getConstraintText()
+        assertNotNull(constraintText, "Constraint message should be set")
+        assertTrue(constraintText.contains("0") && constraintText.contains("120"),
+            "Constraint message should mention valid range: $constraintText")
+    }
+
+    @Test
+    fun testConstraintAcceptsValidValue() {
+        val formDef = loadForm("/test_constraints.xml")!!
+        formDef.initialize(true, null)
+        val model = FormEntryModel(formDef)
+        val controller = FormEntryController(model)
+
+        controller.stepToNextEvent()
+        val prompts = controller.getQuestionPrompts()
+        assertNotNull(prompts)
+
+        // Valid age
+        val result = controller.answerQuestion(prompts[0].getIndex()!!, IntegerData(25))
+        assertEquals(FormEntryController.ANSWER_OK, result)
+    }
+
+    @Test
+    fun testFieldListGroupShowsMultipleQuestions() {
+        val formDef = loadForm("/test_constraints.xml")!!
+        formDef.initialize(true, null)
+        val model = FormEntryModel(formDef)
+        val controller = FormEntryController(model)
+
+        controller.stepToNextEvent()
+        val prompts = controller.getQuestionPrompts()
+        // Field-list should show all 3 questions (age, name, email) at once
+        assertEquals(3, prompts.size, "Field-list should show all 3 questions")
+    }
+
+    @Test
+    fun testViewModelConstraintMessage() {
+        val formDef = loadForm("/test_constraints.xml")!!
+        val session = FormEntrySession(formDef)
+        val vm = FormEntryViewModel(session)
+
+        vm.loadForm()
+        // Field-list: all 3 questions visible
+        assertEquals(3, vm.questions.size, "Should show 3 questions in field-list")
+
+        // Answer age with invalid value
+        vm.answerQuestion(0, IntegerData(200))
+        // Should have constraint message on first question
+        assertNotNull(vm.questions[0].constraintMessage,
+            "First question should have constraint message")
+
+        // Answer age with valid value
+        vm.answerQuestion(0, IntegerData(25))
+        // Constraint should be cleared
+        val q0 = vm.questions[0]
+        assertTrue(q0.constraintMessage == null,
+            "Constraint should be cleared after valid answer, got: ${q0.constraintMessage}")
+    }
+
+    @Test
+    fun testViewModelRequiredValidation() {
+        val formDef = loadForm("/test_constraints.xml")!!
+        val session = FormEntrySession(formDef)
+        val vm = FormEntryViewModel(session)
+
+        vm.loadForm()
+        assertEquals(3, vm.questions.size)
+
+        // Try to go next without filling required field (name)
+        vm.nextQuestion()
+        // Should not advance — name is required
+        assertFalse(vm.isComplete, "Should not complete with missing required field")
+    }
+
+    // --- Helpers ---
+
+    private fun loadForm(resource: String) =
+        XFormUtils.getFormFromInputStream(this::class.java.getResourceAsStream(resource)!!)
+}

--- a/app/src/jvmTest/kotlin/org/commcare/app/oracle/OracleTestRunner.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/oracle/OracleTestRunner.kt
@@ -65,6 +65,33 @@ class OracleTestRunner {
     }
 
     /**
+     * Load a form, run custom navigation via lambda, then serialize.
+     * Use this for forms requiring non-linear navigation (repeats, skip logic).
+     */
+    fun fillAndSerialize(
+        formResource: String,
+        navigate: (FormEntryModel, FormEntryController) -> Unit
+    ): FormResult {
+        val formDef = loadForm(formResource)
+            ?: return FormResult.Error("Could not load form: $formResource")
+
+        formDef.initialize(true, null)
+
+        val model = FormEntryModel(formDef, FormEntryModel.REPEAT_STRUCTURE_LINEAR)
+        val controller = FormEntryController(model)
+
+        controller.stepToNextEvent()
+        navigate(model, controller)
+
+        return try {
+            val xml = FormSerializer.serializeForm(formDef)
+            FormResult.Success(xml, formDef)
+        } catch (e: Exception) {
+            FormResult.Error("Serialization failed: ${e.message}")
+        }
+    }
+
+    /**
      * Compare our cross-platform serialization against the JVM-only XFormSerializingVisitor.
      */
     fun compareSerializers(formResource: String, answers: List<IAnswerData?>): ComparisonResult {

--- a/app/src/jvmTest/resources/test_constraints.xml
+++ b/app/src/jvmTest/resources/test_constraints.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+        xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:jr="http://openrosa.org/javarosa">
+  <h:head>
+    <h:title>Constraint Test</h:title>
+    <model>
+      <instance>
+        <data xmlns="http://test.commcare.org/constraints">
+          <age/>
+          <name/>
+          <email/>
+        </data>
+      </instance>
+      <bind nodeset="/data/age" type="xsd:int"
+            constraint=". &gt;= 0 and . &lt;= 120"
+            jr:constraintMsg="Age must be between 0 and 120"/>
+      <bind nodeset="/data/name" type="xsd:string" required="true()"/>
+      <bind nodeset="/data/email" type="xsd:string"
+            constraint="contains(., '@')"
+            jr:constraintMsg="Must contain @"/>
+    </model>
+  </h:head>
+  <h:body>
+    <group appearance="field-list">
+      <label>Personal Info</label>
+      <input ref="/data/age">
+        <label>Age</label>
+      </input>
+      <input ref="/data/name">
+        <label>Full name</label>
+      </input>
+      <input ref="/data/email">
+        <label>Email</label>
+      </input>
+    </group>
+  </h:body>
+</h:html>

--- a/app/src/jvmTest/resources/test_repeat_and_relevancy.xml
+++ b/app/src/jvmTest/resources/test_repeat_and_relevancy.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<h:html xmlns="http://www.w3.org/2002/xforms"
+        xmlns:h="http://www.w3.org/1999/xhtml"
+        xmlns:jr="http://openrosa.org/javarosa">
+  <h:head>
+    <h:title>Repeat and Relevancy Test</h:title>
+    <model>
+      <instance>
+        <data xmlns="http://test.commcare.org/repeat_relevancy">
+          <has_children/>
+          <child_count/>
+          <child jr:template="">
+            <name/>
+            <age/>
+          </child>
+          <notes/>
+        </data>
+      </instance>
+      <bind nodeset="/data/has_children" type="xsd:string" required="true()"/>
+      <bind nodeset="/data/child_count" type="xsd:int"
+            relevant="/data/has_children = 'yes'"/>
+      <bind nodeset="/data/child/name" type="xsd:string"/>
+      <bind nodeset="/data/child/age" type="xsd:int"
+            constraint=". &gt; 0 and . &lt; 150"
+            jr:constraintMsg="Age must be between 1 and 149"/>
+      <bind nodeset="/data/notes" type="xsd:string"/>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/has_children">
+      <label>Do you have children?</label>
+    </input>
+    <input ref="/data/child_count">
+      <label>How many children?</label>
+    </input>
+    <group ref="/data/child">
+      <label>Child</label>
+      <repeat nodeset="/data/child">
+        <input ref="/data/child/name">
+          <label>Child's name</label>
+        </input>
+        <input ref="/data/child/age">
+          <label>Child's age</label>
+        </input>
+      </repeat>
+    </group>
+    <input ref="/data/notes">
+      <label>Additional notes</label>
+    </input>
+  </h:body>
+</h:html>


### PR DESCRIPTION
## Summary
- **Repeat groups**: `addRepeat()`/`skipRepeat()` in ViewModel, "Add another?" prompt UI, `controller.newRepeat()` engine call
- **Field-list groups**: Detect `appearance="field-list"` on `EVENT_GROUP`, show all questions on one screen via `getQuestionPrompts()`
- **Skip logic**: Refresh questions after each answer so relevancy changes are reflected immediately
- **Constraints**: Per-question `constraintMessage` in `QuestionState`, inline error display below each widget, required field validation before forward navigation

## Test plan
- [x] 9 new oracle tests in `FormStructureOracleTest` (repeat nav, repeat serialization, relevancy, field-list, constraints, required fields)
- [x] All 34 app JVM tests pass
- [x] All 896 commcare-core JVM tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)