### PR TITLE
feat: Wave 6 — multi-language and RTL

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/ui/FormEntryScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/FormEntryScreen.kt
@@ -27,7 +27,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
 import org.commcare.app.viewmodel.FormEntryViewModel
+import org.commcare.app.viewmodel.LanguageViewModel
 import org.commcare.app.viewmodel.QuestionState
 import org.commcare.app.viewmodel.QuestionType
 
@@ -36,8 +40,11 @@ fun FormEntryScreen(
     viewModel: FormEntryViewModel,
     onComplete: () -> Unit,
     onBack: () -> Unit,
-    onSaveDraft: (() -> Unit)? = null
+    onSaveDraft: (() -> Unit)? = null,
+    languageViewModel: LanguageViewModel? = null
 ) {
+    val layoutDirection = if (languageViewModel?.isRtl == true) LayoutDirection.Rtl else LayoutDirection.Ltr
+    CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
     Column(modifier = Modifier.fillMaxSize()) {
         // Header
         Row(
@@ -54,6 +61,29 @@ fun FormEntryScreen(
                 style = MaterialTheme.typography.headlineMedium,
                 color = MaterialTheme.colorScheme.primary
             )
+        }
+
+        // Language selector
+        if (languageViewModel != null && languageViewModel.availableLanguages.size > 1) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.End
+            ) {
+                for (lang in languageViewModel.availableLanguages) {
+                    Text(
+                        text = lang,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (lang == languageViewModel.currentLanguage)
+                            MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.clickable {
+                            if (languageViewModel.setLanguage(lang)) {
+                                viewModel.refreshAfterLanguageChange()
+                            }
+                        }.padding(horizontal = 8.dp, vertical = 4.dp)
+                    )
+                }
+            }
         }
 
         // Progress
@@ -149,6 +179,7 @@ fun FormEntryScreen(
             }
         }
     }
+    } // CompositionLocalProvider
 }
 
 @Composable

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/FormEntryViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/FormEntryViewModel.kt
@@ -62,6 +62,22 @@ class FormEntryViewModel(
         }
     }
 
+    /**
+     * Load available languages into the LanguageViewModel from this form's localizer.
+     */
+    fun loadLanguages(languageViewModel: LanguageViewModel) {
+        val localizer = formSession.formDef.getLocalizer() ?: return
+        languageViewModel.loadLanguages(localizer)
+    }
+
+    /**
+     * Refresh form display after a language change.
+     */
+    fun refreshAfterLanguageChange() {
+        formTitle = formSession.getFormTitle()
+        updateQuestions()
+    }
+
     fun answerQuestion(index: Int, answer: IAnswerData?) {
         try {
             val result = formSession.answerAtIndex(index, answer)

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/LanguageViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/LanguageViewModel.kt
@@ -1,0 +1,57 @@
+package org.commcare.app.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import org.javarosa.core.services.locale.Localizer
+
+/**
+ * Manages language selection for multi-language forms and menus.
+ * Reads available locales from the engine's Localizer and switches display language.
+ */
+class LanguageViewModel {
+    var availableLanguages by mutableStateOf<List<String>>(emptyList())
+        private set
+    var currentLanguage by mutableStateOf("")
+        private set
+
+    private var localizer: Localizer? = null
+
+    /**
+     * Initialize from a Localizer (typically from FormDef or Localization).
+     */
+    fun loadLanguages(localizer: Localizer) {
+        this.localizer = localizer
+        availableLanguages = localizer.availableLocales.toList()
+        currentLanguage = localizer.locale ?: availableLanguages.firstOrNull() ?: ""
+    }
+
+    /**
+     * Switch the active language. Returns true if the switch was successful.
+     */
+    fun setLanguage(language: String): Boolean {
+        val loc = localizer ?: return false
+        return try {
+            loc.setLocale(language)
+            currentLanguage = language
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /**
+     * Check if the current language is RTL.
+     */
+    val isRtl: Boolean
+        get() {
+            val lang = currentLanguage.lowercase()
+            return lang.startsWith("ar") || // Arabic
+                lang.startsWith("he") || // Hebrew
+                lang.startsWith("ur") || // Urdu
+                lang.startsWith("fa") || // Farsi
+                lang.startsWith("ps") || // Pashto
+                lang.startsWith("sd") || // Sindhi
+                lang.startsWith("yi")    // Yiddish
+        }
+}


### PR DESCRIPTION
## Summary
- **Task 22**: Language switching — `LanguageViewModel` reads available locales from engine Localizer, language selector bar in form entry header, `refreshAfterLanguageChange()` updates questions and title
- **Task 23**: RTL support — detects RTL languages (Arabic, Hebrew, Urdu, Farsi, Pashto, Sindhi, Yiddish), applies `CompositionLocalLayoutDirection.Rtl` to form content

## Files changed (3)
- `LanguageViewModel.kt` — new ViewModel: loadLanguages(), setLanguage(), isRtl detection
- `FormEntryViewModel.kt` — loadLanguages(), refreshAfterLanguageChange()
- `FormEntryScreen.kt` — language selector row, CompositionLocalProvider for RTL

## Test plan
- [x] JVM compilation passes (`compileKotlinJvm`)
- [x] All JVM tests pass (`jvmTest`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)