### PR TITLE
fix: wire form loading from platform storage by xmlns

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/engine/AppInstaller.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/engine/AppInstaller.kt
@@ -8,7 +8,18 @@ import org.commcare.resources.model.InstallerFactory
 import org.commcare.resources.model.InstallRequestSource
 import org.commcare.resources.model.Resource
 import org.commcare.resources.model.ResourceTable
+import org.commcare.suite.model.OfflineUserRestore
+import org.commcare.suite.model.Profile
+import org.commcare.suite.model.Suite
 import org.commcare.util.CommCarePlatform
+import org.javarosa.core.model.FormDef
+import org.javarosa.core.model.instance.FormInstance
+import org.javarosa.core.services.storage.IStorageIndexedFactory
+import org.javarosa.core.services.storage.IStorageUtilityIndexed
+import org.javarosa.core.services.storage.Persistable
+import org.javarosa.core.services.storage.StorageManager
+import org.javarosa.core.services.properties.Property
+import kotlin.reflect.KClass
 
 /**
  * Handles CommCare app installation from a profile URL.
@@ -29,7 +40,16 @@ class AppInstaller(
         onProgress: (Float, String) -> Unit = { _, _ -> }
     ): CommCarePlatform {
         onProgress(0.1f, "Creating platform...")
-        val platform = CommCarePlatform(2, 53, 0)
+        val storageFactory = InMemoryStorageFactory()
+        val storageManager = StorageManager(storageFactory)
+        storageManager.registerStorage(FormDef.STORAGE_KEY, FormDef::class)
+        storageManager.registerStorage(Profile.STORAGE_KEY, Profile::class)
+        storageManager.registerStorage(Suite.STORAGE_KEY, Suite::class)
+        storageManager.registerStorage(FormInstance.STORAGE_KEY, FormInstance::class)
+        storageManager.registerStorage(OfflineUserRestore.STORAGE_KEY, OfflineUserRestore::class)
+        storageManager.registerStorage("fixture", FormInstance::class)
+
+        val platform = CommCarePlatform(2, 53, 0, storageManager)
 
         onProgress(0.2f, "Setting up resource tables...")
         val globalStorage = InMemoryStorage<Resource>(Resource::class, { Resource() })
@@ -65,6 +85,37 @@ class AppInstaller(
      * Useful for development/testing when no profile URL is available.
      */
     fun createMinimalPlatform(): CommCarePlatform {
-        return CommCarePlatform(2, 53, 0)
+        val storageFactory = InMemoryStorageFactory()
+        val storageManager = StorageManager(storageFactory)
+        storageManager.registerStorage(FormDef.STORAGE_KEY, FormDef::class)
+        storageManager.registerStorage(Profile.STORAGE_KEY, Profile::class)
+        storageManager.registerStorage(Suite.STORAGE_KEY, Suite::class)
+        storageManager.registerStorage(FormInstance.STORAGE_KEY, FormInstance::class)
+        return CommCarePlatform(2, 53, 0, storageManager)
+    }
+}
+
+/**
+ * Storage factory that creates InMemoryStorage instances for any registered type.
+ * Uses hardcoded constructors since Kotlin/Native doesn't support reflection-based instantiation.
+ */
+private class InMemoryStorageFactory : IStorageIndexedFactory {
+    @Suppress("UNCHECKED_CAST")
+    override fun newStorage(name: String, type: KClass<*>): IStorageUtilityIndexed<*> {
+        val factory = createFactory(type)
+        return InMemoryStorage(type, factory)
+    }
+
+    private fun createFactory(type: KClass<*>): () -> Persistable {
+        return when (type) {
+            FormDef::class -> { { FormDef() } }
+            FormInstance::class -> { { FormInstance() } }
+            Profile::class -> { { Profile() } }
+            Suite::class -> { { Suite() } }
+            Resource::class -> { { Resource() } }
+            OfflineUserRestore::class -> { { OfflineUserRestore() } }
+            Property::class -> { { Property() } }
+            else -> throw IllegalArgumentException("Unknown storage type: ${type.simpleName}")
+        }
     }
 }

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
@@ -21,8 +21,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import org.commcare.app.engine.FormEntrySession
 import org.commcare.app.engine.NavigationStep
 import org.commcare.app.engine.SessionNavigatorImpl
+import org.javarosa.core.model.FormDef
+import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.commcare.app.state.AppState
 import org.commcare.app.storage.CommCareDatabase
 import org.commcare.app.viewmodel.CaseItem
@@ -246,19 +249,28 @@ private fun HomeLanding(
 }
 
 /**
- * Attempt to load a form entry session from the navigator's current session state.
- * Retrieves the form xmlns from the session, then creates a FormEntryViewModel.
- * Currently requires a FormDef to be provided externally (e.g., from resource installation).
- * Returns null if the form cannot be loaded (e.g., minimal platform with no installed forms).
+ * Load a FormDef from the platform's storage by xmlns, then create a FormEntryViewModel.
+ * Returns null if forms aren't installed or the xmlns isn't found.
  */
+@Suppress("UNCHECKED_CAST")
 private fun loadFormEntry(
     navigator: SessionNavigatorImpl,
     state: AppState.Ready,
     languageViewModel: LanguageViewModel
 ): FormEntryViewModel? {
-    // Form loading requires forms to be installed via a profile URL.
-    // With a minimal platform (no profile), this will return null gracefully.
-    return null
+    return try {
+        val xmlns = navigator.session.getForm() ?: return null
+        val storageManager = state.platform.getStorageManager() ?: return null
+        val formStorage = storageManager.getStorage(FormDef.STORAGE_KEY) as IStorageUtilityIndexed<FormDef>
+        val formDef = formStorage.getRecordForValue("XMLNS", xmlns)
+        val session = FormEntrySession(formDef, state.sandbox, state.platform)
+        val viewModel = FormEntryViewModel(session)
+        viewModel.loadForm()
+        viewModel.loadLanguages(languageViewModel)
+        viewModel
+    } catch (_: Exception) {
+        null
+    }
 }
 
 /**

--- a/app/src/jvmTest/kotlin/org/commcare/app/engine/FormLoadingTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/engine/FormLoadingTest.kt
@@ -1,0 +1,93 @@
+package org.commcare.app.engine
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import org.commcare.app.storage.CommCareDatabase
+import org.commcare.app.storage.InMemoryStorage
+import org.commcare.app.storage.SqlDelightUserSandbox
+import org.javarosa.core.model.FormDef
+import org.javarosa.core.services.storage.IStorageUtilityIndexed
+import org.javarosa.xform.util.XFormUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests that FormDef can be stored in and retrieved from InMemoryStorage by xmlns,
+ * validating the form loading pipeline used by HomeScreen.loadFormEntry().
+ */
+class FormLoadingTest {
+
+    private fun createTestDatabase(): CommCareDatabase {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        CommCareDatabase.Schema.create(driver)
+        return CommCareDatabase(driver)
+    }
+
+    @Test
+    fun testFormDefStorageAndRetrievalByXmlns() {
+        // Parse a real form
+        val stream = this::class.java.getResourceAsStream("/test_form_entry_controller.xml")
+        assertNotNull(stream)
+        val formDef = XFormUtils.getFormFromInputStream(stream)
+        assertNotNull(formDef)
+
+        // Store it in InMemoryStorage (same as AppInstaller uses)
+        val storage = InMemoryStorage<FormDef>(FormDef::class, { FormDef() })
+        storage.write(formDef)
+
+        // Retrieve by XMLNS metadata
+        val xmlns = formDef.getInstance()!!.schema
+        assertNotNull(xmlns, "FormDef should have an xmlns")
+
+        @Suppress("UNCHECKED_CAST")
+        val loaded = storage.getRecordForValue("XMLNS", xmlns)
+        assertNotNull(loaded, "Should find FormDef by XMLNS")
+        assertEquals(xmlns, loaded.getInstance()!!.schema)
+    }
+
+    @Test
+    fun testAppInstallerCreatesStorageManager() {
+        val db = createTestDatabase()
+        val sandbox = SqlDelightUserSandbox(db)
+        val installer = AppInstaller(sandbox)
+
+        // createMinimalPlatform should set up a StorageManager
+        val platform = installer.createMinimalPlatform()
+        assertNotNull(platform.getStorageManager(), "Platform should have a StorageManager")
+
+        // FormDef storage should be registered
+        val formStorage = platform.getStorageManager()!!.getStorage(FormDef.STORAGE_KEY)
+        assertNotNull(formStorage, "FormDef storage should be registered")
+        assertEquals(0, formStorage.getNumRecords(), "Should start empty")
+    }
+
+    @Test
+    fun testFormDefRoundTripThroughPlatformStorage() {
+        val db = createTestDatabase()
+        val sandbox = SqlDelightUserSandbox(db)
+        val installer = AppInstaller(sandbox)
+        val platform = installer.createMinimalPlatform()
+
+        // Parse a form and store it in platform storage
+        val stream = this::class.java.getResourceAsStream("/test_form_entry_controller.xml")
+        assertNotNull(stream)
+        val formDef = XFormUtils.getFormFromInputStream(stream)
+        assertNotNull(formDef)
+
+        @Suppress("UNCHECKED_CAST")
+        val formStorage = platform.getStorageManager()!!.getStorage(FormDef.STORAGE_KEY) as IStorageUtilityIndexed<FormDef>
+        formStorage.write(formDef)
+
+        // Retrieve by XMLNS — this is the exact code path HomeScreen.loadFormEntry uses
+        val xmlns = formDef.getInstance()!!.schema!!
+        val loaded = formStorage.getRecordForValue("XMLNS", xmlns)
+        assertNotNull(loaded)
+        assertEquals(xmlns, loaded.getInstance()!!.schema)
+
+        // Verify it can be initialized for form entry
+        val session = FormEntrySession(loaded)
+        session.initialize()
+        assertTrue(session.getQuestionCount() > 0, "Loaded FormDef should have questions")
+    }
+}


### PR DESCRIPTION
## Summary

- **AppInstaller**: Now creates a `StorageManager` with `InMemoryStorage` for `FormDef`, `Profile`, `Suite`, `FormInstance`, `OfflineUserRestore`, and fixtures. The `StorageManager` is passed to `CommCarePlatform` so `XFormInstaller` can write FormDefs during app installation.
- **HomeScreen.loadFormEntry**: No longer returns `null` unconditionally. Looks up `FormDef` from platform storage via `getRecordForValue("XMLNS", xmlns)` — the same pattern used by `CommCareConfigEngine.loadFormByXmlns()`.
- **InMemoryStorageFactory**: K/N-compatible factory with hardcoded constructors (no reflection).

## What this fixes

Previously, after menu → case selection → form entry, the app would silently fail because `loadFormEntry()` was stubbed to return `null`. Now forms installed via a profile URL are stored in the platform's `StorageManager` and can be loaded for entry.

## Test plan

- [x] `FormLoadingTest.testFormDefStorageAndRetrievalByXmlns` — store/retrieve by xmlns
- [x] `FormLoadingTest.testAppInstallerCreatesStorageManager` — platform has storage
- [x] `FormLoadingTest.testFormDefRoundTripThroughPlatformStorage` — full round-trip: parse → store → retrieve → FormEntrySession
- [x] All existing JVM tests pass
- [ ] iOS CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)