### PR TITLE
feat: wire settings, diagnostics, recovery, demo mode into nav

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/App.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/App.kt
@@ -12,17 +12,27 @@ import org.commcare.app.ui.HomeScreen
 import org.commcare.app.ui.InstallErrorScreen
 import org.commcare.app.ui.InstallScreen
 import org.commcare.app.ui.LoginScreen
+import org.commcare.app.viewmodel.DemoModeManager
 import org.commcare.app.viewmodel.LoginViewModel
 
 @Composable
 fun App(db: CommCareDatabase) {
     val loginViewModel = remember { LoginViewModel(db) }
+    val demoModeManager = remember { DemoModeManager(db) }
 
     MaterialTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
             when (val state = loginViewModel.appState) {
                 is AppState.LoggedOut,
-                is AppState.LoginError -> LoginScreen(loginViewModel)
+                is AppState.LoginError -> LoginScreen(
+                    viewModel = loginViewModel,
+                    onDemoMode = {
+                        val demoState = demoModeManager.enterDemoMode()
+                        if (demoState != null) {
+                            loginViewModel.setReadyState(demoState)
+                        }
+                    }
+                )
                 is AppState.LoggingIn -> LoginScreen(loginViewModel)
                 is AppState.Installing -> InstallScreen(state)
                 is AppState.InstallError -> InstallErrorScreen(state) {

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
@@ -37,7 +37,11 @@ import org.commcare.app.viewmodel.FormRecordViewModel
 import org.commcare.app.viewmodel.LanguageViewModel
 import org.commcare.app.viewmodel.MenuViewModel
 import org.commcare.app.viewmodel.NavigationState
+import org.commcare.app.viewmodel.DiagnosticsViewModel
+import org.commcare.app.viewmodel.RecoveryViewModel
+import org.commcare.app.viewmodel.SettingsViewModel
 import org.commcare.app.viewmodel.SyncViewModel
+import org.commcare.app.viewmodel.UpdateViewModel
 import org.commcare.core.interfaces.createHttpClient
 
 /**
@@ -50,6 +54,9 @@ sealed class HomeNav {
     data object InCaseSearch : HomeNav()
     data object InFormEntry : HomeNav()
     data object InSync : HomeNav()
+    data object InSettings : HomeNav()
+    data object InDiagnostics : HomeNav()
+    data object InRecovery : HomeNav()
 }
 
 /**
@@ -72,6 +79,16 @@ fun HomeScreen(state: AppState.Ready, db: CommCareDatabase) {
     }
     val formRecordViewModel = remember { FormRecordViewModel(db).also { it.loadRecords() } }
     val languageViewModel = remember { LanguageViewModel() }
+    val settingsViewModel = remember { SettingsViewModel() }
+    val updateViewModel = remember {
+        if (state.serverUrl.isNotBlank()) {
+            UpdateViewModel(state.sandbox, state.platform, state.serverUrl)
+        } else null
+    }
+    val diagnosticsViewModel = remember {
+        DiagnosticsViewModel(httpClient, state.serverUrl, state.domain, state.authHeader)
+    }
+    val recoveryViewModel = remember { RecoveryViewModel() }
 
     // Current form entry state (set when navigating to a form)
     var formEntryViewModel by remember { mutableStateOf<FormEntryViewModel?>(null) }
@@ -118,6 +135,12 @@ fun HomeScreen(state: AppState.Ready, db: CommCareDatabase) {
                 },
                 onSync = {
                     nav = HomeNav.InSync
+                },
+                onSettings = {
+                    nav = HomeNav.InSettings
+                },
+                onDiagnostics = {
+                    nav = HomeNav.InDiagnostics
                 },
                 pendingFormCount = formQueueViewModel.pendingCount,
                 lastSyncTime = syncViewModel.lastSyncTime
@@ -271,6 +294,32 @@ fun HomeScreen(state: AppState.Ready, db: CommCareDatabase) {
                 onBack = { nav = HomeNav.Landing }
             )
         }
+
+        is HomeNav.InSettings -> {
+            SettingsScreen(
+                viewModel = settingsViewModel,
+                updateViewModel = updateViewModel,
+                onBack = { nav = HomeNav.Landing },
+                onRecovery = { nav = HomeNav.InRecovery }
+            )
+        }
+
+        is HomeNav.InDiagnostics -> {
+            DiagnosticsScreen(
+                viewModel = diagnosticsViewModel,
+                lastSyncTime = syncViewModel.lastSyncTime,
+                pendingFormCount = formQueueViewModel.pendingCount,
+                onBack = { nav = HomeNav.Landing }
+            )
+        }
+
+        is HomeNav.InRecovery -> {
+            RecoveryScreen(
+                viewModel = recoveryViewModel,
+                onBack = { nav = HomeNav.Landing },
+                onClearData = { nav = HomeNav.Landing }
+            )
+        }
     }
 }
 
@@ -278,6 +327,8 @@ fun HomeScreen(state: AppState.Ready, db: CommCareDatabase) {
 private fun HomeLanding(
     onStart: () -> Unit,
     onSync: () -> Unit,
+    onSettings: () -> Unit,
+    onDiagnostics: () -> Unit,
     pendingFormCount: Int,
     lastSyncTime: String?
 ) {
@@ -316,6 +367,26 @@ private fun HomeLanding(
             modifier = Modifier.fillMaxWidth()
         ) {
             Text("Sync")
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedButton(
+                onClick = onSettings,
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Settings")
+            }
+            OutlinedButton(
+                onClick = onDiagnostics,
+                modifier = Modifier.weight(1f)
+            ) {
+                Text("Diagnostics")
+            }
         }
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/SettingsScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/SettingsScreen.kt
@@ -32,7 +32,8 @@ import org.commcare.app.viewmodel.UpdateViewModel
 fun SettingsScreen(
     viewModel: SettingsViewModel,
     updateViewModel: UpdateViewModel?,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onRecovery: (() -> Unit)? = null
 ) {
     Column(
         modifier = Modifier.fillMaxSize().padding(16.dp)
@@ -201,6 +202,18 @@ fun SettingsScreen(
             modifier = Modifier.fillMaxWidth()
         ) {
             Text("Reset to Defaults")
+        }
+
+        if (onRecovery != null) {
+            Spacer(modifier = Modifier.height(24.dp))
+            SectionDivider()
+            SectionHeader("Troubleshooting")
+            OutlinedButton(
+                onClick = onRecovery,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Recovery Mode")
+            }
         }
     }
 }

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/LoginViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/LoginViewModel.kt
@@ -167,6 +167,13 @@ class LoginViewModel(private val db: CommCareDatabase) {
         appState = AppState.LoggedOut
     }
 
+    /**
+     * Set app state directly — used by demo mode to bypass login.
+     */
+    fun setReadyState(state: AppState) {
+        appState = state
+    }
+
     fun getDomain(): String {
         return if (username.contains("@")) {
             username.substringAfter("@")


### PR DESCRIPTION
## Summary
- Add Settings and Diagnostics buttons to the home landing screen (side-by-side OutlinedButtons)
- Wire `SettingsScreen`, `DiagnosticsScreen`, and `RecoveryScreen` into `HomeScreen`'s navigation graph via `HomeNav` sealed class
- Connect demo mode: `App.kt` passes `onDemoMode` to `LoginScreen`, which uses `DemoModeManager` to create an isolated sandbox
- Add `LoginViewModel.setReadyState()` to allow demo mode to bypass normal login flow

## Test plan
- [x] `compileCommonMainKotlinMetadata` passes
- [x] All JVM tests pass (`jvmTest`)
- [ ] Manual verification: Settings, Diagnostics, and Recovery screens are reachable from home landing
- [ ] Manual verification: Demo mode button on login screen creates sandbox and navigates to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)