### PR TITLE
feat: cross-platform XFormInstaller for iOS app install

### DIFF
--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -14,15 +14,14 @@
 #
 # Test status:
 #   login-and-home.yaml       — PASSING (login + verify all home sections)
+#   login-with-app.yaml       — PASSING (login with App ID + full app install)
 #   sync-and-verify.yaml      — PASSING (login + sync + case list + incremental sync)
-#   hq-round-trip.yaml        — BLOCKED (needs iOS HTTP reference factory for app install)
-#   form-entry-navigation.yaml — BLOCKED (same — needs full app install)
+#   hq-round-trip.yaml        — WIP (login + install + sync + form entry)
+#   form-entry-navigation.yaml — WIP (depends on hq-round-trip base flow)
 #
 # Known issues:
 #   - Compose Multiplatform on iOS doesn't dismiss keyboard on tap-outside by default.
 #     We added pointerInput-based dismissal to LoginScreen.
 #   - CMP 1.10+ requires CADisableMinimumFrameDurationOnPhone in Info.plist or app crashes.
-#   - AppInstaller on iOS can't resolve https:// URLs for app resource download.
-#     Needs an iOS equivalent of JavaHttpRoot registered with ReferenceManager.
 
 appId: org.commcare.ios

--- a/.maestro/flows/hq-round-trip.yaml
+++ b/.maestro/flows/hq-round-trip.yaml
@@ -1,10 +1,6 @@
 # Full HQ round-trip E2E test:
 #   Login → Sync → Navigate to form → Fill form → Submit → Sync again
 #
-# BLOCKED: Requires iOS HTTP reference factory in AppInstaller to download
-# app resources from HQ. Without it, app install fails with
-# "No external or local definition could be found for resource Application Descriptor"
-#
 # Run:
 #   .maestro/run.sh .maestro/flows/hq-round-trip.yaml
 appId: org.commcare.ios
@@ -38,32 +34,43 @@ env:
 # Go back to home
 - tapOn: "Back"
 
-# ---- Step 3: Navigate into a form ----
+# ---- Step 3: Navigate through menus into a form ----
 - tapOn: "Start"
-
-# Wait for menu to load
 - waitForAnimationToEnd:
     timeout: 5000
 
-# Tap the first visible menu item
-- tapOn:
-    index: 0
-
-# Wait — could be another menu, case list, or form entry
+# Bonsaaso app structure: Start → menus (m0..m3) → forms
+# Try each module until we find one that opens a form without needing cases.
+# m3 is often a standalone registration module.
+- tapOn: "m3"
 - waitForAnimationToEnd:
     timeout: 5000
 
-# If we see a case list (Search field), select the first case
+# If this is a form list, tap the first form
 - runFlow:
     when:
-      visible: "Search"
+      visible: "m3-f0"
     commands:
-      - tapOn:
-          text: ".*"
-          index: 1
+      - tapOn: "m3-f0"
+      - waitForAnimationToEnd:
+          timeout: 5000
+
+# If we're on a case list with cases, select first case
+- runFlow:
+    when:
+      visible: "Select Case"
+    commands:
+      - runFlow:
+          when:
+            notVisible: "No cases found"
+          commands:
+            - tapOn:
+                text: ".*"
+                index: 2
+            - waitForAnimationToEnd:
+                timeout: 5000
 
 # ---- Step 4: Fill the form ----
-# Wait for form entry screen
 - extendedWaitUntil:
     visible: "Next"
     timeout: 30000

--- a/commcare-core/src/commonMain/kotlin/org/commcare/resources/model/InstallerFactory.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/resources/model/InstallerFactory.kt
@@ -1,5 +1,6 @@
 package org.commcare.resources.model
 
+import org.commcare.resources.model.installers.CommonXFormInstaller
 import org.commcare.resources.model.installers.LocaleFileInstaller
 import org.commcare.resources.model.installers.LoginImageInstaller
 import org.commcare.resources.model.installers.MediaInstaller
@@ -17,9 +18,7 @@ open class InstallerFactory {
     }
 
     open fun getXFormInstaller(): ResourceInstaller<*> {
-        throw UnsupportedOperationException(
-            "XFormInstaller not available. Use JvmInstallerFactory on JVM."
-        )
+        return CommonXFormInstaller()
     }
 
     open fun getUserRestoreInstaller(): ResourceInstaller<*> {

--- a/commcare-core/src/commonMain/kotlin/org/commcare/resources/model/installers/CommonXFormInstaller.kt
+++ b/commcare-core/src/commonMain/kotlin/org/commcare/resources/model/installers/CommonXFormInstaller.kt
@@ -1,0 +1,189 @@
+package org.commcare.resources.model.installers
+
+import org.commcare.resources.ResourceInstallContext
+import org.commcare.resources.model.MissingMediaException
+import org.commcare.resources.model.Resource
+import org.commcare.resources.model.ResourceLocation
+import org.commcare.resources.model.ResourceTable
+import org.commcare.resources.model.UnreliableSourceException
+import org.commcare.resources.model.UnresolvedResourceException
+import org.commcare.util.CommCarePlatform
+import org.javarosa.core.model.FormDef
+import org.javarosa.core.reference.Reference
+import org.javarosa.core.util.SizeBoundUniqueVector
+import org.javarosa.core.io.PlatformInputStream
+import org.javarosa.core.util.externalizable.PlatformIOException
+import org.javarosa.xform.parse.XFormParseException
+import org.javarosa.xform.util.XFormLoader
+import org.javarosa.xml.util.UnfullfilledRequirementsException
+
+/**
+ * Cross-platform XFormInstaller using XFormLoader (works on both JVM and iOS).
+ * Equivalent to the JVM-only XFormInstaller but uses the KMP XFormParser
+ * instead of the kxml2-based XFormUtils.
+ */
+class CommonXFormInstaller : CacheInstaller<FormDef>() {
+
+    companion object {
+        private const val UPGRADE_EXT: String = "_TEMP"
+        private const val STAGING_EXT: String = "_STAGING-OPENROSA"
+        private val exts = arrayOf(UPGRADE_EXT, STAGING_EXT)
+    }
+
+    override fun getCacheKey(): String {
+        return FormDef.STORAGE_KEY
+    }
+
+    @Throws(UnresolvedResourceException::class, UnfullfilledRequirementsException::class)
+    override fun install(
+        r: Resource, location: ResourceLocation, ref: Reference,
+        table: ResourceTable, platform: CommCarePlatform,
+        upgrade: Boolean, resourceInstallContext: ResourceInstallContext
+    ): Boolean {
+        var incoming: PlatformInputStream? = null
+        try {
+            if (location.getAuthority() == Resource.RESOURCE_AUTHORITY_CACHE) {
+                return false
+            } else {
+                incoming = ref.getStream()
+                if (incoming == null) {
+                    return false
+                }
+
+                // Read entire stream into bytes for cross-platform XFormLoader
+                val buffer = ByteArray(4096)
+                val chunks = mutableListOf<ByteArray>()
+                var totalSize = 0
+                while (true) {
+                    val bytesRead = incoming.read(buffer)
+                    if (bytesRead == -1) break
+                    chunks.add(buffer.copyOfRange(0, bytesRead))
+                    totalSize += bytesRead
+                }
+                val xmlBytes = ByteArray(totalSize)
+                var offset = 0
+                for (chunk in chunks) {
+                    chunk.copyInto(xmlBytes, offset)
+                    offset += chunk.size
+                }
+
+                val formDef = XFormLoader.loadForm(xmlBytes)
+                val instance = formDef.getInstance()!!
+                if (upgrade) {
+                    instance.schema = instance.schema + UPGRADE_EXT
+                    storage(platform).write(formDef)
+                    cacheLocation = formDef.getID()
+                    table.commit(r, Resource.RESOURCE_STATUS_UPGRADE)
+                } else {
+                    storage(platform).write(formDef)
+                    cacheLocation = formDef.getID()
+                    table.commit(r, Resource.RESOURCE_STATUS_INSTALLED)
+                }
+                return true
+            }
+        } catch (e: PlatformIOException) {
+            throw UnreliableSourceException(r, e.message)
+        } catch (xpe: XFormParseException) {
+            throw UnresolvedResourceException(r, xpe.message, true)
+        } finally {
+            try {
+                incoming?.close()
+            } catch (e: PlatformIOException) {
+            }
+        }
+    }
+
+    @Throws(UnresolvedResourceException::class)
+    override fun upgrade(r: Resource, platform: CommCarePlatform): Boolean {
+        val form = storage(platform).read(cacheLocation)
+        val instance = form.getInstance()!!
+        val tempString = instance.schema ?: return true
+
+        if (tempString.contains(UPGRADE_EXT)) {
+            instance.schema = tempString.substring(0, tempString.indexOf(UPGRADE_EXT))
+            storage(platform).write(form)
+        }
+        return true
+    }
+
+    override fun unstage(r: Resource, newStatus: Int, platform: CommCarePlatform): Boolean {
+        val destination = if (newStatus == Resource.RESOURCE_STATUS_UNSTAGED) {
+            STAGING_EXT
+        } else {
+            UPGRADE_EXT
+        }
+
+        val form = storage(platform).read(cacheLocation)
+        val instance = form.getInstance()!!
+        val tempString = instance.schema ?: ""
+
+        if (tempString.contains(destination)) {
+            return true
+        } else {
+            instance.schema = tempString + destination
+            storage(platform).write(form)
+            return true
+        }
+    }
+
+    override fun revert(r: Resource, table: ResourceTable, platform: CommCarePlatform): Boolean {
+        val form = storage(platform).read(cacheLocation)
+        val instance = form.getInstance()!!
+        val tempString = instance.schema ?: return true
+
+        for (ext in exts) {
+            if (tempString.contains(ext)) {
+                instance.schema = tempString.substring(0, tempString.indexOf(ext))
+                storage(platform).write(form)
+            }
+        }
+        return true
+    }
+
+    override fun rollback(r: Resource, platform: CommCarePlatform): Int {
+        val status = r.getStatus()
+        val form = storage(platform).read(cacheLocation)
+        val currentSchema = form.getInstance()!!.schema ?: ""
+
+        return when (status) {
+            Resource.RESOURCE_STATUS_INSTALL_TO_UNSTAGE,
+            Resource.RESOURCE_STATUS_UNSTAGE_TO_INSTALL -> {
+                if (currentSchema.contains(STAGING_EXT)) {
+                    Resource.RESOURCE_STATUS_UNSTAGED
+                } else {
+                    Resource.RESOURCE_STATUS_INSTALLED
+                }
+            }
+            Resource.RESOURCE_STATUS_UPGRADE_TO_INSTALL,
+            Resource.RESOURCE_STATUS_INSTALL_TO_UPGRADE -> {
+                if (currentSchema.contains(UPGRADE_EXT)) {
+                    Resource.RESOURCE_STATUS_UPGRADE
+                } else {
+                    Resource.RESOURCE_STATUS_INSTALLED
+                }
+            }
+            else -> throw RuntimeException("Unexpected status for rollback! $status")
+        }
+    }
+
+    override fun verifyInstallation(
+        r: Resource, problemList: ArrayList<MissingMediaException>,
+        platform: CommCarePlatform
+    ): Boolean {
+        @Suppress("UNCHECKED_CAST")
+        val sizeBoundProblems = problemList as SizeBoundUniqueVector<MissingMediaException>
+
+        try {
+            storage(platform).read(cacheLocation)
+        } catch (e: Exception) {
+            sizeBoundProblems.add(
+                MissingMediaException(
+                    r, "Form did not properly save into persistent storage",
+                    MissingMediaException.MissingMediaExceptionType.NONE
+                )
+            )
+            return true
+        }
+        return false
+    }
+}


### PR DESCRIPTION
## Summary

- **CommonXFormInstaller**: Cross-platform XForm resource installer using `XFormLoader` (works on both JVM and iOS). The base `InstallerFactory` now uses this instead of throwing `UnsupportedOperationException`.
- **Maestro flow updates**: Updated hq-round-trip flow for Bonsaaso app menu structure, updated config to reflect passing status.

## What this unblocks

With the XML parser fix from #266 and this XFormInstaller, the full app install pipeline now works on iOS:
- Login + OTA restore
- Profile download + parsing
- Suite installation
- **XForm resource installation** (this PR)
- Menu navigation into forms

## Known remaining issue

Locale resources aren't resolving — menu items show command IDs (`m0`, `m1`) instead of display names, and form questions render blank. This is a separate issue (locale file installer or display text resolution).

## Test plan

- [x] `login-with-app.yaml` Maestro flow passes (full app install + "Start" visible)
- [x] `login-and-home.yaml` passes
- [x] `sync-and-verify.yaml` passes
- [x] JVM + iOS compilation succeeds
- [ ] `hq-round-trip.yaml` — gets through menu navigation but form content is blank (locale issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)