### PR TITLE
feat: activate locale after app install, fix menu display text

### DIFF
--- a/.maestro/flows/hq-round-trip.yaml
+++ b/.maestro/flows/hq-round-trip.yaml
@@ -39,21 +39,18 @@ env:
 - waitForAnimationToEnd:
     timeout: 5000
 
-# Bonsaaso app structure: Start → menus (m0..m3) → forms
-# Try each module until we find one that opens a form without needing cases.
-# m3 is often a standalone registration module.
-- tapOn: "m3"
+# Bonsaaso app: Pregnancy List, Child List, Household List, Registration
+# "Registration" → "Register Household" creates new households — no cases required.
+- tapOn:
+    text: ".*Registration.*"
 - waitForAnimationToEnd:
     timeout: 5000
 
-# If this is a form list, tap the first form
-- runFlow:
-    when:
-      visible: "m3-f0"
-    commands:
-      - tapOn: "m3-f0"
-      - waitForAnimationToEnd:
-          timeout: 5000
+# Tap "Register Household" to open a registration form
+- tapOn:
+    text: ".*Register Household.*"
+- waitForAnimationToEnd:
+    timeout: 10000
 
 # If we're on a case list with cases, select first case
 - runFlow:
@@ -65,15 +62,15 @@ env:
             notVisible: "No cases found"
           commands:
             - tapOn:
-                text: ".*"
                 index: 2
             - waitForAnimationToEnd:
                 timeout: 5000
 
 # ---- Step 4: Fill the form ----
+# Wait longer — form parsing may take time on first load
 - extendedWaitUntil:
     visible: "Next"
-    timeout: 30000
+    timeout: 60000
 
 # Answer text question if visible
 - runFlow:

--- a/app/src/commonMain/kotlin/org/commcare/app/engine/AppInstaller.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/engine/AppInstaller.kt
@@ -18,6 +18,7 @@ import org.javarosa.core.services.storage.IStorageIndexedFactory
 import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.commcare.app.platform.createHttpReferenceFactory
 import org.javarosa.core.reference.ReferenceManager
+import org.javarosa.core.services.locale.Localization
 import org.javarosa.core.services.storage.Persistable
 import org.javarosa.core.services.storage.StorageManager
 import org.javarosa.core.services.properties.Property
@@ -80,8 +81,40 @@ class AppInstaller(
         onProgress(0.8f, "Initializing platform...")
         platform.initialize(globalTable, false)
 
+        // Set the current locale from the profile's cur_locale property.
+        // Without this, Localization.get() throws UnregisteredLocaleException
+        // and all display text (menus, form questions) falls back to IDs.
+        setDefaultLocale(platform)
+
         onProgress(1.0f, "Installation complete")
         return platform
+    }
+
+    /**
+     * Activate the locale specified by the profile's cur_locale property.
+     * Mirrors CommCareConfigEngine.setDefaultLocale() on Android/CLI.
+     */
+    private fun setDefaultLocale(platform: CommCarePlatform) {
+        var locale = "default"
+        val profile = platform.getCurrentProfile()
+        if (profile != null) {
+            for (setter in profile.getPropertySetters()) {
+                if (setter.key == "cur_locale") {
+                    locale = setter.value
+                    break
+                }
+            }
+        }
+        try {
+            Localization.setLocale(locale)
+        } catch (e: Exception) {
+            // If the exact locale isn't available, try setting to default
+            try {
+                Localization.getGlobalLocalizerAdvanced().setToDefault()
+            } catch (_: Exception) {
+                // No locales available at all — display will fall back to IDs
+            }
+        }
     }
 
     /**

--- a/app/src/commonMain/kotlin/org/commcare/app/engine/FormEntrySession.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/engine/FormEntrySession.kt
@@ -53,7 +53,8 @@ class FormEntrySession(
     fun getPrompts(): Array<FormEntryPrompt> {
         return try {
             controller.getQuestionPrompts()
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            println("[FORM-DEBUG] getPrompts failed: ${e::class.simpleName}: ${e.message}")
             emptyArray()
         }
     }

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/FormEntryViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/FormEntryViewModel.kt
@@ -61,8 +61,22 @@ class FormEntryViewModel(
             formSession.stepNext() // Move past BEGINNING_OF_FORM
             advanceToQuestion()
             updateQuestions()
+            // Debug: if no questions loaded, report form state
+            if (questions.isEmpty() && !isComplete && !isRepeatPrompt) {
+                val event = formSession.currentEvent()
+                val eventName = when (event) {
+                    FormEntryController.EVENT_BEGINNING_OF_FORM -> "BEGINNING"
+                    FormEntryController.EVENT_END_OF_FORM -> "END"
+                    FormEntryController.EVENT_QUESTION -> "QUESTION"
+                    FormEntryController.EVENT_GROUP -> "GROUP"
+                    FormEntryController.EVENT_REPEAT -> "REPEAT"
+                    FormEntryController.EVENT_PROMPT_NEW_REPEAT -> "NEW_REPEAT"
+                    else -> "UNKNOWN($event)"
+                }
+                errorMessage = "No questions at event=$eventName, prompts=${formSession.getPrompts().size}"
+            }
         } catch (e: Exception) {
-            errorMessage = "Failed to load form: ${e.message}"
+            errorMessage = "Failed to load form: ${e::class.simpleName}: ${e.message}"
         }
     }
 
@@ -391,7 +405,8 @@ class FormEntryViewModel(
                     appearance = prompt.getAppearanceHint()
                 )
             }
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            errorMessage = "Question load error: ${e::class.simpleName}: ${e.message}"
             emptyList()
         }
     }


### PR DESCRIPTION
## Summary

- **Locale activation**: After `platform.initialize()`, read `cur_locale` from the profile's property setters and call `Localization.setLocale()`. Without this, `Localization.get()` throws `UnregisteredLocaleException` and all display text falls back to command IDs ("m0", "m1" instead of "Pregnancy List", "Registration").
- **Form entry debug**: Surface errors from `getPrompts()` and `updateQuestions()` instead of silently returning empty.
- **Maestro flow**: Updated hq-round-trip for real menu names.

## Before / After

| Before | After |
|--------|-------|
| m0, m1, m2, m3 | Pregnancy List, Child List, Household List, Registration |

## Known remaining issue

Form entry screen renders blank — progress bar visible but no questions or Next button. The form loads and enters form entry mode, but `getQuestionPrompts()` returns empty. Needs unit-level investigation (likely XFormParser or form localizer initialization on iOS).

## Test plan

- [x] `login-with-app.yaml` Maestro flow passes
- [x] `login-and-home.yaml` passes  
- [x] `sync-and-verify.yaml` passes
- [x] Menu items show real display names
- [x] Both JVM + iOS compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)