### PR TITLE
feat: wire SessionWrapper into form entry initialization

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/engine/FormEntrySession.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/engine/FormEntrySession.kt
@@ -2,6 +2,7 @@ package org.commcare.app.engine
 
 import org.commcare.app.storage.SqlDelightUserSandbox
 import org.commcare.core.process.CommCareInstanceInitializer
+import org.commcare.modern.session.SessionWrapper
 import org.commcare.util.CommCarePlatform
 import org.javarosa.core.model.Constants
 import org.javarosa.core.model.FormDef
@@ -24,16 +25,22 @@ import org.javarosa.form.api.FormEntryPrompt
 class FormEntrySession(
     val formDef: FormDef,
     private val sandbox: SqlDelightUserSandbox? = null,
-    private val platform: CommCarePlatform? = null
+    private val platform: CommCarePlatform? = null,
+    private val sessionWrapper: SessionWrapper? = null
 ) {
     val model: FormEntryModel = FormEntryModel(formDef, FormEntryModel.REPEAT_STRUCTURE_LINEAR)
     val controller: FormEntryController = FormEntryController(model)
 
     /**
      * Initialize the form with instance data (case references, fixtures, etc.)
+     * Uses SessionWrapper when available so forms can resolve session instance
+     * references (e.g., instance('commcaresession')/session/data/case_id).
      */
     fun initialize() {
-        if (sandbox != null && platform != null) {
+        if (sessionWrapper != null) {
+            val initializer = CommCareInstanceInitializer(sessionWrapper, sandbox, platform)
+            formDef.initialize(true, initializer)
+        } else if (sandbox != null && platform != null) {
             val initializer = CommCareInstanceInitializer(null, sandbox, platform)
             formDef.initialize(true, initializer)
         } else if (sandbox != null) {

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
@@ -424,7 +424,7 @@ private fun loadFormEntry(
         val storageManager = state.platform.getStorageManager() ?: return null
         val formStorage = storageManager.getStorage(FormDef.STORAGE_KEY) as IStorageUtilityIndexed<FormDef>
         val formDef = formStorage.getRecordForValue("XMLNS", xmlns)
-        val session = FormEntrySession(formDef, state.sandbox, state.platform)
+        val session = FormEntrySession(formDef, state.sandbox, state.platform, navigator.session)
         val viewModel = FormEntryViewModel(session)
         viewModel.loadForm()
         viewModel.loadLanguages(languageViewModel)


### PR DESCRIPTION
## Summary

Pass the existing `SessionWrapper` from `SessionNavigatorImpl` to `FormEntrySession` so that `CommCareInstanceInitializer` can resolve session instance references (`instance('commcaresession')`).

Previously, `FormEntrySession` created `CommCareInstanceInitializer(null, sandbox, platform)` — the null `sessionWrapper` caused NPE when forms referenced session data (selected case, datum values, user properties).

## Changes

- `FormEntrySession`: Accept optional `SessionWrapper` parameter; use it as first arg to `CommCareInstanceInitializer`
- `HomeScreen.loadFormEntry()`: Pass `navigator.session` to `FormEntrySession`

## Test plan

- [x] JVM + iOS compile
- [x] Existing tests pass
- [ ] Maestro hq-round-trip (blocked by Maestro field targeting issue with CMP OutlinedTextField — separate from this code fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)