### PR TITLE
fix: Maestro field targeting with testTag IDs for CMP

### DIFF
--- a/.maestro/flows/login-with-app.yaml
+++ b/.maestro/flows/login-with-app.yaml
@@ -6,14 +6,16 @@ appId: org.commcare.ios
 
 - launchApp:
     appId: "org.commcare.ios"
+    clearState: true
 
 # Wait for login screen to appear
 - extendedWaitUntil:
     visible: "Log In"
     timeout: 10000
 
-# Fill Username
-- tapOn: "Username"
+# Fill Username (using testTag ID to avoid CMP label tap misalignment)
+- tapOn:
+    id: "username_field"
 - inputText: "${COMMCARE_USERNAME}"
 
 # Dismiss keyboard
@@ -23,7 +25,8 @@ appId: org.commcare.ios
     timeout: 1000
 
 # Fill Domain
-- tapOn: "Domain"
+- tapOn:
+    id: "domain_field"
 - inputText: "${COMMCARE_DOMAIN}"
 
 # Dismiss keyboard
@@ -33,7 +36,8 @@ appId: org.commcare.ios
     timeout: 1000
 
 # Fill App ID
-- tapOn: "App ID"
+- tapOn:
+    id: "appid_field"
 - inputText: "${COMMCARE_APP_ID}"
 
 # Dismiss keyboard
@@ -46,7 +50,8 @@ appId: org.commcare.ios
 - scrollUntilVisible:
     element: "Password"
     direction: DOWN
-- tapOn: "Password"
+- tapOn:
+    id: "password_field"
 - inputText: "${COMMCARE_PASSWORD}"
 
 # Dismiss keyboard

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/LoginScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/LoginScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -81,7 +82,7 @@ fun LoginScreen(
             value = viewModel.username,
             onValueChange = { viewModel.username = it },
             label = { Text("Username") },
-            modifier = Modifier.fillMaxWidth().focusRequester(usernameFocus),
+            modifier = Modifier.fillMaxWidth().focusRequester(usernameFocus).testTag("username_field"),
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
             keyboardActions = KeyboardActions(onNext = { domainFocus.requestFocus() }),
@@ -94,7 +95,7 @@ fun LoginScreen(
             value = viewModel.domain,
             onValueChange = { viewModel.domain = it },
             label = { Text("Domain") },
-            modifier = Modifier.fillMaxWidth().focusRequester(domainFocus),
+            modifier = Modifier.fillMaxWidth().focusRequester(domainFocus).testTag("domain_field"),
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
             keyboardActions = KeyboardActions(onNext = { appIdFocus.requestFocus() }),
@@ -107,7 +108,7 @@ fun LoginScreen(
             value = viewModel.appId,
             onValueChange = { viewModel.appId = it },
             label = { Text("App ID") },
-            modifier = Modifier.fillMaxWidth().focusRequester(appIdFocus),
+            modifier = Modifier.fillMaxWidth().focusRequester(appIdFocus).testTag("appid_field"),
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
             keyboardActions = KeyboardActions(onNext = { passwordFocus.requestFocus() }),
@@ -120,7 +121,7 @@ fun LoginScreen(
             value = viewModel.password,
             onValueChange = { viewModel.password = it },
             label = { Text("Password") },
-            modifier = Modifier.fillMaxWidth().focusRequester(passwordFocus),
+            modifier = Modifier.fillMaxWidth().focusRequester(passwordFocus).testTag("password_field"),
             singleLine = true,
             visualTransformation = PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions(


### PR DESCRIPTION
## Summary

CMP `OutlinedTextField` labels cause Maestro `tapOn` misalignment — tapping the "Username" label text hits the Domain field below it. This caused login flows to fail intermittently.

**Fix**: Added `testTag` to each login field and updated Maestro flows to use `id:`-based targeting instead of text matching.

## Test plan

- [x] `login-with-app.yaml` passes reliably with testTag IDs
- [x] JVM + iOS compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)