### PR TITLE
fix: hq-integration workflow parse error

### DIFF
--- a/.github/workflows/hq-integration.yml
+++ b/.github/workflows/hq-integration.yml
@@ -20,8 +20,6 @@ concurrency:
 jobs:
   integration:
     runs-on: macos-15
-    # Only run if secrets are configured
-    if: ${{ secrets.COMMCARE_USERNAME != '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -35,7 +33,20 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x app/gradlew
 
+      - name: Check credentials
+        id: check_creds
+        env:
+          COMMCARE_USERNAME: ${{ secrets.COMMCARE_USERNAME }}
+        run: |
+          if [ -z "$COMMCARE_USERNAME" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "⚠️ HQ credentials not configured — skipping integration tests"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run HQ integration tests
+        if: steps.check_creds.outputs.skip != 'true'
         working-directory: app
         env:
           COMMCARE_HQ_URL: ${{ inputs.hq_url || secrets.COMMCARE_HQ_URL || 'https://www.commcarehq.org' }}


### PR DESCRIPTION
## Summary

The `if: ${{ secrets.COMMCARE_USERNAME != '' }}` at job level caused a workflow file parse error on every push, showing as a failing CI check.

Replaced with a check step that tests the env var and sets a skip output for subsequent steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)