### PR TITLE
feat: Phase 5 Wave 3 — multi-app management

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/App.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/App.kt
@@ -5,12 +5,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import org.commcare.app.state.AppState
 import org.commcare.app.storage.AppRecordRepository
 import org.commcare.app.storage.CommCareDatabase
+import org.commcare.app.ui.AppManagerScreen
 import org.commcare.app.ui.EnterCodeScreen
 import org.commcare.app.ui.HomeScreen
 import org.commcare.app.ui.InstallErrorScreen
@@ -20,6 +23,7 @@ import org.commcare.app.ui.InstallScreen
 import org.commcare.app.ui.LoginScreen
 import org.commcare.app.ui.SetupScreen
 import org.commcare.app.viewmodel.AppInstallViewModel
+import org.commcare.app.viewmodel.AppManagerViewModel
 import org.commcare.app.viewmodel.DemoModeManager
 import org.commcare.app.viewmodel.InstallState
 import org.commcare.app.viewmodel.LoginViewModel
@@ -36,6 +40,7 @@ fun App(db: CommCareDatabase) {
 
     // Track whether any apps are installed; starts false on first launch
     val hasApps = remember { mutableStateOf(appRepository.getAppCount() > 0) }
+    var showAppManager by remember { mutableStateOf(false) }
 
     MaterialTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
@@ -44,6 +49,16 @@ fun App(db: CommCareDatabase) {
             // Once an app is seated (NeedsLogin or Ready), flip hasApps so we leave setup flow
             if (appState is AppState.NeedsLogin || appState is AppState.Ready) {
                 hasApps.value = true
+            }
+
+            // If apps exist in DB but LoginViewModel is still LoggedOut, bridge the gap:
+            // load the seated app and transition to NeedsLogin so the app switcher gets data.
+            if (hasApps.value && appState is AppState.LoggedOut) {
+                val seatedApp = appRepository.getSeatedApp()
+                if (seatedApp != null) {
+                    val allApps = appRepository.getAllApps()
+                    loginViewModel.setReadyState(AppState.NeedsLogin(seatedApp, allApps))
+                }
             }
 
             if (!hasApps.value) {
@@ -58,7 +73,6 @@ fun App(db: CommCareDatabase) {
                 // Normal routing: login, install, home, etc.
                 when (appState) {
                     is AppState.NoAppsInstalled,
-                    is AppState.NeedsLogin,
                     is AppState.LoggedOut,
                     is AppState.LoginError -> LoginScreen(
                         viewModel = loginViewModel,
@@ -69,6 +83,48 @@ fun App(db: CommCareDatabase) {
                             }
                         }
                     )
+                    is AppState.NeedsLogin -> {
+                        // Auto-configure LoginViewModel from the seated app
+                        loginViewModel.configureApp(
+                            serverUrl = "https://www.commcarehq.org",
+                            appId = appState.seatedApp.id,
+                            app = appState.seatedApp
+                        )
+                        if (showAppManager) {
+                            val appManagerViewModel = remember { AppManagerViewModel(appRepository) }
+                            AppManagerScreen(
+                                viewModel = appManagerViewModel,
+                                onBack = { showAppManager = false },
+                                onInstallNew = {
+                                    showAppManager = false
+                                    hasApps.value = false
+                                }
+                            )
+                        } else {
+                            LoginScreen(
+                                viewModel = loginViewModel,
+                                onDemoMode = {
+                                    val demoState = demoModeManager.enterDemoMode()
+                                    if (demoState != null) {
+                                        loginViewModel.setReadyState(demoState)
+                                    }
+                                },
+                                seatedApp = appState.seatedApp,
+                                allApps = appState.allApps,
+                                onSwitchApp = { app ->
+                                    appRepository.seatApp(app.id)
+                                    loginViewModel.configureApp(
+                                        serverUrl = "https://www.commcarehq.org",
+                                        appId = app.id,
+                                        app = app
+                                    )
+                                    val allApps = appRepository.getAllApps()
+                                    loginViewModel.setReadyState(AppState.NeedsLogin(app, allApps))
+                                },
+                                onAppManager = { showAppManager = true }
+                            )
+                        }
+                    }
                     is AppState.LoggingIn -> LoginScreen(loginViewModel)
                     is AppState.Installing -> InstallScreen(appState)
                     is AppState.InstallError -> InstallErrorScreen(appState) {

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/AppManagerScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/AppManagerScreen.kt
@@ -1,0 +1,233 @@
+package org.commcare.app.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.commcare.app.model.AppStatus
+import org.commcare.app.model.ApplicationRecord
+import org.commcare.app.viewmodel.AppManagerViewModel
+
+@Composable
+fun AppManagerScreen(
+    viewModel: AppManagerViewModel,
+    onBack: () -> Unit,
+    onInstallNew: () -> Unit
+) {
+    LaunchedEffect(Unit) {
+        viewModel.refresh()
+    }
+
+    var appToUninstall by remember { mutableStateOf<ApplicationRecord?>(null) }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        // Header
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "<",
+                style = MaterialTheme.typography.headlineSmall,
+                modifier = Modifier.clickable { onBack() }
+                    .defaultMinSize(minHeight = 44.dp, minWidth = 44.dp)
+                    .padding(end = 8.dp)
+            )
+            Text(
+                text = "App Manager",
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+
+        HorizontalDivider()
+
+        LazyColumn(
+            modifier = Modifier.weight(1f).padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            item { Spacer(modifier = Modifier.height(8.dp)) }
+
+            if (viewModel.apps.isEmpty()) {
+                item {
+                    Text(
+                        text = "No apps installed",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(vertical = 8.dp)
+                    )
+                }
+            } else {
+                items(viewModel.apps) { app ->
+                    AppCard(
+                        app = app,
+                        isSeated = app.id == viewModel.seatedAppId,
+                        onSetActive = { viewModel.seatApp(app.id) },
+                        onArchive = { viewModel.archiveApp(app.id) },
+                        onUninstall = { appToUninstall = app }
+                    )
+                }
+            }
+
+            item { Spacer(modifier = Modifier.height(8.dp)) }
+        }
+
+        HorizontalDivider()
+
+        // Bottom: Install New App button
+        Column(modifier = Modifier.padding(16.dp)) {
+            val canInstall = viewModel.canInstallMore()
+            Button(
+                onClick = onInstallNew,
+                modifier = Modifier.fillMaxWidth(),
+                enabled = canInstall
+            ) {
+                Text("Install New App")
+            }
+            if (!canInstall) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "(max ${AppManagerViewModel.MAX_APPS} apps)",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+
+    // Uninstall confirmation dialog
+    val uninstallTarget = appToUninstall
+    if (uninstallTarget != null) {
+        AlertDialog(
+            onDismissRequest = { appToUninstall = null },
+            title = { Text("Uninstall App") },
+            text = { Text("Remove \"${uninstallTarget.displayName}\"? This cannot be undone.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.uninstallApp(uninstallTarget.id)
+                        appToUninstall = null
+                    }
+                ) {
+                    Text(
+                        text = "Uninstall",
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { appToUninstall = null }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun AppCard(
+    app: ApplicationRecord,
+    isSeated: Boolean,
+    onSetActive: () -> Unit,
+    onArchive: () -> Unit,
+    onUninstall: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = app.displayName,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f)
+                )
+                AppStatusBadge(app = app, isSeated = isSeated)
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = "${app.domain} · v${app.majorVersion}.${app.minorVersion}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                if (!isSeated && app.isUsable()) {
+                    TextButton(
+                        onClick = onSetActive,
+                        modifier = Modifier.defaultMinSize(minHeight = 44.dp)
+                    ) {
+                        Text("Set Active")
+                    }
+                }
+                if (app.isUsable()) {
+                    TextButton(
+                        onClick = onArchive,
+                        modifier = Modifier.defaultMinSize(minHeight = 44.dp)
+                    ) {
+                        Text("Archive")
+                    }
+                }
+                TextButton(
+                    onClick = onUninstall,
+                    modifier = Modifier.defaultMinSize(minHeight = 44.dp)
+                ) {
+                    Text(
+                        text = "Uninstall",
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AppStatusBadge(app: ApplicationRecord, isSeated: Boolean) {
+    val (label, color) = when {
+        isSeated && app.isUsable() -> "Active" to MaterialTheme.colorScheme.primary
+        app.isArchived() -> "Archived" to MaterialTheme.colorScheme.tertiary
+        else -> "Installed" to MaterialTheme.colorScheme.onSurfaceVariant
+    }
+    Text(
+        text = label,
+        style = MaterialTheme.typography.labelMedium,
+        color = color
+    )
+}

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/LoginScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/LoginScreen.kt
@@ -2,6 +2,7 @@ package org.commcare.app.ui
 
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,12 +13,17 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -29,18 +35,24 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import org.commcare.app.model.ApplicationRecord
 import org.commcare.app.state.AppState
 import org.commcare.app.viewmodel.LoginViewModel
 
 @Composable
 fun LoginScreen(
     viewModel: LoginViewModel,
-    onDemoMode: (() -> Unit)? = null
+    onDemoMode: (() -> Unit)? = null,
+    seatedApp: ApplicationRecord? = null,
+    allApps: List<ApplicationRecord> = emptyList(),
+    onSwitchApp: ((ApplicationRecord) -> Unit)? = null,
+    onAppManager: (() -> Unit)? = null
 ) {
     val isLoggingIn = viewModel.appState is AppState.LoggingIn
     val focusManager = LocalFocusManager.current
     val usernameFocus = remember { FocusRequester() }
     val passwordFocus = remember { FocusRequester() }
+    var appDropdownExpanded by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -57,6 +69,49 @@ fun LoginScreen(
             style = MaterialTheme.typography.headlineLarge,
             color = MaterialTheme.colorScheme.primary
         )
+
+        if (seatedApp != null) {
+            Spacer(modifier = Modifier.height(8.dp))
+
+            if (allApps.size > 1 && onSwitchApp != null) {
+                // Show app name as a tappable dropdown trigger
+                Box {
+                    TextButton(
+                        onClick = { appDropdownExpanded = true },
+                        modifier = Modifier.testTag("app_switcher_button")
+                    ) {
+                        Text(
+                            text = "${seatedApp.displayName} ▼",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.secondary
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = appDropdownExpanded,
+                        onDismissRequest = { appDropdownExpanded = false }
+                    ) {
+                        allApps.forEach { app ->
+                            DropdownMenuItem(
+                                text = { Text(app.displayName) },
+                                onClick = {
+                                    appDropdownExpanded = false
+                                    onSwitchApp(app)
+                                },
+                                modifier = Modifier.testTag("app_option_${app.id}")
+                            )
+                        }
+                    }
+                }
+            } else {
+                // Single app — just show as subtitle
+                Text(
+                    text = seatedApp.displayName,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier.testTag("app_name_subtitle")
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.height(32.dp))
 
@@ -127,6 +182,13 @@ fun LoginScreen(
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Text("Enter Demo Mode")
+                }
+            }
+
+            if (onAppManager != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+                TextButton(onClick = onAppManager) {
+                    Text("App Manager", style = MaterialTheme.typography.bodySmall)
                 }
             }
         }

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/AppManagerViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/AppManagerViewModel.kt
@@ -1,0 +1,55 @@
+package org.commcare.app.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import org.commcare.app.model.ApplicationRecord
+import org.commcare.app.storage.AppRecordRepository
+
+class AppManagerViewModel(private val appRepository: AppRecordRepository) {
+    var apps by mutableStateOf<List<ApplicationRecord>>(emptyList())
+        private set
+    var seatedAppId by mutableStateOf<String?>(null)
+        private set
+    var errorMessage by mutableStateOf<String?>(null)
+        private set
+
+    companion object {
+        const val MAX_APPS = 4
+    }
+
+    fun refresh() {
+        apps = appRepository.getAllApps()
+        seatedAppId = appRepository.getSeatedApp()?.id
+    }
+
+    fun canInstallMore(): Boolean = apps.count { it.isUsable() } < MAX_APPS
+
+    fun archiveApp(appId: String) {
+        appRepository.archiveApp(appId)
+        // If archived app was seated, seat the next usable one
+        if (appId == seatedAppId) {
+            val nextApp = appRepository.getAllApps().firstOrNull { it.isUsable() }
+            if (nextApp != null) {
+                appRepository.seatApp(nextApp.id)
+            }
+        }
+        refresh()
+    }
+
+    fun uninstallApp(appId: String) {
+        appRepository.deleteApp(appId)
+        if (appId == seatedAppId) {
+            val nextApp = appRepository.getAllApps().firstOrNull { it.isUsable() }
+            if (nextApp != null) {
+                appRepository.seatApp(nextApp.id)
+            }
+        }
+        refresh()
+    }
+
+    fun seatApp(appId: String) {
+        appRepository.seatApp(appId)
+        seatedAppId = appId
+    }
+}


### PR DESCRIPTION
## Summary

- **AppManagerScreen** — list/archive/uninstall apps, max 4 enforcement
- **App switcher** on login screen (dropdown when multiple apps)
- **Auto-configure** LoginViewModel from seated ApplicationRecord
- **Routing** — AppManager accessible from login screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)