### PR TITLE
fix: Connect ID recovery flow for existing users

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/network/ConnectIdApi.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/network/ConnectIdApi.kt
@@ -86,18 +86,49 @@ class ConnectIdApi(
     }
 
     /**
-     * Check if a display name is available.
+     * Check if a display name is available, and whether the account already exists.
      * POST /users/check_name
+     *
+     * Returns [CheckNameResponse] with `accountExists` (true for recovery flow)
+     * and optionally the existing user's photo (base64).
      */
-    fun checkName(sessionToken: String, name: String): Result<Unit> {
-        return executeSimplePost(
-            "$BASE_URL/users/check_name",
-            "session_token=$sessionToken&name=$name"
-        )
+    fun checkName(sessionToken: String, name: String): Result<CheckNameResponse> {
+        return try {
+            val body = "session_token=$sessionToken&name=$name"
+
+            val response = httpClient.execute(
+                HttpRequest(
+                    url = "$BASE_URL/users/check_name",
+                    method = "POST",
+                    headers = mapOf("Content-Type" to "application/x-www-form-urlencoded"),
+                    body = body.encodeToByteArray(),
+                    contentType = "application/x-www-form-urlencoded"
+                )
+            )
+
+            if (response.code !in 200..299) {
+                val errorMsg = response.errorBody?.decodeToString()
+                    ?: response.body?.decodeToString()
+                    ?: "HTTP ${response.code}"
+                return Result.failure(ConnectIdException(errorMsg))
+            }
+
+            val json = response.body?.decodeToString()
+                ?: return Result.failure(ConnectIdException("Empty response"))
+
+            Result.success(
+                CheckNameResponse(
+                    accountExists = extractJsonBoolean(json, "account_exists") ?: false,
+                    existingPhoto = extractJsonString(json, "photo")
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(ConnectIdException("Name check request failed: ${e.message}", e))
+        }
     }
 
     /**
-     * Confirm a backup/recovery code.
+     * Confirm a backup/recovery code (new registration flow).
      * POST /users/confirm_backup_code
      */
     fun confirmBackupCode(sessionToken: String, code: String): Result<Unit> {
@@ -105,6 +136,49 @@ class ConnectIdApi(
             "$BASE_URL/users/confirm_backup_code",
             "session_token=$sessionToken&backup_code=$code"
         )
+    }
+
+    /**
+     * Confirm a backup code for account recovery (existing user, new device).
+     * POST /users/recover/confirm_backup_code
+     *
+     * In recovery mode the server returns the user's credentials (username, password, db_key)
+     * so the device can re-establish access without creating a new account.
+     */
+    fun confirmBackupCodeRecovery(sessionToken: String, code: String): Result<CompleteProfileResponse> {
+        return try {
+            val body = "session_token=$sessionToken&backup_code=$code"
+
+            val response = httpClient.execute(
+                HttpRequest(
+                    url = "$BASE_URL/users/recover/confirm_backup_code",
+                    method = "POST",
+                    headers = mapOf("Content-Type" to "application/x-www-form-urlencoded"),
+                    body = body.encodeToByteArray(),
+                    contentType = "application/x-www-form-urlencoded"
+                )
+            )
+
+            if (response.code !in 200..299) {
+                val errorMsg = response.errorBody?.decodeToString()
+                    ?: response.body?.decodeToString()
+                    ?: "HTTP ${response.code}"
+                return Result.failure(ConnectIdException("Recovery backup code failed: $errorMsg"))
+            }
+
+            val json = response.body?.decodeToString()
+                ?: return Result.failure(ConnectIdException("Empty response"))
+
+            Result.success(
+                CompleteProfileResponse(
+                    username = extractJsonString(json, "username") ?: "",
+                    password = extractJsonString(json, "password") ?: "",
+                    dbKey = extractJsonString(json, "db_key") ?: ""
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(ConnectIdException("Recovery backup code request failed: ${e.message}", e))
+        }
     }
 
     /**
@@ -304,7 +378,36 @@ class ConnectIdApi(
 
         return sb.toString().toLongOrNull()
     }
+
+    /**
+     * Extract a boolean value from a JSON response.
+     * Matches pattern: "key": true or "key": false
+     */
+    private fun extractJsonBoolean(json: String, key: String): Boolean? {
+        val searchKey = "\"$key\""
+        val keyIdx = json.indexOf(searchKey)
+        if (keyIdx == -1) return null
+
+        val colonIdx = json.indexOf(':', keyIdx + searchKey.length)
+        if (colonIdx == -1) return null
+
+        // Skip whitespace after colon
+        var start = colonIdx + 1
+        while (start < json.length && json[start].isWhitespace()) start++
+        if (start >= json.length) return null
+
+        return when {
+            json.startsWith("true", start) -> true
+            json.startsWith("false", start) -> false
+            else -> null
+        }
+    }
 }
+
+data class CheckNameResponse(
+    val accountExists: Boolean,
+    val existingPhoto: String?  // base64 photo of existing user (for recovery confirmation)
+)
 
 data class CompleteProfileResponse(
     val username: String,

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/BackupCodeStep.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/BackupCodeStep.kt
@@ -22,26 +22,44 @@ import org.commcare.app.viewmodel.ConnectIdViewModel
 
 @Composable
 fun BackupCodeStep(viewModel: ConnectIdViewModel) {
+    val isRecovery = viewModel.isRecoveryFlow
+
     Column(modifier = Modifier.fillMaxWidth().padding(24.dp)) {
         Text(
-            text = "Set a backup code",
+            text = if (isRecovery) "Enter your backup code" else "Set a backup code",
             style = MaterialTheme.typography.titleLarge
         )
 
         Spacer(modifier = Modifier.height(8.dp))
 
         Text(
-            text = "This 6-digit code helps you recover your account",
+            text = if (isRecovery) {
+                "Enter the 6-digit code you saved during registration"
+            } else {
+                "This 6-digit code helps you recover your account"
+            },
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+
+        // In recovery mode, show reminder of existing user photo if available
+        if (isRecovery && viewModel.existingUserPhoto != null) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Recovering your existing account",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
 
         Spacer(modifier = Modifier.height(24.dp))
 
         OutlinedTextField(
             value = viewModel.backupCode,
             onValueChange = { if (it.length <= 6) viewModel.backupCode = it },
-            label = { Text("6-digit backup code") },
+            label = {
+                Text(if (isRecovery) "Enter backup code" else "6-digit backup code")
+            },
             modifier = Modifier.fillMaxWidth().testTag("backup_code_field"),
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
@@ -63,7 +81,7 @@ fun BackupCodeStep(viewModel: ConnectIdViewModel) {
                 modifier = Modifier.fillMaxWidth().testTag("continue_button"),
                 enabled = viewModel.backupCode.length == 6
             ) {
-                Text("Continue")
+                Text(if (isRecovery) "Verify" else "Continue")
             }
         }
     }

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/ConnectIdViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/ConnectIdViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.commcare.app.model.ConnectIdUser
 import org.commcare.app.model.RegistrationSession
+import org.commcare.app.network.CheckNameResponse
 import org.commcare.app.network.ConnectIdApi
 import org.commcare.app.platform.PlatformKeychainStore
 import org.commcare.app.storage.ConnectIdRepository
@@ -38,6 +39,12 @@ class ConnectIdViewModel(
     var photoBase64 by mutableStateOf<String?>(null)
     var securityMethod by mutableStateOf("pin")  // "pin" or "biometric"
     var devicePin by mutableStateOf("")
+
+    // Recovery flow state — set when check_name returns account_exists=true
+    var isRecoveryFlow by mutableStateOf(false)
+        private set
+    var existingUserPhoto by mutableStateOf<String?>(null)
+        private set
 
     // Server state
     private var session: RegistrationSession? = null
@@ -92,7 +99,7 @@ class ConnectIdViewModel(
         }
     }
 
-    // Step 3: Submit name
+    // Step 3: Submit name — check_name response determines new vs recovery flow
     fun submitName() {
         val token = session?.sessionToken ?: return
         if (fullName.isBlank()) { errorMessage = "Name required"; return }
@@ -101,24 +108,53 @@ class ConnectIdViewModel(
             val result = api.checkName(token, fullName)
             isLoading = false
             result.fold(
-                onSuccess = { currentStep = RegistrationStep.BACKUP_CODE },
+                onSuccess = { response: CheckNameResponse ->
+                    if (response.accountExists) {
+                        // Recovery flow: existing user on a new device
+                        isRecoveryFlow = true
+                        existingUserPhoto = response.existingPhoto?.takeIf { it.isNotEmpty() }
+                        // Skip PHOTO_CAPTURE — go straight to BACKUP_CODE (input mode)
+                    }
+                    currentStep = RegistrationStep.BACKUP_CODE
+                },
                 onFailure = { errorMessage = "Name check failed: ${it.message}" }
             )
         }
     }
 
-    // Step 4: Submit backup code
+    // Step 4: Submit backup code — branches on recovery vs new registration
     fun submitBackupCode() {
         val token = session?.sessionToken ?: return
         if (backupCode.length < 6) { errorMessage = "Enter a 6-digit backup code"; return }
         isLoading = true; errorMessage = null
         scope.launch {
-            val result = api.confirmBackupCode(token, backupCode)
-            isLoading = false
-            result.fold(
-                onSuccess = { currentStep = RegistrationStep.PHOTO_CAPTURE },
-                onFailure = { errorMessage = "Failed: ${it.message}" }
-            )
+            if (isRecoveryFlow) {
+                // Recovery: verify existing backup code and receive credentials
+                val result = api.confirmBackupCodeRecovery(token, backupCode)
+                isLoading = false
+                result.fold(
+                    onSuccess = { response ->
+                        createdUsername = response.username
+                        createdPassword = response.password
+                        dbKey = response.dbKey
+                        // Store recovered credentials securely
+                        keychainStore.store("connect_username", response.username)
+                        keychainStore.store("connect_password", response.password)
+                        keychainStore.store("connect_db_key", response.dbKey)
+                        // Skip PHOTO_CAPTURE + ACCOUNT_CREATION, go to biometric
+                        currentStep = RegistrationStep.BIOMETRIC_SETUP
+                    },
+                    onFailure = { errorMessage = "Invalid backup code: ${it.message}" }
+                )
+            } else {
+                // New registration: set backup code, then proceed to photo capture
+                val result = api.confirmBackupCode(token, backupCode)
+                isLoading = false
+                result.fold(
+                    onSuccess = { currentStep = RegistrationStep.PHOTO_CAPTURE },
+                    onFailure = { errorMessage = "Failed: ${it.message}" }
+                )
+            }
         }
     }
 
@@ -178,14 +214,17 @@ class ConnectIdViewModel(
         // Reset wizard state — caller handles navigation
     }
 
-    // Navigation
+    // Navigation — recovery flow skips PHOTO_CAPTURE and ACCOUNT_CREATION
     fun goBack() {
         currentStep = when (currentStep) {
             RegistrationStep.OTP_VERIFICATION -> RegistrationStep.PHONE_ENTRY
             RegistrationStep.NAME_ENTRY -> RegistrationStep.OTP_VERIFICATION
             RegistrationStep.BACKUP_CODE -> RegistrationStep.NAME_ENTRY
             RegistrationStep.PHOTO_CAPTURE -> RegistrationStep.BACKUP_CODE
-            RegistrationStep.BIOMETRIC_SETUP -> RegistrationStep.PHOTO_CAPTURE
+            RegistrationStep.BIOMETRIC_SETUP -> {
+                if (isRecoveryFlow) RegistrationStep.BACKUP_CODE
+                else RegistrationStep.PHOTO_CAPTURE
+            }
             else -> currentStep  // can't go back from PHONE_ENTRY, ACCOUNT_CREATION, SUCCESS
         }
         errorMessage = null

--- a/docs/learnings/2026-03-19-connect-id-recovery-flow-gap.md
+++ b/docs/learnings/2026-03-19-connect-id-recovery-flow-gap.md
@@ -1,0 +1,35 @@
+# Connect ID Recovery Flow Was Missing From Wave 5 Implementation
+
+**Date:** 2026-03-19
+**Context:** Phase 5 Wave 5 (Connect ID) implemented only the new-user registration flow. The recovery flow (existing user, new device) was mentioned in a single line of the spec but never implemented.
+
+## What Happened
+
+The Phase 5 spec (Section 4.7) described the 8-step registration wizard in detail but only included recovery as a one-line footnote:
+
+> "Recovery flow (existing user, new device): Phone → Biometric → Backup Code → Photo → Success."
+
+This line was also incorrect — the actual recovery flow is Phone → OTP → Name → Backup Code (input, not set) → Biometric → Success, with no photo step.
+
+The implementation plan (Wave 5 Tasks 1-5) never mentioned recovery. The ConnectIdViewModel was built as a linear 8-step wizard with no branching logic.
+
+## The Actual Branching Point
+
+The ConnectID server determines new vs recovery at the `check_name` step:
+- `POST /users/check_name` returns `account_exists: true/false`
+- If `true`: user already exists → recovery mode → enter existing backup code → get credentials
+- If `false`: new user → set backup code → capture photo → create account
+
+This is a single API response field that switches the entire second half of the wizard.
+
+## Root Cause
+
+The spec was written based on high-level Android code reading but missed this critical branching logic. The `PersonalIdBackupCodeFragment` in Android switches between "display mode" (new registration) and "input mode" (recovery) based on `sessionData.accountExists`, but this detail wasn't captured in the spec.
+
+## Lesson
+
+When speccing a multi-step wizard that talks to an external server:
+1. Document the **response shape** of each API call, not just the endpoint
+2. Identify **branching points** where server responses change the flow
+3. Write acceptance criteria for BOTH the happy path AND the recovery/error paths
+4. Don't bury alternate flows in footnotes — give them their own section with the same level of detail


### PR DESCRIPTION
## Summary

Add recovery flow branching to Connect ID wizard. `check_name` response's `account_exists` flag determines new vs recovery path. Includes learning doc on the spec gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)