### PR TITLE
fix: OTP field name 'otp' not 'token' in confirm_session_otp

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/network/ConnectIdApi.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/network/ConnectIdApi.kt
@@ -80,13 +80,13 @@ class ConnectIdApi(
      * Confirm an OTP code.
      * POST /users/confirm_session_otp
      * Authorization: Bearer <session_token>
-     * Body: token=<otp_code>
+     * Body: {"otp":"<code>"}
      */
     fun confirmOtp(sessionToken: String, otp: String): Result<Unit> {
         return executeAuthenticatedPost(
             "$BASE_URL/users/confirm_session_otp",
             sessionToken,
-            body = """{"token":"$otp"}"""
+            body = """{"otp":"$otp"}"""
         )
     }
 


### PR DESCRIPTION
Confirmed via curl: JSON body needs {"otp":"code"} not {"token":"code"}