### PR TITLE
feat: Wave D — Connect app download buttons + install flow

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/App.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/App.kt
@@ -65,6 +65,8 @@ fun App(db: CommCareDatabase) {
     // When non-null, ConnectScreen opens at the given tab ("opportunities" or "messaging")
     var connectInitialTab by remember { mutableStateOf("opportunities") }
     var connectIdRegistered by remember { mutableStateOf(connectIdRepository.isRegistered()) }
+    // When non-null, an in-progress Connect app download is pending install
+    var pendingConnectInstall by remember { mutableStateOf<Pair<String, String>?>(null) }
 
     MaterialTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
@@ -83,13 +85,51 @@ fun App(db: CommCareDatabase) {
                 return@Surface
             }
 
+            // Handle a Connect-initiated app install: run the standard install-progress
+            // screen, then return to Connect opportunities when done.
+            if (pendingConnectInstall != null) {
+                val (installUrl, _) = pendingConnectInstall!!
+                // Kick off the install if not already running
+                if (appInstallViewModel.installState is InstallState.Idle) {
+                    appInstallViewModel.install(installUrl)
+                }
+                when (val installState = appInstallViewModel.installState) {
+                    is InstallState.Installing, is InstallState.Failed -> {
+                        InstallProgressScreen(
+                            viewModel = appInstallViewModel,
+                            onCancel = {
+                                appInstallViewModel.reset()
+                                pendingConnectInstall = null
+                                showOpportunities = true
+                            },
+                            onRetry = {
+                                appInstallViewModel.reset()
+                                appInstallViewModel.install(installUrl)
+                            }
+                        )
+                    }
+                    is InstallState.Completed -> {
+                        // Install succeeded — return to Connect screen
+                        appInstallViewModel.reset()
+                        pendingConnectInstall = null
+                        showOpportunities = true
+                    }
+                    is InstallState.Idle -> { /* waiting for install to start */ }
+                }
+                return@Surface
+            }
+
             // Show ConnectScreen overlay when requested
             if (showOpportunities) {
                 ConnectScreen(
                     api = marketplaceApi,
                     tokenManager = connectIdTokenManager,
                     onBack = { showOpportunities = false },
-                    initialTab = connectInitialTab
+                    initialTab = connectInitialTab,
+                    onDownloadApp = { installUrl, appName ->
+                        showOpportunities = false
+                        pendingConnectInstall = Pair(installUrl, appName)
+                    }
                 )
                 return@Surface
             }

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/ConnectScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/ConnectScreen.kt
@@ -22,13 +22,19 @@ import org.commcare.app.viewmodel.OpportunitiesViewModel
  *
  * The [initialTab] parameter lets callers deep-link to "messaging" directly
  * (e.g. when the user taps Messaging in the navigation drawer).
+ *
+ * The optional [onDownloadApp] callback is invoked when the user requests to
+ * download a learn or deliver app.  The caller (App.kt) wires this to the
+ * AppInstallViewModel so that the standard install-progress screen is shown.
+ * When null, download buttons are hidden.
  */
 @Composable
 fun ConnectScreen(
     api: ConnectMarketplaceApi,
     tokenManager: ConnectIdTokenManager,
     onBack: () -> Unit,
-    initialTab: String = "opportunities"
+    initialTab: String = "opportunities",
+    onDownloadApp: ((installUrl: String, appName: String) -> Unit)? = null
 ) {
     val opportunitiesViewModel = remember { OpportunitiesViewModel(api, tokenManager) }
     val messagingViewModel = remember { MessagingViewModel(api, tokenManager) }
@@ -51,7 +57,8 @@ fun ConnectScreen(
             onBack = {
                 opportunitiesViewModel.clearSelection()
                 currentScreen = "opportunities"
-            }
+            },
+            onDownloadApp = onDownloadApp
         )
 
         "messaging" -> MessagingScreen(

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/DeliveryProgressScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/DeliveryProgressScreen.kt
@@ -45,13 +45,18 @@ private enum class DeliveryFilter(val label: String) {
 /**
  * Shows delivery progress for a claimed opportunity:
  * a list of delivery records with status, summary stats, and filter buttons.
- * Includes a "Start Delivery" button that would launch the CommCare deliver app.
+ * Includes a "Start Delivery" / "Download Deliver App" button.
+ *
+ * When [onDownloadApp] is provided and the opportunity has a deliver app with an
+ * install URL, a "Download Deliver App" button is shown alongside (or in place of)
+ * the "Start Delivery" button so the user can install the app first.
  */
 @Composable
 fun DeliveryProgressScreen(
     viewModel: OpportunitiesViewModel,
     opportunity: Opportunity,
-    onStartDelivery: (() -> Unit)? = null
+    onStartDelivery: (() -> Unit)? = null,
+    onDownloadApp: ((installUrl: String, appName: String) -> Unit)? = null
 ) {
     val detail = viewModel.deliveryProgress
     var selectedFilter by remember { mutableStateOf(DeliveryFilter.ALL) }
@@ -131,18 +136,30 @@ fun DeliveryProgressScreen(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Start Delivery button
-        val hasDeliverApp = opportunity.deliverApp != null
-        Button(
-            onClick = { onStartDelivery?.invoke() },
-            enabled = hasDeliverApp && onStartDelivery != null,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Start Delivery")
-        }
+        // Deliver app action buttons
+        val deliverApp = opportunity.deliverApp
+        val deliverInstallUrl = deliverApp?.installUrl
+        if (deliverApp != null) {
+            // Show "Download Deliver App" if an install URL is available
+            if (onDownloadApp != null && !deliverInstallUrl.isNullOrBlank()) {
+                Button(
+                    onClick = { onDownloadApp(deliverInstallUrl, deliverApp.name) },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Download Deliver App")
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
 
-        if (!hasDeliverApp) {
-            Spacer(modifier = Modifier.height(4.dp))
+            // "Start Delivery" is shown when a caller provides onStartDelivery
+            Button(
+                onClick = { onStartDelivery?.invoke() },
+                enabled = onStartDelivery != null,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Start Delivery")
+            }
+        } else {
             Text(
                 text = "No delivery app configured for this opportunity.",
                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/LearnProgressScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/LearnProgressScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.LinearProgressIndicator
@@ -25,13 +26,34 @@ import org.commcare.app.viewmodel.OpportunitiesViewModel
 /**
  * Shows the learning progress for a claimed opportunity with completed modules,
  * assessments, and an overall progress indicator.
+ *
+ * When [onDownloadApp] is provided and the opportunity has a learn app with an
+ * install URL, a "Download Learn App" button is shown so the user can install
+ * the app via the standard install-progress screen.
  */
 @Composable
-fun LearnProgressScreen(viewModel: OpportunitiesViewModel) {
+fun LearnProgressScreen(
+    viewModel: OpportunitiesViewModel,
+    onDownloadApp: ((installUrl: String, appName: String) -> Unit)? = null
+) {
     val detail = viewModel.learnProgress
     val opp = viewModel.selectedOpportunity
 
     Column(modifier = Modifier.fillMaxSize()) {
+        // Download Learn App button — shown when a learn app install URL is available
+        val learnApp = opp?.learnApp
+        val learnInstallUrl = learnApp?.installUrl
+        if (onDownloadApp != null && !learnInstallUrl.isNullOrBlank()) {
+            Button(
+                onClick = { onDownloadApp(learnInstallUrl, learnApp.name) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+                Text("Download Learn App")
+            }
+        }
+
         if (detail == null) {
             Text(
                 text = "No learning data available",

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/OpportunityDetailScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/OpportunityDetailScreen.kt
@@ -73,11 +73,15 @@ private fun determineJobStep(opp: Opportunity): Int {
  * and "Start Learning" button.
  * Claimed: shows 4-step progress indicator and tabbed sections for
  * Learn, Deliver, and Payments.
+ *
+ * [onDownloadApp] is forwarded to the Learn / Deliver sub-screens so they can
+ * show download buttons.  When null, download buttons are hidden.
  */
 @Composable
 fun OpportunityDetailScreen(
     viewModel: OpportunitiesViewModel,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onDownloadApp: ((installUrl: String, appName: String) -> Unit)? = null
 ) {
     val opp = viewModel.selectedOpportunity ?: return
 
@@ -167,8 +171,15 @@ fun OpportunityDetailScreen(
 
             // Tab content
             when (selectedTab) {
-                DetailTab.LEARN -> LearnProgressScreen(viewModel = viewModel)
-                DetailTab.DELIVER -> DeliveryProgressScreen(viewModel = viewModel, opportunity = opp)
+                DetailTab.LEARN -> LearnProgressScreen(
+                    viewModel = viewModel,
+                    onDownloadApp = onDownloadApp
+                )
+                DetailTab.DELIVER -> DeliveryProgressScreen(
+                    viewModel = viewModel,
+                    opportunity = opp,
+                    onDownloadApp = onDownloadApp
+                )
                 DetailTab.PAYMENTS -> PaymentScreen(viewModel = viewModel)
             }
         } else {


### PR DESCRIPTION
Download Learn/Deliver apps from opportunity detail. Closes Connect screen, shows install progress, returns after install.