### PR TITLE
fix: Keychain storage, AppDependencies extraction, Connect test coverage

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/App.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/App.kt
@@ -11,13 +11,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import org.commcare.app.network.ConnectIdApi
-import org.commcare.app.network.ConnectMarketplaceApi
-import org.commcare.app.platform.PlatformKeychainStore
 import org.commcare.app.state.AppState
-import org.commcare.app.storage.AppRecordRepository
 import org.commcare.app.storage.CommCareDatabase
-import org.commcare.app.storage.ConnectIdRepository
 import org.commcare.app.ui.AppManagerScreen
 import org.commcare.app.ui.EnterCodeScreen
 import org.commcare.app.ui.HomeScreen
@@ -32,31 +27,17 @@ import org.commcare.app.ui.connect.PersonalIdScreen
 import org.commcare.app.ui.PinEntryScreen
 import org.commcare.app.viewmodel.AppInstallViewModel
 import org.commcare.app.viewmodel.AppManagerViewModel
-import org.commcare.app.viewmodel.ConnectIdTokenManager
-import org.commcare.app.viewmodel.ConnectIdViewModel
-import org.commcare.app.viewmodel.DemoModeManager
 import org.commcare.app.viewmodel.InstallState
-import org.commcare.app.viewmodel.LoginViewModel
 import org.commcare.app.viewmodel.SetupStep
 import org.commcare.app.viewmodel.SetupViewModel
 import org.commcare.app.viewmodel.UserKeyRecordManager
 
 @Composable
 fun App(db: CommCareDatabase) {
-    val appRepository = remember { AppRecordRepository(db) }
-    val connectIdRepository = remember { ConnectIdRepository(db) }
-    val connectIdApi = remember { ConnectIdApi() }
-    val keychainStore = remember { PlatformKeychainStore() }
-    val connectIdViewModel = remember { ConnectIdViewModel(connectIdApi, connectIdRepository, keychainStore) }
-    val keyRecordManager = remember { UserKeyRecordManager(db, keychainStore) }
-    val loginViewModel = remember {
-        LoginViewModel(db).also { it.setKeyRecordManager(keyRecordManager) }
-    }
-    val demoModeManager = remember { DemoModeManager(db) }
-    val setupViewModel = remember { SetupViewModel() }
-    val appInstallViewModel = remember { AppInstallViewModel(db, appRepository) }
-    val marketplaceApi = remember { ConnectMarketplaceApi() }
-    val connectIdTokenManager = remember { ConnectIdTokenManager(connectIdApi, connectIdRepository, keychainStore) }
+    val deps = remember { AppDependencies(db) }
+    val appRepository = deps.appRepository
+    val loginViewModel = deps.loginViewModel
+    val appInstallViewModel = deps.appInstallViewModel
 
     // Track whether any apps are installed; starts false on first launch
     val hasApps = remember { mutableStateOf(appRepository.getAppCount() > 0) }
@@ -65,7 +46,7 @@ fun App(db: CommCareDatabase) {
     var showOpportunities by remember { mutableStateOf(false) }
     // When non-null, ConnectScreen opens at the given tab ("opportunities" or "messaging")
     var connectInitialTab by remember { mutableStateOf("opportunities") }
-    var connectIdRegistered by remember { mutableStateOf(connectIdRepository.isRegistered()) }
+    var connectIdRegistered by remember { mutableStateOf(deps.connectIdRepository.isRegistered()) }
     // When non-null, an in-progress Connect app download is pending install
     var pendingConnectInstall by remember { mutableStateOf<Pair<String, String>?>(null) }
 
@@ -76,10 +57,10 @@ fun App(db: CommCareDatabase) {
             // Show PersonalIdScreen overlay when registration is requested
             if (showPersonalIdRegistration) {
                 PersonalIdScreen(
-                    viewModel = connectIdViewModel,
+                    viewModel = deps.connectIdViewModel,
                     onComplete = {
                         showPersonalIdRegistration = false
-                        connectIdRegistered = connectIdRepository.isRegistered()
+                        connectIdRegistered = deps.connectIdRepository.isRegistered()
                     },
                     onCancel = { showPersonalIdRegistration = false }
                 )
@@ -123,8 +104,8 @@ fun App(db: CommCareDatabase) {
             // Show ConnectScreen overlay when requested
             if (showOpportunities) {
                 ConnectScreen(
-                    api = marketplaceApi,
-                    tokenManager = connectIdTokenManager,
+                    api = deps.marketplaceApi,
+                    tokenManager = deps.connectIdTokenManager,
                     onBack = { showOpportunities = false },
                     initialTab = connectInitialTab,
                     onDownloadApp = { installUrl, appName ->
@@ -153,8 +134,7 @@ fun App(db: CommCareDatabase) {
             if (!hasApps.value) {
                 // No apps installed — show setup flow (including install progress within it)
                 SetupFlow(
-                    setupViewModel = setupViewModel,
-                    loginViewModel = loginViewModel,
+                    setupViewModel = deps.setupViewModel,
                     appInstallViewModel = appInstallViewModel,
                     hasApps = hasApps,
                     onSignUpPersonalId = { showPersonalIdRegistration = true },
@@ -169,7 +149,7 @@ fun App(db: CommCareDatabase) {
                     is AppState.LoginError -> LoginScreen(
                         viewModel = loginViewModel,
                         onDemoMode = {
-                            val demoState = demoModeManager.enterDemoMode()
+                            val demoState = deps.demoModeManager.enterDemoMode()
                             if (demoState != null) {
                                 loginViewModel.setReadyState(demoState)
                             }
@@ -227,7 +207,7 @@ fun App(db: CommCareDatabase) {
                                 LoginScreen(
                                     viewModel = loginViewModel,
                                     onDemoMode = {
-                                        val demoState = demoModeManager.enterDemoMode()
+                                        val demoState = deps.demoModeManager.enterDemoMode()
                                         if (demoState != null) {
                                             loginViewModel.setReadyState(demoState)
                                         }
@@ -268,7 +248,7 @@ fun App(db: CommCareDatabase) {
                             connectInitialTab = "messaging"
                             showOpportunities = true
                         },
-                        keyRecordManager = keyRecordManager
+                        keyRecordManager = deps.keyRecordManager
                     )
                     is AppState.AppCorrupted -> InstallErrorScreen(
                         AppState.InstallError("App corrupted: ${appState.message}")
@@ -282,7 +262,6 @@ fun App(db: CommCareDatabase) {
 @Composable
 private fun SetupFlow(
     setupViewModel: SetupViewModel,
-    loginViewModel: LoginViewModel,
     appInstallViewModel: AppInstallViewModel,
     hasApps: MutableState<Boolean>,
     onSignUpPersonalId: (() -> Unit)? = null,
@@ -315,23 +294,6 @@ private fun SetupFlow(
             return
         }
         is InstallState.Idle -> { /* fall through to setup navigation */ }
-    }
-
-    // If loginViewModel's older install path is still active (e.g. login→install flow),
-    // show the legacy install screens so they aren't broken.
-    when (val loginState = loginViewModel.appState) {
-        is AppState.Installing -> {
-            InstallScreen(loginState)
-            return
-        }
-        is AppState.InstallError -> {
-            InstallErrorScreen(loginState) {
-                loginViewModel.resetError()
-                setupViewModel.backToMain()
-            }
-            return
-        }
-        else -> { /* fall through to setup navigation */ }
     }
 
     when (setupViewModel.currentStep) {

--- a/app/src/commonMain/kotlin/org/commcare/app/AppDependencies.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/AppDependencies.kt
@@ -1,0 +1,41 @@
+package org.commcare.app
+
+import org.commcare.app.network.ConnectIdApi
+import org.commcare.app.network.ConnectMarketplaceApi
+import org.commcare.app.platform.PlatformKeychainStore
+import org.commcare.app.storage.AppRecordRepository
+import org.commcare.app.storage.CommCareDatabase
+import org.commcare.app.storage.ConnectIdRepository
+import org.commcare.app.viewmodel.AppInstallViewModel
+import org.commcare.app.viewmodel.ConnectIdTokenManager
+import org.commcare.app.viewmodel.ConnectIdViewModel
+import org.commcare.app.viewmodel.DemoModeManager
+import org.commcare.app.viewmodel.LoginViewModel
+import org.commcare.app.viewmodel.SetupViewModel
+import org.commcare.app.viewmodel.UserKeyRecordManager
+
+/**
+ * Simple dependency container that constructs all app-level services and ViewModels once.
+ * Created via `remember {}` in [App] so instances survive recomposition but are
+ * tied to the composable lifecycle. Not a DI framework — just a single place to
+ * wire constructor dependencies instead of scattering them across the composable body.
+ */
+class AppDependencies(db: CommCareDatabase) {
+    // -- Repositories & services --
+    val appRepository = AppRecordRepository(db)
+    val connectIdRepository = ConnectIdRepository(db)
+    val connectIdApi = ConnectIdApi()
+    val keychainStore = PlatformKeychainStore()
+    val marketplaceApi = ConnectMarketplaceApi()
+
+    // -- Managers --
+    val keyRecordManager = UserKeyRecordManager(db, keychainStore)
+    val demoModeManager = DemoModeManager(db)
+    val connectIdTokenManager = ConnectIdTokenManager(connectIdApi, connectIdRepository, keychainStore)
+
+    // -- ViewModels --
+    val connectIdViewModel = ConnectIdViewModel(connectIdApi, connectIdRepository, keychainStore)
+    val loginViewModel = LoginViewModel(db).also { it.setKeyRecordManager(keyRecordManager) }
+    val setupViewModel = SetupViewModel()
+    val appInstallViewModel = AppInstallViewModel(db, appRepository)
+}

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/LoginViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/LoginViewModel.kt
@@ -30,7 +30,6 @@ class LoginViewModel(private val db: CommCareDatabase) {
     // Internal — not shown in UI. Will come from ApplicationRecord in Wave 2.
     private var serverUrl = "https://www.commcarehq.org"
     private var appId = ""
-    private var profileUrl = ""
     private var currentApp: ApplicationRecord? = null
 
     var appState by mutableStateOf<AppState>(AppState.LoggedOut)
@@ -72,58 +71,6 @@ class LoginViewModel(private val db: CommCareDatabase) {
         this.serverUrl = serverUrl
         this.appId = appId
         this.currentApp = app
-    }
-
-    /**
-     * Set the profile URL directly — used by the setup flow when the user scans/enters a URL
-     * before logging in.
-     */
-    fun setProfileUrl(url: String) {
-        this.profileUrl = url
-    }
-
-    /**
-     * Install an app directly from the configured profileUrl, without requiring server login.
-     * Used by the setup flow to install a CommCare app from a profile URL or barcode.
-     */
-    fun startInstall() {
-        scope.launch {
-            try {
-                val sandbox = SqlDelightUserSandbox(db)
-                val installer = AppInstaller(sandbox)
-
-                val resolvedProfileUrl = profileUrl
-                if (resolvedProfileUrl.isBlank()) {
-                    appState = AppState.InstallError("No profile URL configured")
-                    return@launch
-                }
-
-                appState = AppState.Installing(0.1f, "Starting installation...")
-                val platform = installer.install(resolvedProfileUrl) { progress, message ->
-                    appState = AppState.Installing(progress, message)
-                }
-
-                val profileDisplayName = try {
-                    platform.getCurrentProfile().getDisplayName() ?: "CommCare"
-                } catch (_: Exception) {
-                    "CommCare"
-                }
-
-                val app = ApplicationRecord(
-                    id = appId.ifBlank { "installed" },
-                    profileUrl = resolvedProfileUrl,
-                    displayName = profileDisplayName,
-                    domain = "",
-                    majorVersion = platform.majorVersion,
-                    minorVersion = platform.minorVersion,
-                    installDate = 0L
-                )
-                this@LoginViewModel.sandbox = sandbox
-                appState = AppState.NeedsLogin(app, listOf(app))
-            } catch (e: Exception) {
-                appState = AppState.InstallError("Installation failed: ${e.message}")
-            }
-        }
     }
 
     fun login() {
@@ -219,15 +166,23 @@ class LoginViewModel(private val db: CommCareDatabase) {
         }
     }
 
+    /**
+     * Post-login app installation. Called after successful server auth + restore parsing.
+     * Builds the profile URL from [appId] and installs the app, or falls back to a
+     * minimal platform when no appId is configured (development mode).
+     *
+     * This is intentionally separate from [AppInstallViewModel.install], which handles
+     * the pre-login fresh-install flow (setup screen, Connect downloads). This method
+     * runs after the user is already authenticated and their sandbox is populated.
+     */
     private fun installApp(sandbox: SqlDelightUserSandbox, domain: String) {
         try {
             val installer = AppInstaller(sandbox)
 
-            // Build profile URL from appId if no explicit profileUrl set
-            val resolvedProfileUrl = when {
-                profileUrl.isNotBlank() -> profileUrl
-                appId.isNotBlank() -> "${serverUrl.trimEnd('/')}/a/$domain/apps/download/$appId/profile.ccpr"
-                else -> ""
+            val resolvedProfileUrl = if (appId.isNotBlank()) {
+                "${serverUrl.trimEnd('/')}/a/$domain/apps/download/$appId/profile.ccpr"
+            } else {
+                ""
             }
 
             if (resolvedProfileUrl.isNotBlank()) {

--- a/app/src/iosMain/kotlin/org/commcare/app/platform/PlatformKeychainStore.kt
+++ b/app/src/iosMain/kotlin/org/commcare/app/platform/PlatformKeychainStore.kt
@@ -1,37 +1,97 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
+
 package org.commcare.app.platform
 
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import platform.CoreFoundation.CFDictionaryRef
+import platform.CoreFoundation.CFTypeRefVar
+import platform.Foundation.CFBridgingRelease
+import platform.Foundation.NSData
 import platform.Foundation.NSString
-import platform.Foundation.NSUserDefaults
+import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.create
+import platform.Foundation.dataUsingEncoding
+import platform.Security.SecItemAdd
+import platform.Security.SecItemCopyMatching
+import platform.Security.SecItemDelete
+import platform.Security.kSecAttrAccessible
+import platform.Security.kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+import platform.Security.kSecAttrAccount
+import platform.Security.kSecAttrService
+import platform.Security.kSecClass
+import platform.Security.kSecClassGenericPassword
+import platform.Security.kSecMatchLimit
+import platform.Security.kSecMatchLimitOne
+import platform.Security.kSecReturnData
+import platform.Security.kSecValueData
+import platform.Security.errSecSuccess
 
-private const val PREFIX = "commcare_secure_"
+private const val SERVICE_NAME = "org.commcare.ios"
 
 /**
  * iOS implementation of PlatformKeychainStore.
- * Uses NSUserDefaults with explicit NSString bridging to avoid K/N CPointer cast issues.
+ * Uses the iOS Security framework Keychain for secure credential storage.
  *
- * TODO: Replace with proper Keychain via Swift helper for App Store builds.
+ * Stores items as kSecClassGenericPassword with a fixed service name
+ * and per-key account names. Items are accessible only when the device
+ * is unlocked and are not included in backups (ThisDeviceOnly).
  */
 actual class PlatformKeychainStore actual constructor() {
-    private val defaults = NSUserDefaults.standardUserDefaults
 
     actual fun store(key: String, value: String) {
-        // Explicitly create NSString to ensure proper bridging
-        val nsKey = NSString.create(string = PREFIX + key)
-        val nsValue = NSString.create(string = value)
-        defaults.setObject(nsValue, forKey = nsKey.toString())
-        defaults.synchronize()
+        // Delete any existing item first to avoid errSecDuplicateItem
+        delete(key)
+
+        val valueData = NSString.create(string = value)
+            .dataUsingEncoding(NSUTF8StringEncoding) ?: return
+
+        val query = mapOf<Any?, Any?>(
+            kSecClass to kSecClassGenericPassword,
+            kSecAttrService to SERVICE_NAME,
+            kSecAttrAccount to key,
+            kSecValueData to valueData,
+            kSecAttrAccessible to kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        SecItemAdd(query as CFDictionaryRef, null)
     }
 
     actual fun retrieve(key: String): String? {
-        val nsKey = NSString.create(string = PREFIX + key)
-        val obj = defaults.objectForKey(nsKey.toString()) ?: return null
-        return obj.toString()
+        val query = mapOf<Any?, Any?>(
+            kSecClass to kSecClassGenericPassword,
+            kSecAttrService to SERVICE_NAME,
+            kSecAttrAccount to key,
+            kSecReturnData to true,
+            kSecMatchLimit to kSecMatchLimitOne
+        )
+
+        return memScoped {
+            val result = alloc<CFTypeRefVar>()
+
+            @Suppress("UNCHECKED_CAST")
+            val status = SecItemCopyMatching(query as CFDictionaryRef, result.ptr)
+
+            if (status != errSecSuccess) {
+                return null
+            }
+
+            val data = CFBridgingRelease(result.value) as? NSData ?: return null
+            NSString.create(data = data, encoding = NSUTF8StringEncoding) as? String
+        }
     }
 
     actual fun delete(key: String) {
-        val nsKey = NSString.create(string = PREFIX + key)
-        defaults.removeObjectForKey(nsKey.toString())
-        defaults.synchronize()
+        val query = mapOf<Any?, Any?>(
+            kSecClass to kSecClassGenericPassword,
+            kSecAttrService to SERVICE_NAME,
+            kSecAttrAccount to key
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        SecItemDelete(query as CFDictionaryRef)
     }
 }

--- a/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectIdApiJsonTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectIdApiJsonTest.kt
@@ -1,0 +1,414 @@
+package org.commcare.app.network
+
+import org.commcare.core.interfaces.HttpRequest
+import org.commcare.core.interfaces.HttpResponse
+import org.commcare.core.interfaces.PlatformHttpClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for ConnectIdApi JSON parsing through its public API methods.
+ *
+ * Uses a mock PlatformHttpClient that returns controlled JSON responses to
+ * exercise the private extractJsonString, extractJsonNumber, extractJsonBoolean,
+ * and escapeJson helpers inside ConnectIdApi.
+ */
+class ConnectIdApiJsonTest {
+
+    /** A mock HTTP client that returns a pre-configured response. */
+    private class MockHttpClient(
+        private val responseCode: Int = 200,
+        private val responseBody: String? = null,
+        private val errorBody: String? = null
+    ) : PlatformHttpClient {
+        var lastRequest: HttpRequest? = null
+            private set
+
+        override fun execute(request: HttpRequest): HttpResponse {
+            lastRequest = request
+            return HttpResponse(
+                code = responseCode,
+                headers = emptyMap(),
+                body = responseBody?.encodeToByteArray(),
+                errorBody = errorBody?.encodeToByteArray()
+            )
+        }
+    }
+
+    // =====================================================================
+    // startConfiguration — exercises extractJsonString
+    // =====================================================================
+
+    @Test
+    fun testStartConfiguration_basicJsonParsing() {
+        val json = """{"token":"abc123","sms_method":"firebase","required_lock":"pin"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.startConfiguration("+15551234567")
+        assertTrue(result.isSuccess)
+        val session = result.getOrThrow()
+        assertEquals("abc123", session.sessionToken)
+        assertEquals("firebase", session.smsMethod)
+        assertEquals("pin", session.requiredLock)
+    }
+
+    @Test
+    fun testStartConfiguration_jsonWithWhitespace() {
+        val json = """{ "token" : "tok-456" , "sms_method" : "twilio" , "required_lock" : "password" }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.startConfiguration("+15551234567")
+        assertTrue(result.isSuccess)
+        val session = result.getOrThrow()
+        assertEquals("tok-456", session.sessionToken)
+        assertEquals("twilio", session.smsMethod)
+        assertEquals("password", session.requiredLock)
+    }
+
+    @Test
+    fun testStartConfiguration_missingFields_defaultsToEmpty() {
+        // Only "token" present, other keys missing
+        val json = """{"token":"tok-only"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.startConfiguration("+15551234567")
+        assertTrue(result.isSuccess)
+        val session = result.getOrThrow()
+        assertEquals("tok-only", session.sessionToken)
+        // Missing keys should default to their fallback values
+        assertEquals("firebase", session.smsMethod)
+        assertEquals("pin", session.requiredLock)
+    }
+
+    @Test
+    fun testStartConfiguration_emptyResponse_fails() {
+        val client = MockHttpClient(responseBody = null)
+        val api = ConnectIdApi(client)
+
+        val result = api.startConfiguration("+15551234567")
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun testStartConfiguration_httpError_fails() {
+        val client = MockHttpClient(responseCode = 400, responseBody = """{"error":"bad request"}""")
+        val api = ConnectIdApi(client)
+
+        val result = api.startConfiguration("+15551234567")
+        assertTrue(result.isFailure)
+        val ex = result.exceptionOrNull()
+        assertNotNull(ex)
+        assertTrue(ex.message!!.contains("400"))
+    }
+
+    @Test
+    fun testStartConfiguration_jsonWithEscapedQuotesInValue() {
+        // The value contains escaped quotes: token is: abc\"def
+        val json = """{"token":"abc\"def","sms_method":"firebase","required_lock":"pin"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.startConfiguration("+15551234567")
+        assertTrue(result.isSuccess)
+        // The escaped quote in the JSON value should be included literally as: abc\"def
+        // (ConnectIdApi's extractJsonString does not unescape JSON escape sequences)
+        val session = result.getOrThrow()
+        assertEquals("abc\\\"def", session.sessionToken)
+    }
+
+    @Test
+    fun testStartConfiguration_emptyStringValues() {
+        val json = """{"token":"","sms_method":"","required_lock":""}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.startConfiguration("+15551234567")
+        assertTrue(result.isSuccess)
+        val session = result.getOrThrow()
+        assertEquals("", session.sessionToken)
+        assertEquals("", session.smsMethod)
+        assertEquals("", session.requiredLock)
+    }
+
+    // =====================================================================
+    // getOAuthToken — exercises extractJsonString + extractJsonNumber
+    // =====================================================================
+
+    @Test
+    fun testGetOAuthToken_basicParsing() {
+        val json = """{"access_token":"at-xyz-789","expires_in":7200,"token_type":"Bearer"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.getOAuthToken("user@test", "pass123")
+        assertTrue(result.isSuccess)
+        val tokens = result.getOrThrow()
+        assertEquals("at-xyz-789", tokens.accessToken)
+        assertEquals(7200L, tokens.expiresIn)
+    }
+
+    @Test
+    fun testGetOAuthToken_missingExpiresIn_defaultsTo3600() {
+        val json = """{"access_token":"at-abc","token_type":"Bearer"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.getOAuthToken("user@test", "pass123")
+        assertTrue(result.isSuccess)
+        val tokens = result.getOrThrow()
+        assertEquals("at-abc", tokens.accessToken)
+        assertEquals(3600L, tokens.expiresIn)
+    }
+
+    @Test
+    fun testGetOAuthToken_missingAccessToken_fails() {
+        val json = """{"token_type":"Bearer","expires_in":3600}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.getOAuthToken("user@test", "pass123")
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()!!.message!!.contains("access_token"))
+    }
+
+    @Test
+    fun testGetOAuthToken_largeExpiresIn() {
+        val json = """{"access_token":"at-123","expires_in":86400}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.getOAuthToken("user", "pass")
+        assertTrue(result.isSuccess)
+        assertEquals(86400L, result.getOrThrow().expiresIn)
+    }
+
+    @Test
+    fun testGetOAuthToken_sendsCorrectFormBody() {
+        val json = """{"access_token":"at-123","expires_in":3600}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        api.getOAuthToken("user@test.com", "p@ss w0rd!")
+        val body = client.lastRequest!!.body!!.decodeToString()
+        assertTrue(body.contains("grant_type=password"))
+        assertTrue(body.contains("client_id="))
+        // username and password should be form-url-encoded
+        assertTrue(body.contains("username=user%40test.com"))
+        assertTrue(body.contains("password=p%40ss+w0rd%21"))
+    }
+
+    @Test
+    fun testGetOAuthToken_expiresInWithWhitespace() {
+        val json = """{"access_token": "at-ws", "expires_in": 1800}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.getOAuthToken("user", "pass")
+        assertTrue(result.isSuccess)
+        assertEquals("at-ws", result.getOrThrow().accessToken)
+        assertEquals(1800L, result.getOrThrow().expiresIn)
+    }
+
+    // =====================================================================
+    // checkName — exercises extractJsonBoolean + extractJsonString
+    // =====================================================================
+
+    @Test
+    fun testCheckName_accountExists_true() {
+        val json = """{"account_exists":true,"photo":"base64data=="}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.checkName("session-tok", "John")
+        assertTrue(result.isSuccess)
+        val resp = result.getOrThrow()
+        assertTrue(resp.accountExists)
+        assertEquals("base64data==", resp.existingPhoto)
+    }
+
+    @Test
+    fun testCheckName_accountExists_false() {
+        val json = """{"account_exists":false}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.checkName("session-tok", "NewUser")
+        assertTrue(result.isSuccess)
+        val resp = result.getOrThrow()
+        assertFalse(resp.accountExists)
+        assertNull(resp.existingPhoto)
+    }
+
+    @Test
+    fun testCheckName_booleanWithWhitespace() {
+        val json = """{"account_exists" : true , "photo" : null}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.checkName("session-tok", "User")
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().accountExists)
+        // photo is JSON null, so should be returned as null
+        assertNull(result.getOrThrow().existingPhoto)
+    }
+
+    @Test
+    fun testCheckName_missingAccountExists_defaultsFalse() {
+        val json = """{"photo":"somedata"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.checkName("session-tok", "User")
+        assertTrue(result.isSuccess)
+        assertFalse(result.getOrThrow().accountExists)
+    }
+
+    // =====================================================================
+    // completeProfile — exercises multiple extractJsonString calls
+    // =====================================================================
+
+    @Test
+    fun testCompleteProfile_parsesAllFields() {
+        val json = """{"username":"user123","password":"p@ss","db_key":"key-abc"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.completeProfile("session-tok", "John", "1234", "photo-base64")
+        assertTrue(result.isSuccess)
+        val resp = result.getOrThrow()
+        assertEquals("user123", resp.username)
+        assertEquals("p@ss", resp.password)
+        assertEquals("key-abc", resp.dbKey)
+    }
+
+    @Test
+    fun testCompleteProfile_escapesNameInBody() {
+        val json = """{"username":"u","password":"p","db_key":"k"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        api.completeProfile("session-tok", "John \"Doe\"", "1234", "photo")
+        val body = client.lastRequest!!.body!!.decodeToString()
+        // The name with quotes should be escaped in the request body
+        assertTrue(body.contains("John \\\"Doe\\\""), "Name should be JSON-escaped in request body")
+    }
+
+    // =====================================================================
+    // fetchDbKey — exercises extractJsonString for single field extraction
+    // =====================================================================
+
+    @Test
+    fun testFetchDbKey_success() {
+        val json = """{"db_key":"encryption-key-12345"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.fetchDbKey("access-token")
+        assertTrue(result.isSuccess)
+        assertEquals("encryption-key-12345", result.getOrThrow())
+    }
+
+    @Test
+    fun testFetchDbKey_missingKey_fails() {
+        val json = """{"other_field":"value"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.fetchDbKey("access-token")
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull()!!.message!!.contains("db_key"))
+    }
+
+    @Test
+    fun testFetchDbKey_nullValue_fails() {
+        // ConnectIdApi's extractJsonString sees null as no match since it looks for '"' after ':'
+        val json = """{"db_key":null}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.fetchDbKey("access-token")
+        assertTrue(result.isFailure)
+    }
+
+    // =====================================================================
+    // confirmOtp / sendOtp — exercises authenticated POST path
+    // =====================================================================
+
+    @Test
+    fun testSendOtp_successOnHttp200() {
+        val client = MockHttpClient(responseCode = 200, responseBody = """{"status":"sent"}""")
+        val api = ConnectIdApi(client)
+
+        val result = api.sendOtp("session-token")
+        assertTrue(result.isSuccess)
+        // Verify authorization header is set
+        assertEquals("Bearer session-token", client.lastRequest!!.headers["Authorization"])
+    }
+
+    @Test
+    fun testConfirmOtp_successOnHttp200() {
+        val client = MockHttpClient(responseCode = 200, responseBody = "{}")
+        val api = ConnectIdApi(client)
+
+        val result = api.confirmOtp("session-token", "123456")
+        assertTrue(result.isSuccess)
+        val body = client.lastRequest!!.body!!.decodeToString()
+        assertTrue(body.contains("123456"))
+    }
+
+    @Test
+    fun testConfirmOtp_failsOnHttp401() {
+        val client = MockHttpClient(responseCode = 401, errorBody = "Unauthorized")
+        val api = ConnectIdApi(client)
+
+        val result = api.confirmOtp("bad-token", "123456")
+        assertTrue(result.isFailure)
+    }
+
+    // =====================================================================
+    // Edge cases for JSON value extraction
+    // =====================================================================
+
+    @Test
+    fun testJsonParsingWithUnicodeValues() {
+        val json = """{"token":"tok-\u00e9\u00e0\u00fc","sms_method":"firebase","required_lock":"pin"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.startConfiguration("+15551234567")
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun testJsonParsingWithNestedBraces() {
+        // The token value doesn't contain braces, but the JSON has extra fields with objects
+        val json = """{"token":"tok-nested","extra":{"nested":true},"sms_method":"firebase","required_lock":"pin"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.startConfiguration("+15551234567")
+        assertTrue(result.isSuccess)
+        assertEquals("tok-nested", result.getOrThrow().sessionToken)
+    }
+
+    @Test
+    fun testConfirmBackupCodeRecovery_parsesCredentials() {
+        val json = """{"username":"recovered_user","password":"new_pass_123","db_key":"recov-key"}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectIdApi(client)
+
+        val result = api.confirmBackupCodeRecovery("session-tok", "backup-code")
+        assertTrue(result.isSuccess)
+        val resp = result.getOrThrow()
+        assertEquals("recovered_user", resp.username)
+        assertEquals("new_pass_123", resp.password)
+        assertEquals("recov-key", resp.dbKey)
+    }
+}

--- a/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectIdTokenManagerTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectIdTokenManagerTest.kt
@@ -1,0 +1,231 @@
+package org.commcare.app.network
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import org.commcare.app.platform.PlatformKeychainStore
+import org.commcare.app.storage.CommCareDatabase
+import org.commcare.app.storage.ConnectIdRepository
+import org.commcare.app.viewmodel.ConnectIdTokenManager
+import org.commcare.core.interfaces.HttpRequest
+import org.commcare.core.interfaces.HttpResponse
+import org.commcare.core.interfaces.PlatformHttpClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for ConnectIdTokenManager's OAuth token caching, expiry, and refresh logic.
+ *
+ * Uses the JVM in-memory PlatformKeychainStore and a mock ConnectIdApi (via
+ * mock PlatformHttpClient) to verify token lifecycle behavior without network calls.
+ */
+class ConnectIdTokenManagerTest {
+
+    /** Mock HTTP client that returns configurable OAuth token responses. */
+    private class MockOAuthHttpClient(
+        private var tokenResponse: String = """{"access_token":"mock-token","expires_in":3600}""",
+        private var responseCode: Int = 200
+    ) : PlatformHttpClient {
+        var requestCount = 0
+            private set
+        var lastRequest: HttpRequest? = null
+            private set
+
+        fun setNextResponse(token: String, expiresIn: Long) {
+            tokenResponse = """{"access_token":"$token","expires_in":$expiresIn}"""
+        }
+
+        fun setFailure() {
+            responseCode = 401
+        }
+
+        fun setSuccess() {
+            responseCode = 200
+        }
+
+        override fun execute(request: HttpRequest): HttpResponse {
+            requestCount++
+            lastRequest = request
+            return HttpResponse(
+                code = responseCode,
+                headers = emptyMap(),
+                body = if (responseCode in 200..299) tokenResponse.encodeToByteArray() else null,
+                errorBody = if (responseCode !in 200..299) "Unauthorized".encodeToByteArray() else null
+            )
+        }
+    }
+
+    private fun createTestDatabase(): CommCareDatabase {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        CommCareDatabase.Schema.create(driver)
+        return CommCareDatabase(driver)
+    }
+
+    private fun createManager(
+        httpClient: MockOAuthHttpClient = MockOAuthHttpClient(),
+        keychain: PlatformKeychainStore = PlatformKeychainStore()
+    ): Triple<ConnectIdTokenManager, MockOAuthHttpClient, PlatformKeychainStore> {
+        val db = createTestDatabase()
+        val repo = ConnectIdRepository(db)
+        val api = ConnectIdApi(httpClient)
+        val manager = ConnectIdTokenManager(api, repo, keychain)
+        return Triple(manager, httpClient, keychain)
+    }
+
+    // =====================================================================
+    // getConnectIdToken — caching + expiry
+    // =====================================================================
+
+    @Test
+    fun testGetConnectIdToken_returnsNull_whenNoCredentials() {
+        val (manager, _, _) = createManager()
+        // No username/password stored in keychain
+        assertNull(manager.getConnectIdToken())
+    }
+
+    @Test
+    fun testGetConnectIdToken_fetchesNewToken_whenNoCache() {
+        val httpClient = MockOAuthHttpClient()
+        httpClient.setNextResponse("fresh-token", 3600)
+        val keychain = PlatformKeychainStore()
+        keychain.store("connect_username", "testuser")
+        keychain.store("connect_password", "testpass")
+
+        val (manager, _, _) = createManager(httpClient, keychain)
+
+        val token = manager.getConnectIdToken()
+        assertEquals("fresh-token", token)
+        assertEquals(1, httpClient.requestCount)
+    }
+
+    @Test
+    fun testGetConnectIdToken_returnsCached_whenNotExpired() {
+        val httpClient = MockOAuthHttpClient()
+        httpClient.setNextResponse("cached-token", 3600)
+        val keychain = PlatformKeychainStore()
+        keychain.store("connect_username", "testuser")
+        keychain.store("connect_password", "testpass")
+
+        val (manager, _, _) = createManager(httpClient, keychain)
+
+        // First call — fetches from API
+        val token1 = manager.getConnectIdToken()
+        assertEquals("cached-token", token1)
+        assertEquals(1, httpClient.requestCount)
+
+        // Second call — should return from cache without new API call
+        httpClient.setNextResponse("new-token", 3600)
+        val token2 = manager.getConnectIdToken()
+        assertEquals("cached-token", token2)
+        assertEquals(1, httpClient.requestCount, "Should not make a second API call when cache is valid")
+    }
+
+    @Test
+    fun testGetConnectIdToken_refreshes_whenExpired() {
+        val httpClient = MockOAuthHttpClient()
+        httpClient.setNextResponse("first-token", 3600)
+        val keychain = PlatformKeychainStore()
+        keychain.store("connect_username", "testuser")
+        keychain.store("connect_password", "testpass")
+
+        val (manager, _, _) = createManager(httpClient, keychain)
+
+        // First call fetches token
+        val token1 = manager.getConnectIdToken()
+        assertEquals("first-token", token1)
+
+        // Simulate expiry by setting the expiry to a past timestamp
+        keychain.store("connect_token_expiry", "0")
+
+        httpClient.setNextResponse("refreshed-token", 7200)
+        val token2 = manager.getConnectIdToken()
+        assertEquals("refreshed-token", token2)
+        assertEquals(2, httpClient.requestCount, "Should make a second API call after expiry")
+    }
+
+    // =====================================================================
+    // refreshConnectIdToken
+    // =====================================================================
+
+    @Test
+    fun testRefreshConnectIdToken_returnsNull_whenNoCredentials() {
+        val (manager, _, _) = createManager()
+        assertNull(manager.refreshConnectIdToken())
+    }
+
+    @Test
+    fun testRefreshConnectIdToken_returnsNull_whenMissingPassword() {
+        val keychain = PlatformKeychainStore()
+        keychain.store("connect_username", "testuser")
+        // No password stored
+
+        val (manager, _, _) = createManager(keychain = keychain)
+        assertNull(manager.refreshConnectIdToken())
+    }
+
+    @Test
+    fun testRefreshConnectIdToken_returnsNull_whenApiFails() {
+        val httpClient = MockOAuthHttpClient()
+        httpClient.setFailure()
+        val keychain = PlatformKeychainStore()
+        keychain.store("connect_username", "testuser")
+        keychain.store("connect_password", "testpass")
+
+        val (manager, _, _) = createManager(httpClient, keychain)
+        assertNull(manager.refreshConnectIdToken())
+    }
+
+    @Test
+    fun testRefreshConnectIdToken_storesTokenAndExpiry() {
+        val httpClient = MockOAuthHttpClient()
+        httpClient.setNextResponse("stored-token", 3600)
+        val keychain = PlatformKeychainStore()
+        keychain.store("connect_username", "testuser")
+        keychain.store("connect_password", "testpass")
+
+        val (manager, _, _) = createManager(httpClient, keychain)
+
+        val token = manager.refreshConnectIdToken()
+        assertEquals("stored-token", token)
+
+        // Verify token is stored in keychain
+        assertEquals("stored-token", keychain.retrieve("connect_access_token"))
+        // Verify expiry is stored (should be currentEpochSeconds + expiresIn - 60)
+        val expiryStr = keychain.retrieve("connect_token_expiry")
+        assertNotNull(expiryStr)
+        val expiry = expiryStr.toLong()
+        // The expiry should be a reasonable future timestamp (> current epoch)
+        assertTrue(expiry > 0, "Expiry should be a positive timestamp")
+    }
+
+    // =====================================================================
+    // isRegistered
+    // =====================================================================
+
+    @Test
+    fun testIsRegistered_falseByDefault() {
+        val (manager, _, _) = createManager()
+        assertFalse(manager.isRegistered())
+    }
+
+    // =====================================================================
+    // getStoredUsername
+    // =====================================================================
+
+    @Test
+    fun testGetStoredUsername_nullWhenNotStored() {
+        val (manager, _, _) = createManager()
+        assertNull(manager.getStoredUsername())
+    }
+
+    @Test
+    fun testGetStoredUsername_returnsStoredValue() {
+        val keychain = PlatformKeychainStore()
+        keychain.store("connect_username", "john@example.com")
+
+        val (manager, _, _) = createManager(keychain = keychain)
+        assertEquals("john@example.com", manager.getStoredUsername())
+    }
+}

--- a/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectMarketplaceApiJsonTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectMarketplaceApiJsonTest.kt
@@ -1,0 +1,618 @@
+package org.commcare.app.network
+
+import org.commcare.core.interfaces.HttpRequest
+import org.commcare.core.interfaces.HttpResponse
+import org.commcare.core.interfaces.PlatformHttpClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for ConnectMarketplaceApi JSON parsing through its public API methods.
+ *
+ * Uses a mock PlatformHttpClient that returns controlled JSON responses to
+ * exercise the private JSON parsing helpers (extractJsonString, extractJsonInt,
+ * extractJsonBoolean, extractJsonObjectByKey, extractJsonArrayByKey, splitJsonArray,
+ * parseStringMap) inside ConnectMarketplaceApi.
+ */
+class ConnectMarketplaceApiJsonTest {
+
+    /** A mock HTTP client that returns a pre-configured response. */
+    private class MockHttpClient(
+        private val responseCode: Int = 200,
+        private val responseBody: String? = null,
+        private val errorBody: String? = null
+    ) : PlatformHttpClient {
+        var lastRequest: HttpRequest? = null
+            private set
+
+        override fun execute(request: HttpRequest): HttpResponse {
+            lastRequest = request
+            return HttpResponse(
+                code = responseCode,
+                headers = emptyMap(),
+                body = responseBody?.encodeToByteArray(),
+                errorBody = errorBody?.encodeToByteArray()
+            )
+        }
+    }
+
+    // =====================================================================
+    // getOpportunities — exercises splitJsonArray + parseOpportunity (complex)
+    // =====================================================================
+
+    @Test
+    fun testGetOpportunities_emptyArray() {
+        val client = MockHttpClient(responseBody = "[]")
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunities("access-token")
+        assertTrue(result.isSuccess)
+        assertEquals(0, result.getOrThrow().size)
+    }
+
+    @Test
+    fun testGetOpportunities_singleMinimalOpportunity() {
+        val json = """[{"id":42,"opportunity_id":"opp-1","name":"Test Opp","description":"Desc","organization":"Org","is_active":true}]"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunities("access-token")
+        assertTrue(result.isSuccess)
+        val opps = result.getOrThrow()
+        assertEquals(1, opps.size)
+        assertEquals(42, opps[0].id)
+        assertEquals("opp-1", opps[0].opportunityId)
+        assertEquals("Test Opp", opps[0].name)
+        assertEquals("Desc", opps[0].description)
+        assertEquals("Org", opps[0].organization)
+        assertTrue(opps[0].isActive)
+    }
+
+    @Test
+    fun testGetOpportunities_multipleOpportunities() {
+        val json = """[{"id":1,"opportunity_id":"opp-a","name":"First","description":"A","organization":"Org1","is_active":true},{"id":2,"opportunity_id":"opp-b","name":"Second","description":"B","organization":"Org2","is_active":false}]"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunities("access-token")
+        assertTrue(result.isSuccess)
+        val opps = result.getOrThrow()
+        assertEquals(2, opps.size)
+        assertEquals("First", opps[0].name)
+        assertEquals("Second", opps[1].name)
+        assertFalse(opps[1].isActive)
+    }
+
+    @Test
+    fun testGetOpportunities_httpError() {
+        val client = MockHttpClient(responseCode = 500, errorBody = "Internal Server Error")
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunities("access-token")
+        assertTrue(result.isFailure)
+    }
+
+    // =====================================================================
+    // getOpportunityDetail — exercises nested object parsing
+    // =====================================================================
+
+    @Test
+    fun testGetOpportunityDetail_withNestedObjects() {
+        val json = """{
+            "id": 10,
+            "opportunity_id": "opp-detail",
+            "name": "Detailed Opp",
+            "description": "Full description here",
+            "organization": "Org",
+            "is_active": true,
+            "learn_app": {
+                "id": 5,
+                "cc_domain": "test-domain",
+                "cc_app_id": "app-123",
+                "name": "Learn App",
+                "description": "Learning",
+                "organization": "Org",
+                "learn_modules": [],
+                "passing_score": 80
+            },
+            "deliver_app": {
+                "id": 6,
+                "cc_domain": "test-domain",
+                "cc_app_id": "app-456",
+                "name": "Deliver App",
+                "description": "Delivering",
+                "organization": "Org",
+                "learn_modules": [],
+                "passing_score": -1
+            },
+            "max_visits_per_user": 100,
+            "budget_per_visit": 50,
+            "currency": "USD"
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 10)
+        assertTrue(result.isSuccess)
+        val opp = result.getOrThrow()
+        assertEquals(10, opp.id)
+        assertEquals("Detailed Opp", opp.name)
+        assertEquals(100, opp.maxVisitsPerUser)
+        assertEquals(50, opp.budgetPerVisit)
+        assertEquals("USD", opp.currency)
+
+        // Nested learn_app
+        assertNotNull(opp.learnApp)
+        assertEquals("Learn App", opp.learnApp!!.name)
+        assertEquals("test-domain", opp.learnApp!!.ccDomain)
+        assertEquals("app-123", opp.learnApp!!.ccAppId)
+        assertEquals(80, opp.learnApp!!.passingScore)
+
+        // Nested deliver_app
+        assertNotNull(opp.deliverApp)
+        assertEquals("Deliver App", opp.deliverApp!!.name)
+        assertEquals("app-456", opp.deliverApp!!.ccAppId)
+    }
+
+    @Test
+    fun testGetOpportunityDetail_withNullNestedObjects() {
+        val json = """{
+            "id": 11,
+            "opportunity_id": "opp-null",
+            "name": "No Apps",
+            "description": "Opp without apps",
+            "organization": "Org",
+            "is_active": false,
+            "learn_app": null,
+            "deliver_app": null,
+            "claim": null
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 11)
+        assertTrue(result.isSuccess)
+        val opp = result.getOrThrow()
+        assertNull(opp.learnApp)
+        assertNull(opp.deliverApp)
+        assertNull(opp.claim)
+    }
+
+    @Test
+    fun testGetOpportunityDetail_withLearnModules() {
+        val json = """{
+            "id": 12,
+            "opportunity_id": "opp-modules",
+            "name": "With Modules",
+            "description": "Has modules",
+            "organization": "Org",
+            "is_active": true,
+            "learn_app": {
+                "id": 7,
+                "cc_domain": "domain",
+                "cc_app_id": "app-789",
+                "name": "App",
+                "description": "Desc",
+                "organization": "Org",
+                "learn_modules": [
+                    {"id": 1, "slug": "mod-1", "name": "Module 1", "description": "First", "time_estimate": 30},
+                    {"id": 2, "slug": "mod-2", "name": "Module 2", "description": "Second", "time_estimate": 45}
+                ],
+                "passing_score": 70
+            }
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 12)
+        assertTrue(result.isSuccess)
+        val modules = result.getOrThrow().learnApp!!.learnModules
+        assertEquals(2, modules.size)
+        assertEquals("mod-1", modules[0].slug)
+        assertEquals("Module 1", modules[0].name)
+        assertEquals(30, modules[0].timeEstimate)
+        assertEquals("mod-2", modules[1].slug)
+        assertEquals(45, modules[1].timeEstimate)
+    }
+
+    @Test
+    fun testGetOpportunityDetail_withClaim() {
+        val json = """{
+            "id": 13,
+            "opportunity_id": "opp-claimed",
+            "name": "Claimed",
+            "description": "D",
+            "organization": "O",
+            "is_active": true,
+            "claim": {
+                "id": 99,
+                "max_payments": 50,
+                "end_date": "2026-12-31",
+                "date_claimed": "2026-01-15",
+                "payment_units": [
+                    {"max_visits": 10, "payment_unit": 1, "payment_unit_id": "pu-1"}
+                ]
+            }
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 13)
+        assertTrue(result.isSuccess)
+        val claim = result.getOrThrow().claim
+        assertNotNull(claim)
+        assertEquals(99, claim.id)
+        assertEquals(50, claim.maxPayments)
+        assertEquals("2026-12-31", claim.endDate)
+        assertEquals("2026-01-15", claim.dateClaimed)
+        assertEquals(1, claim.paymentUnits.size)
+        assertEquals(10, claim.paymentUnits[0].maxVisits)
+        assertEquals("pu-1", claim.paymentUnits[0].paymentUnitId)
+    }
+
+    // =====================================================================
+    // getLearnProgress — exercises extractJsonArrayByKey + nested objects
+    // =====================================================================
+
+    @Test
+    fun testGetLearnProgress_parsesCompletedModulesAndAssessments() {
+        val json = """{
+            "completed_modules": [
+                {"id": 1, "module": 10, "date": "2026-03-01", "duration": "00:30:00"},
+                {"id": 2, "module": 11, "date": "2026-03-02", "duration": null}
+            ],
+            "assessments": [
+                {"id": 100, "date": "2026-03-03", "score": 85, "passing_score": 70, "passed": true}
+            ]
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getLearnProgress("access-token", 1)
+        assertTrue(result.isSuccess)
+        val progress = result.getOrThrow()
+        assertEquals(2, progress.completedModules.size)
+        assertEquals(10, progress.completedModules[0].module)
+        assertEquals("2026-03-01", progress.completedModules[0].date)
+        assertEquals("00:30:00", progress.completedModules[0].duration)
+        assertNull(progress.completedModules[1].duration)
+
+        assertEquals(1, progress.assessments.size)
+        assertEquals(85, progress.assessments[0].score)
+        assertEquals(70, progress.assessments[0].passingScore)
+        assertTrue(progress.assessments[0].passed)
+    }
+
+    @Test
+    fun testGetLearnProgress_emptyArrays() {
+        val json = """{"completed_modules": [], "assessments": []}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getLearnProgress("access-token", 1)
+        assertTrue(result.isSuccess)
+        assertEquals(0, result.getOrThrow().completedModules.size)
+        assertEquals(0, result.getOrThrow().assessments.size)
+    }
+
+    @Test
+    fun testGetLearnProgress_missingArrayKeys_defaultsToEmpty() {
+        // No completed_modules or assessments keys
+        val json = """{}"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getLearnProgress("access-token", 1)
+        assertTrue(result.isSuccess)
+        assertEquals(0, result.getOrThrow().completedModules.size)
+        assertEquals(0, result.getOrThrow().assessments.size)
+    }
+
+    // =====================================================================
+    // getDeliveryProgress — exercises complex nested parsing with flags map
+    // =====================================================================
+
+    @Test
+    fun testGetDeliveryProgress_fullResponse() {
+        val json = """{
+            "deliveries": [
+                {
+                    "id": 1,
+                    "status": "approved",
+                    "visit_date": "2026-03-10",
+                    "deliver_unit_name": "Visit",
+                    "deliver_unit_slug": "visit",
+                    "deliver_unit_slug_id": "v1",
+                    "entity_id": "ent-1",
+                    "entity_name": "Patient A",
+                    "reason": null,
+                    "flags": {"gps_valid": "true", "photo_valid": "false"},
+                    "last_modified": "2026-03-10T12:00:00Z"
+                }
+            ],
+            "payments": [
+                {
+                    "id": 10,
+                    "payment_id": "pay-1",
+                    "amount": "50.00",
+                    "date_paid": "2026-03-11",
+                    "confirmed": true,
+                    "confirmation_date": "2026-03-12"
+                }
+            ],
+            "max_payments": 100,
+            "payment_accrued": 50,
+            "end_date": "2026-12-31"
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getDeliveryProgress("access-token", 1)
+        assertTrue(result.isSuccess)
+        val progress = result.getOrThrow()
+
+        // Deliveries
+        assertEquals(1, progress.deliveries.size)
+        val delivery = progress.deliveries[0]
+        assertEquals(1, delivery.id)
+        assertEquals("approved", delivery.status)
+        assertEquals("2026-03-10", delivery.visitDate)
+        assertEquals("Patient A", delivery.entityName)
+        assertNull(delivery.reason)
+        assertEquals("true", delivery.flags["gps_valid"])
+        assertEquals("false", delivery.flags["photo_valid"])
+
+        // Payments
+        assertEquals(1, progress.payments.size)
+        val payment = progress.payments[0]
+        assertEquals(10, payment.id)
+        assertEquals("pay-1", payment.paymentId)
+        assertEquals("50.00", payment.amount)
+        assertTrue(payment.confirmed)
+
+        // Top-level fields
+        assertEquals(100, progress.maxPayments)
+        assertEquals(50, progress.paymentAccrued)
+        assertEquals("2026-12-31", progress.endDate)
+    }
+
+    @Test
+    fun testGetDeliveryProgress_emptyFlags() {
+        val json = """{
+            "deliveries": [
+                {"id": 1, "status": "pending", "flags": {}}
+            ],
+            "payments": [],
+            "max_payments": 10,
+            "payment_accrued": 0
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getDeliveryProgress("access-token", 1)
+        assertTrue(result.isSuccess)
+        assertEquals(0, result.getOrThrow().deliveries[0].flags.size)
+    }
+
+    // =====================================================================
+    // getMessages — exercises splitJsonArray for top-level arrays of objects
+    // =====================================================================
+
+    @Test
+    fun testGetMessages_parsesThreads() {
+        val json = """[
+            {"id": "t1", "participant_name": "Alice", "last_message": "Hello", "last_message_date": "2026-03-10", "unread_count": 2},
+            {"id": "t2", "participant_name": "Bob", "last_message": "Hi there", "last_message_date": "2026-03-09", "unread_count": 0}
+        ]"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getMessages("access-token")
+        assertTrue(result.isSuccess)
+        val threads = result.getOrThrow()
+        assertEquals(2, threads.size)
+        assertEquals("t1", threads[0].id)
+        assertEquals("Alice", threads[0].participantName)
+        assertEquals(2, threads[0].unreadCount)
+        assertEquals("Bob", threads[1].participantName)
+        assertEquals(0, threads[1].unreadCount)
+    }
+
+    @Test
+    fun testGetMessages_emptyList() {
+        val client = MockHttpClient(responseBody = "[]")
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getMessages("access-token")
+        assertTrue(result.isSuccess)
+        assertEquals(0, result.getOrThrow().size)
+    }
+
+    // =====================================================================
+    // getThreadMessages — exercises per-message parsing
+    // =====================================================================
+
+    @Test
+    fun testGetThreadMessages_parsesMessages() {
+        val json = """[
+            {"id": "m1", "thread_id": "t1", "sender_name": "Alice", "content": "Hello!", "timestamp": "2026-03-10T10:00:00Z", "is_from_me": false},
+            {"id": "m2", "thread_id": "t1", "sender_name": "Me", "content": "Hi Alice", "timestamp": "2026-03-10T10:01:00Z", "is_from_me": true}
+        ]"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getThreadMessages("access-token", "t1")
+        assertTrue(result.isSuccess)
+        val messages = result.getOrThrow()
+        assertEquals(2, messages.size)
+        assertFalse(messages[0].isFromMe)
+        assertEquals("Hello!", messages[0].content)
+        assertTrue(messages[1].isFromMe)
+        assertEquals("Hi Alice", messages[1].content)
+    }
+
+    // =====================================================================
+    // JSON edge cases — strings with special characters
+    // =====================================================================
+
+    @Test
+    fun testOpportunityWithEscapedQuotesInDescription() {
+        val json = """[{"id":1,"opportunity_id":"opp-esc","name":"Test","description":"A \"quoted\" description","organization":"Org","is_active":true}]"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunities("access-token")
+        assertTrue(result.isSuccess)
+        val opp = result.getOrThrow()[0]
+        // The marketplace API's extractJsonString properly skips escaped quotes
+        assertEquals("A \\\"quoted\\\" description", opp.description)
+    }
+
+    @Test
+    fun testOpportunityWithNewlinesInDescription() {
+        val json = """[{"id":1,"opportunity_id":"opp-nl","name":"Test","description":"Line1\\nLine2","organization":"Org","is_active":true}]"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunities("access-token")
+        assertTrue(result.isSuccess)
+        // The raw JSON string "Line1\\nLine2" should be extracted as-is
+        assertTrue(result.getOrThrow()[0].description.contains("Line1"))
+    }
+
+    @Test
+    fun testOpportunityWithPaymentUnits() {
+        val json = """{
+            "id": 20,
+            "opportunity_id": "opp-pu",
+            "name": "With Payment Units",
+            "description": "D",
+            "organization": "O",
+            "is_active": true,
+            "payment_units": [
+                {"id": 1, "payment_unit_id": "pu-abc", "name": "Per Visit", "max_total": 100, "max_daily": 10, "amount": 50, "end_date": "2026-12-31"},
+                {"id": 2, "payment_unit_id": "pu-def", "name": "Bonus", "max_total": null, "max_daily": null, "amount": 100, "end_date": null}
+            ]
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 20)
+        assertTrue(result.isSuccess)
+        val units = result.getOrThrow().paymentUnits
+        assertEquals(2, units.size)
+        assertEquals("Per Visit", units[0].name)
+        assertEquals(100, units[0].maxTotal)
+        assertEquals(10, units[0].maxDaily)
+        assertEquals(50, units[0].amount)
+        assertEquals("pu-def", units[1].paymentUnitId)
+        assertNull(units[1].maxTotal)
+        assertNull(units[1].maxDaily)
+    }
+
+    @Test
+    fun testOpportunityWithVerificationFlags() {
+        val json = """{
+            "id": 21,
+            "opportunity_id": "opp-vf",
+            "name": "VF",
+            "description": "D",
+            "organization": "O",
+            "is_active": true,
+            "verification_flags": {
+                "form_submission_start": "2026-01-01",
+                "form_submission_end": "2026-12-31"
+            }
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 21)
+        assertTrue(result.isSuccess)
+        val vf = result.getOrThrow().verificationFlags
+        assertNotNull(vf)
+        assertEquals("2026-01-01", vf.formSubmissionStart)
+        assertEquals("2026-12-31", vf.formSubmissionEnd)
+    }
+
+    @Test
+    fun testOpportunityWithCatchmentAreas() {
+        val json = """{
+            "id": 22,
+            "opportunity_id": "opp-ca",
+            "name": "CA",
+            "description": "D",
+            "organization": "O",
+            "is_active": true,
+            "catchment_areas": [
+                {"id": 1, "name": "Zone A", "latitude": "12.345", "longitude": "67.890", "radius": 500, "active": true},
+                {"id": 2, "name": "Zone B", "latitude": "-1.23", "longitude": "36.82", "radius": 1000, "active": false}
+            ]
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 22)
+        assertTrue(result.isSuccess)
+        val areas = result.getOrThrow().catchmentAreas
+        assertEquals(2, areas.size)
+        assertEquals("Zone A", areas[0].name)
+        assertEquals("12.345", areas[0].latitude)
+        assertEquals(500, areas[0].radius)
+        assertTrue(areas[0].active)
+        assertFalse(areas[1].active)
+    }
+
+    @Test
+    fun testOpportunityWithLearnProgress() {
+        val json = """{
+            "id": 23,
+            "opportunity_id": "opp-lp",
+            "name": "LP",
+            "description": "D",
+            "organization": "O",
+            "is_active": true,
+            "learn_progress": {"total_modules": 5, "completed_modules": 3}
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 23)
+        assertTrue(result.isSuccess)
+        val lp = result.getOrThrow().learnProgress
+        assertNotNull(lp)
+        assertEquals(5, lp.totalModules)
+        assertEquals(3, lp.completedModules)
+    }
+
+    // =====================================================================
+    // Claim + confirm payment
+    // =====================================================================
+
+    @Test
+    fun testClaimOpportunity_sendsCorrectRequest() {
+        val client = MockHttpClient(responseCode = 201, responseBody = "{}")
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.claimOpportunity("access-token", 42)
+        assertTrue(result.isSuccess)
+        assertTrue(client.lastRequest!!.url.endsWith("/api/opportunity/42/claim"))
+        assertEquals("Bearer access-token", client.lastRequest!!.headers["Authorization"])
+    }
+
+    @Test
+    fun testConfirmPayment_sendsCorrectBody() {
+        val client = MockHttpClient(responseCode = 200, responseBody = "{}")
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.confirmPayment("access-token", 99)
+        assertTrue(result.isSuccess)
+        val body = client.lastRequest!!.body!!.decodeToString()
+        assertTrue(body.contains("\"id\":99"))
+        assertTrue(body.contains("\"confirmed\":\"true\""))
+    }
+}

--- a/app/src/jvmTest/kotlin/org/commcare/app/network/UrlEncodingTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/network/UrlEncodingTest.kt
@@ -1,0 +1,96 @@
+package org.commcare.app.network
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests for the formUrlEncode utility function.
+ *
+ * Verifies RFC 3986 percent-encoding behavior: unreserved characters pass through,
+ * spaces become '+', and everything else is percent-encoded with uppercase hex digits.
+ */
+class UrlEncodingTest {
+
+    @Test
+    fun testUnreservedCharacters_notEncoded() {
+        // Letters, digits, and the four unreserved characters: - _ . ~
+        assertEquals("abcXYZ", formUrlEncode("abcXYZ"))
+        assertEquals("0123456789", formUrlEncode("0123456789"))
+        assertEquals("-_.~", formUrlEncode("-_.~"))
+    }
+
+    @Test
+    fun testEmptyString() {
+        assertEquals("", formUrlEncode(""))
+    }
+
+    @Test
+    fun testSpaces_encodedAsPlus() {
+        assertEquals("hello+world", formUrlEncode("hello world"))
+        assertEquals("+++", formUrlEncode("   "))
+    }
+
+    @Test
+    fun testAtSign_percentEncoded() {
+        assertEquals("user%40example.com", formUrlEncode("user@example.com"))
+    }
+
+    @Test
+    fun testSpecialCharacters_percentEncoded() {
+        assertEquals("%21", formUrlEncode("!"))
+        assertEquals("%23", formUrlEncode("#"))
+        assertEquals("%24", formUrlEncode("$"))
+        assertEquals("%25", formUrlEncode("%"))
+        assertEquals("%26", formUrlEncode("&"))
+        assertEquals("%27", formUrlEncode("'"))
+        assertEquals("%2B", formUrlEncode("+"))
+        assertEquals("%2F", formUrlEncode("/"))
+        assertEquals("%3A", formUrlEncode(":"))
+        assertEquals("%3D", formUrlEncode("="))
+        assertEquals("%3F", formUrlEncode("?"))
+    }
+
+    @Test
+    fun testMixedContent() {
+        assertEquals("grant_type%3Dpassword", formUrlEncode("grant_type=password"))
+        assertEquals("p%40ss+w0rd%21", formUrlEncode("p@ss w0rd!"))
+    }
+
+    @Test
+    fun testOAuthClientId_passesThrough() {
+        // The client ID contains only unreserved characters
+        val clientId = "zqFUtAAMrxmjnC1Ji74KAa6ZpY1mZly0J0PlalIa"
+        assertEquals(clientId, formUrlEncode(clientId))
+    }
+
+    @Test
+    fun testUnicodeCharacters_percentEncodedAsUtf8() {
+        // e-acute (U+00E9) encodes to UTF-8 bytes C3 A9
+        assertEquals("%C3%A9", formUrlEncode("\u00e9"))
+        // CJK character (U+4E16) encodes to UTF-8 bytes E4 B8 96
+        assertEquals("%E4%B8%96", formUrlEncode("\u4e16"))
+    }
+
+    @Test
+    fun testHexDigitsAreUppercase() {
+        // Verify that percent-encoding uses uppercase hex (A-F not a-f)
+        val encoded = formUrlEncode("@")  // @ = 0x40
+        assertEquals("%40", encoded)
+        // Check a byte that has a-f in hex: [ = 0x5B
+        val encoded2 = formUrlEncode("[")
+        assertEquals("%5B", encoded2)
+    }
+
+    @Test
+    fun testSlashAndQueryString() {
+        assertEquals("https%3A%2F%2Fexample.com%2Fpath%3Fkey%3Dvalue", formUrlEncode("https://example.com/path?key=value"))
+    }
+
+    @Test
+    fun testFormBodySegment() {
+        // Simulate encoding a typical form body value with special chars
+        val username = "user+name@test.com"
+        val encoded = formUrlEncode(username)
+        assertEquals("user%2Bname%40test.com", encoded)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the remaining 3 issues from the codebase review (#309, #320, #327).

### iOS Keychain (#309)
- `PlatformKeychainStore` now uses iOS Security framework (`SecItemAdd`/`SecItemCopyMatching`/`SecItemDelete`) instead of NSUserDefaults
- Credentials protected with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` — not backed up to iCloud, not accessible when device is locked

### App Architecture (#327)
- Extracted `AppDependencies` container — all ViewModels/services constructed once via `remember {}` instead of 12 separate blocks in the composition body
- Removed dead `LoginViewModel.startInstall()` divergent install path
- Two intentional install paths remain with clear separation: pre-login (`AppInstallViewModel`) and post-login (`LoginViewModel.installApp`)

### Connect Test Coverage (#320)
- 74 new tests across 4 test files:
  - `ConnectIdApiJsonTest` (28) — JSON extraction edge cases
  - `ConnectMarketplaceApiJsonTest` (24) — recursive JSON parsing
  - `ConnectIdTokenManagerTest` (11) — OAuth caching lifecycle
  - `UrlEncodingTest` (11) — percent-encoding

Closes #309, #320, #327

## Test plan
- [x] iOS compilation passes (Keychain APIs compile)
- [x] JVM compilation passes (AppDependencies, LoginViewModel changes)
- [x] 74 new tests pass
- [ ] CI validates

🤖 Generated with [Claude Code](https://claude.ai/code)