### PR TITLE
feat: Connect marketplace data model rework — nested types + lifecycle fields

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/model/ConnectMarketplaceModels.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/model/ConnectMarketplaceModels.kt
@@ -50,10 +50,21 @@ data class Opportunity(
     val paymentUnits: List<PaymentUnit>,
     val isUserSuspended: Boolean,
     val verificationFlags: VerificationFlags?,
-    val catchmentAreas: List<CatchmentArea>
+    val catchmentAreas: List<CatchmentArea>,
+    // Inline nested collections — populated when detail endpoint returns them
+    val learnings: List<CompletedModule> = emptyList(),
+    val assessments: List<Assessment> = emptyList(),
+    val deliveries: List<DeliveryRecord> = emptyList(),
+    val payments: List<PaymentRecord> = emptyList(),
+    // Lifecycle fields surfaced from server
+    val paymentAccrued: Int = 0,
+    val dailyStartTime: String? = null,
+    val dailyFinishTime: String? = null
 ) {
     val isClaimed: Boolean get() = claim != null
     val daysRemaining: Int get() = daysUntil(endDate)
+    /** Convenience: date the user claimed this opportunity, from the claim sub-object. */
+    val dateClaimed: String? get() = claim?.dateClaimed
 }
 
 data class CommCareAppInfo(
@@ -73,7 +84,8 @@ data class LearnModuleInfo(
     val slug: String,
     val name: String,
     val description: String,
-    val timeEstimate: Int  // hours
+    val timeEstimate: Int,  // hours
+    val completed: Boolean = false  // true if user completed this module
 )
 
 data class OpportunityClaim(

--- a/app/src/commonMain/kotlin/org/commcare/app/network/ConnectMarketplaceApi.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/network/ConnectMarketplaceApi.kt
@@ -133,7 +133,7 @@ class ConnectMarketplaceApi(
         return executeAuthenticatedPost(
             "$baseUrl/users/start_learn_app",
             accessToken,
-            body = """{"opportunity_id":"${escapeJson(opportunityId)}"}"""
+            body = """{"opportunity":"${escapeJson(opportunityId)}"}"""
         )
     }
 
@@ -438,6 +438,53 @@ class ConnectMarketplaceApi(
             )
         }
 
+        // Parse inline learnings (completed_modules) array if present on opportunity detail
+        val learningsJson = extractJsonArrayByKey(json, "completed_modules")
+        val learnings = splitJsonArray(learningsJson).map { obj ->
+            CompletedModule(
+                id = extractJsonInt(obj, "id") ?: 0,
+                module = extractJsonInt(obj, "module") ?: 0,
+                date = extractJsonString(obj, "date") ?: "",
+                duration = extractJsonString(obj, "duration")
+            )
+        }
+
+        // Parse inline assessments array if present on opportunity detail
+        val inlineAssessmentsJson = extractJsonArrayByKey(json, "assessments")
+        val inlineAssessments = splitJsonArray(inlineAssessmentsJson).map { obj ->
+            Assessment(
+                id = extractJsonInt(obj, "id") ?: 0,
+                date = extractJsonString(obj, "date") ?: "",
+                score = extractJsonInt(obj, "score") ?: 0,
+                passingScore = extractJsonInt(obj, "passing_score") ?: 0,
+                passed = extractJsonBoolean(obj, "passed") ?: false
+            )
+        }
+
+        // Parse inline deliveries array if present on opportunity detail
+        val inlineDeliveriesJson = extractJsonArrayByKey(json, "deliveries")
+        val inlineDeliveries = splitJsonArray(inlineDeliveriesJson).map { obj ->
+            DeliveryRecord(
+                id = extractJsonInt(obj, "id") ?: 0,
+                status = extractJsonString(obj, "status") ?: "pending",
+                visitDate = extractJsonString(obj, "visit_date"),
+                deliverUnitName = extractJsonString(obj, "deliver_unit_name"),
+                deliverUnitSlug = extractJsonString(obj, "deliver_unit_slug"),
+                deliverUnitSlugId = extractJsonString(obj, "deliver_unit_slug_id"),
+                entityId = extractJsonString(obj, "entity_id"),
+                entityName = extractJsonString(obj, "entity_name"),
+                reason = extractJsonString(obj, "reason"),
+                flags = parseStringMap(extractJsonObjectByKey(obj, "flags")),
+                lastModified = extractJsonString(obj, "last_modified")
+            )
+        }
+
+        // Parse inline payments array if present on opportunity detail
+        val inlinePaymentsJson = extractJsonArrayByKey(json, "payments")
+        val inlinePayments = splitJsonArray(inlinePaymentsJson).map { obj ->
+            parsePaymentRecord(obj)
+        }
+
         return Opportunity(
             id = extractJsonInt(json, "id") ?: 0,
             opportunityId = extractJsonString(json, "opportunity_id") ?: "",
@@ -462,7 +509,14 @@ class ConnectMarketplaceApi(
             paymentUnits = paymentUnits,
             isUserSuspended = extractJsonBoolean(json, "is_user_suspended") ?: false,
             verificationFlags = verificationFlags,
-            catchmentAreas = catchmentAreas
+            catchmentAreas = catchmentAreas,
+            learnings = learnings,
+            assessments = inlineAssessments,
+            deliveries = inlineDeliveries,
+            payments = inlinePayments,
+            paymentAccrued = extractJsonInt(json, "payment_accrued") ?: 0,
+            dailyStartTime = extractJsonString(json, "daily_start_time"),
+            dailyFinishTime = extractJsonString(json, "daily_finish_time")
         )
     }
 
@@ -474,7 +528,8 @@ class ConnectMarketplaceApi(
                 slug = extractJsonString(obj, "slug") ?: "",
                 name = extractJsonString(obj, "name") ?: "",
                 description = extractJsonString(obj, "description") ?: "",
-                timeEstimate = extractJsonInt(obj, "time_estimate") ?: 0
+                timeEstimate = extractJsonInt(obj, "time_estimate") ?: 0,
+                completed = extractJsonBoolean(obj, "completed") ?: false
             )
         }
 

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/LearnProgressScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/LearnProgressScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.commcare.app.model.Assessment
 import org.commcare.app.model.CompletedModule
+import org.commcare.app.model.LearnModuleInfo
 import org.commcare.app.viewmodel.OpportunitiesViewModel
 
 /**
@@ -94,7 +95,22 @@ fun LearnProgressScreen(
             }
 
             LazyColumn(modifier = Modifier.fillMaxSize()) {
-                // Completed modules section
+                // Learn module list from the learn app (shows all modules with completion status)
+                val learnModules = opp?.learnApp?.learnModules ?: emptyList()
+                if (learnModules.isNotEmpty()) {
+                    item {
+                        Text(
+                            text = "Learning Modules",
+                            style = MaterialTheme.typography.titleSmall,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                        )
+                    }
+                    items(learnModules) { mod ->
+                        LearnModuleRow(mod)
+                    }
+                }
+
+                // Completed modules section (from learn_progress endpoint)
                 if (detail.completedModules.isNotEmpty()) {
                     item {
                         Text(
@@ -171,6 +187,52 @@ private fun CompletedModuleRow(module: CompletedModule) {
                 module.duration?.let {
                     Text(
                         text = "Duration: $it",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LearnModuleRow(module: LearnModuleInfo) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = if (module.completed) "[x]" else "[ ]",
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (module.completed) MaterialTheme.colorScheme.primary
+                else MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(end = 12.dp)
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = module.name,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                if (module.description.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = module.description,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                if (module.timeEstimate > 0) {
+                    Text(
+                        text = "~${module.timeEstimate} min",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/OpportunityDetailScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/OpportunityDetailScreen.kt
@@ -402,7 +402,7 @@ private fun ProgressTabContent(
         }
     }
 
-    // Payment unit breakdown
+    // Per-payment-unit breakdown with approved/remaining counts
     if (opportunity.paymentUnits.isNotEmpty()) {
         Spacer(modifier = Modifier.height(8.dp))
         Text(
@@ -411,17 +411,31 @@ private fun ProgressTabContent(
             fontWeight = FontWeight.Bold,
             modifier = Modifier.padding(horizontal = 16.dp)
         )
+        val allDeliveries = detail?.deliveries ?: opportunity.deliveries
         opportunity.paymentUnits.forEach { unit ->
+            val unitDeliveries = allDeliveries.filter { it.deliverUnitSlugId == unit.paymentUnitId }
+            val unitApproved = unitDeliveries.count { it.status == "approved" }
+            val maxForUnit = unit.maxTotal
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 4.dp)
             ) {
-                Text(
-                    text = unit.name,
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.weight(1f)
-                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = unit.name,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Text(
+                        text = buildString {
+                            append("$unitApproved approved")
+                            if (maxForUnit != null) append(" / $maxForUnit max")
+                        },
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
                 Text(
                     text = "${unit.amount} ${opportunity.currency ?: ""}/visit",
                     style = MaterialTheme.typography.bodySmall,
@@ -644,6 +658,22 @@ private fun JobIntroContent(
                     DeliveryDetailItem(
                         icon = "\u2713",
                         text = "Payment: ${opp.budgetPerVisit} $currency per visit"
+                    )
+                }
+
+                // Working hours if specified
+                if (opp.dailyStartTime != null && opp.dailyFinishTime != null) {
+                    DeliveryDetailItem(
+                        icon = "\u2713",
+                        text = "Working hours: ${opp.dailyStartTime} - ${opp.dailyFinishTime}"
+                    )
+                }
+
+                // Payment accrued
+                if (opp.paymentAccrued > 0) {
+                    DeliveryDetailItem(
+                        icon = "\u2713",
+                        text = "Payment accrued: ${opp.paymentAccrued} $currency"
                     )
                 }
             }

--- a/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectMarketplaceApiJsonTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectMarketplaceApiJsonTest.kt
@@ -615,4 +615,377 @@ class ConnectMarketplaceApiJsonTest {
         assertTrue(body.contains("\"id\":99"))
         assertTrue(body.contains("\"confirmed\":\"true\""))
     }
+
+    // =====================================================================
+    // startLearnApp — exercises correct body format
+    // =====================================================================
+
+    @Test
+    fun testStartLearnApp_sendsOpportunityKey() {
+        val client = MockHttpClient(responseCode = 200, responseBody = "{}")
+        val api = ConnectMarketplaceApi(client)
+
+        api.startLearnApp("access-token", "opp-uuid-123")
+        val body = client.lastRequest!!.body!!.decodeToString()
+        assertTrue(body.contains("\"opportunity\""), "Body should use 'opportunity' key, got: $body")
+        assertTrue(body.contains("opp-uuid-123"))
+    }
+
+    // =====================================================================
+    // API version header — all requests should include Accept version header
+    // =====================================================================
+
+    @Test
+    fun testApiVersionHeader_presentOnAllRequests() {
+        val client = MockHttpClient(responseBody = "[]")
+        val api = ConnectMarketplaceApi(client)
+
+        api.getOpportunities("access-token")
+        assertEquals("application/json; version=1.0", client.lastRequest!!.headers["Accept"])
+    }
+
+    // =====================================================================
+    // Inline nested structures on Opportunity detail
+    // =====================================================================
+
+    @Test
+    fun testOpportunityDetail_withInlineDeliveriesAndPayments() {
+        val json = """{
+            "id": 30,
+            "opportunity_id": "opp-inline",
+            "name": "Inline Detail",
+            "description": "Has inline deliveries and payments",
+            "organization": "Org",
+            "is_active": true,
+            "payment_accrued": 250,
+            "daily_start_time": "08:00:00",
+            "daily_finish_time": "17:00:00",
+            "deliveries": [
+                {
+                    "id": 100,
+                    "status": "approved",
+                    "visit_date": "2026-03-15",
+                    "deliver_unit_name": "Home Visit",
+                    "entity_name": "Patient X",
+                    "flags": {}
+                }
+            ],
+            "payments": [
+                {
+                    "id": 200,
+                    "payment_id": "pay-inline",
+                    "amount": "75.00",
+                    "date_paid": "2026-03-16",
+                    "confirmed": false,
+                    "confirmation_date": null
+                }
+            ]
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 30)
+        assertTrue(result.isSuccess)
+        val opp = result.getOrThrow()
+
+        // Lifecycle fields
+        assertEquals(250, opp.paymentAccrued)
+        assertEquals("08:00:00", opp.dailyStartTime)
+        assertEquals("17:00:00", opp.dailyFinishTime)
+
+        // Inline deliveries
+        assertEquals(1, opp.deliveries.size)
+        assertEquals(100, opp.deliveries[0].id)
+        assertEquals("approved", opp.deliveries[0].status)
+        assertEquals("Home Visit", opp.deliveries[0].deliverUnitName)
+        assertEquals("Patient X", opp.deliveries[0].entityName)
+
+        // Inline payments
+        assertEquals(1, opp.payments.size)
+        assertEquals(200, opp.payments[0].id)
+        assertEquals("75.00", opp.payments[0].amount)
+        assertFalse(opp.payments[0].confirmed)
+    }
+
+    @Test
+    fun testOpportunityDetail_withInlineAssessmentsAndLearnings() {
+        val json = """{
+            "id": 31,
+            "opportunity_id": "opp-learn-inline",
+            "name": "Learning Inline",
+            "description": "Has inline learnings and assessments",
+            "organization": "Org",
+            "is_active": true,
+            "completed_modules": [
+                {"id": 1, "module": 10, "date": "2026-03-10", "duration": "00:45:00"}
+            ],
+            "assessments": [
+                {"id": 50, "date": "2026-03-11", "score": 90, "passing_score": 70, "passed": true}
+            ]
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 31)
+        assertTrue(result.isSuccess)
+        val opp = result.getOrThrow()
+
+        // Inline learnings
+        assertEquals(1, opp.learnings.size)
+        assertEquals(10, opp.learnings[0].module)
+        assertEquals("2026-03-10", opp.learnings[0].date)
+        assertEquals("00:45:00", opp.learnings[0].duration)
+
+        // Inline assessments
+        assertEquals(1, opp.assessments.size)
+        assertEquals(90, opp.assessments[0].score)
+        assertEquals(70, opp.assessments[0].passingScore)
+        assertTrue(opp.assessments[0].passed)
+    }
+
+    @Test
+    fun testOpportunityDetail_withLearnModuleCompletionStatus() {
+        val json = """{
+            "id": 32,
+            "opportunity_id": "opp-modules-status",
+            "name": "Module Status",
+            "description": "D",
+            "organization": "O",
+            "is_active": true,
+            "learn_app": {
+                "id": 8,
+                "cc_domain": "domain",
+                "cc_app_id": "app-mod",
+                "name": "Learn",
+                "description": "D",
+                "organization": "O",
+                "learn_modules": [
+                    {"id": 1, "slug": "m1", "name": "Intro", "description": "Introduction", "time_estimate": 15, "completed": true},
+                    {"id": 2, "slug": "m2", "name": "Advanced", "description": "Deep dive", "time_estimate": 30, "completed": false}
+                ],
+                "passing_score": 80
+            }
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 32)
+        assertTrue(result.isSuccess)
+        val modules = result.getOrThrow().learnApp!!.learnModules
+        assertEquals(2, modules.size)
+        assertTrue(modules[0].completed)
+        assertFalse(modules[1].completed)
+        assertEquals("Intro", modules[0].name)
+        assertEquals("Introduction", modules[0].description)
+    }
+
+    @Test
+    fun testOpportunity_dateClaimed_convenienceProperty() {
+        val json = """{
+            "id": 33,
+            "opportunity_id": "opp-claimed-date",
+            "name": "With Claim",
+            "description": "D",
+            "organization": "O",
+            "is_active": true,
+            "claim": {
+                "id": 55,
+                "max_payments": 20,
+                "end_date": "2026-06-30",
+                "date_claimed": "2026-02-15",
+                "payment_units": []
+            }
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 33)
+        assertTrue(result.isSuccess)
+        val opp = result.getOrThrow()
+        assertEquals("2026-02-15", opp.dateClaimed)
+        assertTrue(opp.isClaimed)
+    }
+
+    @Test
+    fun testOpportunity_noInlineCollections_defaultsToEmpty() {
+        val json = """{
+            "id": 34,
+            "opportunity_id": "opp-minimal",
+            "name": "Minimal",
+            "description": "No inline collections",
+            "organization": "O",
+            "is_active": true
+        }"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunityDetail("access-token", 34)
+        assertTrue(result.isSuccess)
+        val opp = result.getOrThrow()
+        assertEquals(0, opp.deliveries.size)
+        assertEquals(0, opp.payments.size)
+        assertEquals(0, opp.learnings.size)
+        assertEquals(0, opp.assessments.size)
+        assertEquals(0, opp.paymentAccrued)
+        assertNull(opp.dailyStartTime)
+        assertNull(opp.dailyFinishTime)
+        assertNull(opp.dateClaimed)
+    }
+
+    @Test
+    fun testOpportunityList_withFullNestedStructures() {
+        val json = """[{
+            "id": 40,
+            "opportunity_id": "opp-full",
+            "name": "Full Opportunity",
+            "description": "Complete nested structure",
+            "short_description": "Short desc",
+            "organization": "BigOrg",
+            "is_active": true,
+            "start_date": "2026-01-01",
+            "end_date": "2026-12-31",
+            "max_visits_per_user": 200,
+            "daily_max_visits_per_user": 10,
+            "budget_per_visit": 100,
+            "currency": "KES",
+            "budget_per_user": 5000,
+            "payment_accrued": 1500,
+            "is_user_suspended": false,
+            "daily_start_time": "09:00:00",
+            "daily_finish_time": "18:00:00",
+            "payment_units": [
+                {"id": 1, "payment_unit_id": "pu-a", "name": "Standard Visit", "max_total": 100, "max_daily": 5, "amount": 50, "end_date": "2026-12-31"},
+                {"id": 2, "payment_unit_id": "pu-b", "name": "Bonus Visit", "max_total": null, "max_daily": null, "amount": 100, "end_date": null}
+            ],
+            "learn_app": {
+                "id": 20,
+                "cc_domain": "kenya",
+                "cc_app_id": "app-learn-1",
+                "name": "Learn App",
+                "description": "For learning",
+                "organization": "BigOrg",
+                "learn_modules": [
+                    {"id": 1, "slug": "basics", "name": "Basics", "description": "Start here", "time_estimate": 20, "completed": true},
+                    {"id": 2, "slug": "advanced", "name": "Advanced", "description": "Go deeper", "time_estimate": 40, "completed": false}
+                ],
+                "passing_score": 75,
+                "install_url": "https://example.com/learn.ccz"
+            },
+            "deliver_app": {
+                "id": 21,
+                "cc_domain": "kenya",
+                "cc_app_id": "app-deliver-1",
+                "name": "Deliver App",
+                "description": "For delivering",
+                "organization": "BigOrg",
+                "learn_modules": [],
+                "passing_score": -1,
+                "install_url": "https://example.com/deliver.ccz"
+            },
+            "claim": {
+                "id": 77,
+                "max_payments": 200,
+                "end_date": "2026-12-31",
+                "date_claimed": "2026-02-01",
+                "payment_units": [
+                    {"max_visits": 100, "payment_unit": 1, "payment_unit_id": "pu-a"},
+                    {"max_visits": 100, "payment_unit": 2, "payment_unit_id": "pu-b"}
+                ]
+            },
+            "learn_progress": {"total_modules": 2, "completed_modules": 1},
+            "verification_flags": {
+                "form_submission_start": "09:00:00",
+                "form_submission_end": "17:00:00"
+            },
+            "catchment_areas": [
+                {"id": 1, "name": "Nairobi", "latitude": "-1.286", "longitude": "36.817", "radius": 2000, "active": true}
+            ],
+            "deliveries": [
+                {"id": 301, "status": "approved", "visit_date": "2026-03-01", "deliver_unit_name": "Standard Visit", "deliver_unit_slug_id": "pu-a", "entity_name": "John D", "flags": {"gps": "ok"}},
+                {"id": 302, "status": "pending", "visit_date": "2026-03-02", "deliver_unit_name": "Bonus Visit", "deliver_unit_slug_id": "pu-b", "entity_name": "Jane S", "flags": {}}
+            ],
+            "payments": [
+                {"id": 401, "payment_id": "pay-1", "amount": "50.00", "date_paid": "2026-03-05", "confirmed": true, "confirmation_date": "2026-03-06"}
+            ],
+            "completed_modules": [
+                {"id": 501, "module": 1, "date": "2026-02-15", "duration": "00:25:00"}
+            ],
+            "assessments": [
+                {"id": 601, "date": "2026-02-20", "score": 85, "passing_score": 75, "passed": true}
+            ]
+        }]"""
+        val client = MockHttpClient(responseBody = json)
+        val api = ConnectMarketplaceApi(client)
+
+        val result = api.getOpportunities("access-token")
+        assertTrue(result.isSuccess)
+        val opps = result.getOrThrow()
+        assertEquals(1, opps.size)
+        val opp = opps[0]
+
+        // Core fields
+        assertEquals(40, opp.id)
+        assertEquals("Full Opportunity", opp.name)
+        assertEquals("Short desc", opp.shortDescription)
+        assertEquals("KES", opp.currency)
+        assertEquals(200, opp.maxVisitsPerUser)
+        assertEquals(10, opp.dailyMaxVisitsPerUser)
+        assertEquals(100, opp.budgetPerVisit)
+        assertEquals(5000, opp.budgetPerUser)
+
+        // Lifecycle fields
+        assertEquals(1500, opp.paymentAccrued)
+        assertEquals("09:00:00", opp.dailyStartTime)
+        assertEquals("18:00:00", opp.dailyFinishTime)
+        assertFalse(opp.isUserSuspended)
+
+        // Nested apps
+        assertNotNull(opp.learnApp)
+        assertEquals(2, opp.learnApp!!.learnModules.size)
+        assertTrue(opp.learnApp!!.learnModules[0].completed)
+        assertFalse(opp.learnApp!!.learnModules[1].completed)
+        assertEquals("https://example.com/learn.ccz", opp.learnApp!!.installUrl)
+        assertNotNull(opp.deliverApp)
+        assertEquals("https://example.com/deliver.ccz", opp.deliverApp!!.installUrl)
+
+        // Claim
+        assertNotNull(opp.claim)
+        assertEquals("2026-02-01", opp.dateClaimed)
+        assertEquals(2, opp.claim!!.paymentUnits.size)
+
+        // Learn progress summary
+        assertNotNull(opp.learnProgress)
+        assertEquals(2, opp.learnProgress!!.totalModules)
+        assertEquals(1, opp.learnProgress!!.completedModules)
+
+        // Payment units
+        assertEquals(2, opp.paymentUnits.size)
+        assertEquals("Standard Visit", opp.paymentUnits[0].name)
+        assertNull(opp.paymentUnits[1].maxTotal)
+
+        // Verification flags
+        assertNotNull(opp.verificationFlags)
+
+        // Catchment areas
+        assertEquals(1, opp.catchmentAreas.size)
+        assertEquals("Nairobi", opp.catchmentAreas[0].name)
+
+        // Inline deliveries
+        assertEquals(2, opp.deliveries.size)
+        assertEquals("approved", opp.deliveries[0].status)
+        assertEquals("John D", opp.deliveries[0].entityName)
+        assertEquals("ok", opp.deliveries[0].flags["gps"])
+
+        // Inline payments
+        assertEquals(1, opp.payments.size)
+        assertTrue(opp.payments[0].confirmed)
+
+        // Inline learnings
+        assertEquals(1, opp.learnings.size)
+        assertEquals(1, opp.learnings[0].module)
+
+        // Inline assessments
+        assertEquals(1, opp.assessments.size)
+        assertTrue(opp.assessments[0].passed)
+    }
 }


### PR DESCRIPTION
## Summary

- Add inline nested collections on `Opportunity`: `learnings`, `assessments`, `deliveries`, `payments` — parsed when detail endpoint returns them inline
- Add lifecycle fields: `paymentAccrued`, `dailyStartTime`, `dailyFinishTime` on Opportunity
- Add `completed` field on `LearnModuleInfo` to track per-module completion status
- Add convenience `dateClaimed` property on `Opportunity` (delegates to `claim.dateClaimed`)
- Fix `startLearnApp` body format: use `"opportunity"` key (was `"opportunity_id"`)
- Update `OpportunityDetailScreen` to show working hours, payment accrued, and per-unit delivery breakdown
- Update `LearnProgressScreen` to show learn modules from the learn app with completion status
- Add 8 new tests covering inline nested structures, lifecycle fields, API version header, and full nested opportunity parsing

## Test plan

- [x] `./gradlew :app:compileKotlinJvm` passes (compilation clean)
- [x] `./gradlew :app:jvmTest` passes — 242 tests, 0 failures
- [x] All existing `ConnectMarketplaceApiJsonTest` tests pass unchanged
- [x] New tests cover: inline deliveries/payments, inline assessments/learnings, module completion status, dateClaimed convenience, empty-defaults, full nested structure, startLearnApp body format, API version header

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)