### PR TITLE
feat: Connect app download buttons + install flow

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/LearnProgressScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/LearnProgressScreen.kt
@@ -18,10 +18,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.commcare.app.model.Assessment
 import org.commcare.app.model.CompletedModule
 import org.commcare.app.model.LearnModuleInfo
+import org.commcare.app.viewmodel.DownloadState
 import org.commcare.app.viewmodel.OpportunitiesViewModel
 
 /**
@@ -41,18 +43,48 @@ fun LearnProgressScreen(
     val opp = viewModel.selectedOpportunity
 
     Column(modifier = Modifier.fillMaxSize()) {
-        // Download Learn App button — shown when a learn app install URL is available
+        // "Start Learning" button — shown when a learn app install URL is available
+        // and learning is not yet complete
         val learnApp = opp?.learnApp
         val learnInstallUrl = learnApp?.installUrl
-        if (onDownloadApp != null && !learnInstallUrl.isNullOrBlank()) {
+        val learningComplete = opp != null && viewModel.isLearningComplete(opp)
+        if (onDownloadApp != null && learnApp != null && !learnInstallUrl.isNullOrBlank() && !learningComplete) {
+            val downloadState = viewModel.downloadState
+            val isDownloading = downloadState is DownloadState.Downloading &&
+                downloadState.appName == learnApp.name
             Button(
-                onClick = { onDownloadApp(learnInstallUrl, learnApp.name) },
+                onClick = {
+                    viewModel.downloadAndInstallApp(learnApp) { success ->
+                        if (success) {
+                            onDownloadApp(learnInstallUrl, learnApp.name)
+                        }
+                    }
+                },
+                enabled = !isDownloading,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp, vertical = 8.dp)
             ) {
-                Text("Download Learn App")
+                Text(if (isDownloading) "Downloading..." else "Start Learning")
             }
+            if (downloadState is DownloadState.Error) {
+                Text(
+                    text = downloadState.message,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+            }
+        }
+        // Show completion message when learning is done
+        if (learningComplete && learnApp != null) {
+            Text(
+                text = "Learning complete!",
+                style = MaterialTheme.typography.bodyMedium,
+                color = ConnectIndigo,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            )
         }
 
         if (detail == null) {

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/OpportunityDetailScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/OpportunityDetailScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.commcare.app.model.Opportunity
 import org.commcare.app.model.daysUntil
+import org.commcare.app.viewmodel.DownloadState
 import org.commcare.app.viewmodel.OpportunitiesViewModel
 
 private enum class DetailTab { PROGRESS, PAYMENT }
@@ -375,31 +376,70 @@ private fun ProgressTabContent(
         }
     }
 
-    // Download buttons if applicable
+    // Context-aware action buttons for learning and delivery
+    val learnApp = opportunity.learnApp
     val deliverApp = opportunity.deliverApp
-    if (onDownloadApp != null && deliverApp != null && !deliverApp.installUrl.isNullOrBlank()) {
+    val learningComplete = viewModel.isLearningComplete(opportunity)
+    val downloadState = viewModel.downloadState
+
+    // Show "Start Learning" when learn app exists and learning is not yet complete
+    if (onDownloadApp != null && learnApp != null && !learnApp.installUrl.isNullOrBlank() && !learningComplete) {
+        val isDownloadingLearn = downloadState is DownloadState.Downloading &&
+            downloadState.appName == learnApp.name
         Button(
-            onClick = { onDownloadApp(deliverApp.installUrl, deliverApp.name) },
+            onClick = {
+                viewModel.downloadAndInstallApp(learnApp) { success ->
+                    if (success) {
+                        onDownloadApp(learnApp.installUrl, learnApp.name)
+                    }
+                }
+            },
+            enabled = !isDownloadingLearn,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 4.dp),
             colors = ButtonDefaults.buttonColors(containerColor = ConnectIndigo)
         ) {
-            Text("Download Deliver App")
+            Text(
+                text = if (isDownloadingLearn) "Downloading..." else "Start Learning",
+                color = Color.White
+            )
         }
     }
 
-    val learnApp = opportunity.learnApp
-    if (onDownloadApp != null && learnApp != null && !learnApp.installUrl.isNullOrBlank()) {
+    // Show "Start Delivering" when learning is complete (or no learn app) and deliver app exists
+    if (onDownloadApp != null && deliverApp != null && !deliverApp.installUrl.isNullOrBlank() && learningComplete) {
+        val isDownloadingDeliver = downloadState is DownloadState.Downloading &&
+            downloadState.appName == deliverApp.name
         Button(
-            onClick = { onDownloadApp(learnApp.installUrl, learnApp.name) },
+            onClick = {
+                viewModel.downloadAndInstallApp(deliverApp) { success ->
+                    if (success) {
+                        onDownloadApp(deliverApp.installUrl, deliverApp.name)
+                    }
+                }
+            },
+            enabled = !isDownloadingDeliver,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 4.dp),
-            colors = ButtonDefaults.buttonColors(containerColor = ConnectIndigo)
+            colors = ButtonDefaults.buttonColors(containerColor = ConnectTeal)
         ) {
-            Text("Download Learn App")
+            Text(
+                text = if (isDownloadingDeliver) "Downloading..." else "Start Delivering",
+                color = Color.White
+            )
         }
+    }
+
+    // Download error message
+    if (downloadState is DownloadState.Error) {
+        Text(
+            text = downloadState.message,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+        )
     }
 
     // Per-payment-unit breakdown with approved/remaining counts

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/OpportunitiesViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/OpportunitiesViewModel.kt
@@ -8,10 +8,21 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import org.commcare.app.model.CommCareAppInfo
 import org.commcare.app.model.DeliveryProgressDetail
 import org.commcare.app.model.LearnProgressDetail
 import org.commcare.app.model.Opportunity
 import org.commcare.app.network.ConnectMarketplaceApi
+
+/**
+ * Tracks the state of a Connect app download and install operation.
+ */
+sealed class DownloadState {
+    data object Idle : DownloadState()
+    data class Downloading(val appName: String) : DownloadState()
+    data class Complete(val appName: String) : DownloadState()
+    data class Error(val message: String) : DownloadState()
+}
 
 /**
  * ViewModel for the Connect opportunities hub.
@@ -40,6 +51,17 @@ class OpportunitiesViewModel(
     var learnProgress by mutableStateOf<LearnProgressDetail?>(null)
         private set
     var deliveryProgress by mutableStateOf<DeliveryProgressDetail?>(null)
+        private set
+
+    // Connect app download state
+    var downloadState by mutableStateOf<DownloadState>(DownloadState.Idle)
+        private set
+
+    /**
+     * Cached HQ SSO token obtained after a Connect app install completes.
+     * The caller (e.g. LoginViewModel) can use this for auto-login.
+     */
+    var cachedHqSsoToken by mutableStateOf<String?>(null)
         private set
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -235,5 +257,87 @@ class OpportunitiesViewModel(
                 errorMessage = "Confirm payment error: ${e::class.simpleName}: ${e.message}"
             }
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Connect app download + install
+    // -----------------------------------------------------------------
+
+    /**
+     * Initiate download and install of a Connect app (learn or deliver).
+     *
+     * Delegates the actual installation to the [onDownloadApp] callback which
+     * triggers the standard [AppInstallViewModel] install-progress screen via
+     * App.kt's pendingConnectInstall wiring. This method manages the download
+     * state tracking and SSO token retrieval.
+     *
+     * After install completes, retrieves an HQ SSO token for auto-login.
+     *
+     * @param appInfo   The CommCareAppInfo describing the app to install.
+     * @param onComplete Callback with true on success, false on failure.
+     */
+    fun downloadAndInstallApp(appInfo: CommCareAppInfo, onComplete: (Boolean) -> Unit) {
+        val installUrl = appInfo.installUrl
+        if (installUrl.isNullOrBlank()) {
+            downloadState = DownloadState.Error("No install URL available for ${appInfo.name}")
+            onComplete(false)
+            return
+        }
+
+        downloadState = DownloadState.Downloading(appInfo.name)
+        scope.launch {
+            try {
+                // Attempt to retrieve the HQ SSO token for auto-login after install.
+                // The actual app installation is handled externally via the onDownloadApp
+                // callback (which goes through App.kt -> AppInstallViewModel), but we
+                // pre-fetch the SSO token so it's ready when the install completes.
+                val hqSsoToken = try {
+                    tokenManager.getHqSsoToken(
+                        hqUrl = "https://www.commcarehq.org",
+                        domain = appInfo.ccDomain,
+                        hqUsername = tokenManager.getStoredUsername() ?: ""
+                    )
+                } catch (_: Exception) {
+                    null
+                }
+
+                cachedHqSsoToken = hqSsoToken
+                downloadState = DownloadState.Complete(appInfo.name)
+                onComplete(true)
+            } catch (e: Exception) {
+                downloadState = DownloadState.Error(
+                    "Download failed: ${e.message ?: e::class.simpleName}"
+                )
+                onComplete(false)
+            }
+        }
+    }
+
+    /** Reset download state to idle. */
+    fun resetDownloadState() {
+        downloadState = DownloadState.Idle
+        cachedHqSsoToken = null
+    }
+
+    /**
+     * Returns true if this opportunity's learning phase is considered complete.
+     * Learning is complete when:
+     * - There is no learn app (learning not required), OR
+     * - All learn modules have been completed
+     */
+    fun isLearningComplete(opp: Opportunity): Boolean {
+        if (opp.learnApp == null) return true
+        val summary = opp.learnProgress ?: return false
+        return summary.totalModules > 0 && summary.completedModules >= summary.totalModules
+    }
+
+    /**
+     * Returns true if this opportunity is ready for delivery.
+     * Delivery is ready when:
+     * - The opportunity is claimed, AND
+     * - Learning is complete (or no learn app required)
+     */
+    fun isReadyForDelivery(opp: Opportunity): Boolean {
+        return opp.isClaimed && isLearningComplete(opp)
     }
 }


### PR DESCRIPTION
## Summary
- Add `DownloadState` sealed class and `downloadAndInstallApp()` to `OpportunitiesViewModel` for tracking Connect app download lifecycle
- Replace generic "Download Learn App" / "Download Deliver App" buttons with context-aware "Start Learning" / "Start Delivering" buttons on `OpportunityDetailScreen` and `LearnProgressScreen`
- Pre-fetch HQ SSO token via `ConnectIdTokenManager.getHqSsoToken()` for auto-login after app install
- Add `isLearningComplete()` and `isReadyForDelivery()` helper methods for determining which buttons to show
- "Start Learning" button shown when learn app exists and learning modules are incomplete
- "Start Delivering" button shown when learning is complete (or no learn app required)

Closes #340

## Test plan
- [x] `./gradlew compileKotlinJvm` passes
- [x] `./gradlew jvmTest` passes (all existing tests)
- [ ] Manual: verify "Start Learning" button appears for opportunity with learn app
- [ ] Manual: verify "Start Delivering" button appears when learning is complete
- [ ] Manual: verify download state transitions (Idle -> Downloading -> Complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)