### PR TITLE
fix: quality polish — timestamps, offline indicator, background updates

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
@@ -1,6 +1,7 @@
 package org.commcare.app.ui
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -118,6 +119,11 @@ fun HomeScreen(
 
     LaunchedEffect(Unit) { drawerViewModel.refresh() }
 
+    // Start background periodic update checking
+    LaunchedEffect(updateViewModel) {
+        updateViewModel?.schedulePeriodicCheck()
+    }
+
     // Current form entry state (set when navigating to a form)
     var formEntryViewModel by remember { mutableStateOf<FormEntryViewModel?>(null) }
     var caseListViewModel by remember { mutableStateOf<CaseListViewModel?>(null) }
@@ -196,6 +202,8 @@ fun HomeScreen(
                 },
                 pendingFormCount = formQueueViewModel.pendingCount,
                 lastSyncTime = syncViewModel.lastSyncTime,
+                isOffline = syncViewModel.isOffline,
+                hasNewUpdate = updateViewModel?.hasNewUpdate == true,
                 onOpenDrawer = { scope.launch { drawerState.open() } }
             )
         }
@@ -393,6 +401,8 @@ private fun HomeLanding(
     onDiagnostics: () -> Unit,
     pendingFormCount: Int,
     lastSyncTime: String?,
+    isOffline: Boolean = false,
+    hasNewUpdate: Boolean = false,
     onOpenDrawer: () -> Unit = {}
 ) {
     Column(
@@ -414,6 +424,34 @@ private fun HomeLanding(
                     .defaultMinSize(minWidth = 44.dp, minHeight = 44.dp)
                     .padding(end = 8.dp)
             )
+        }
+
+        // Offline banner
+        if (isOffline) {
+            Text(
+                text = "Offline — No network connection",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+
+        // Update available indicator
+        if (hasNewUpdate) {
+            Text(
+                text = "A new version is available. Go to Settings to update.",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+            Spacer(modifier = Modifier.height(8.dp))
         }
 
         Spacer(modifier = Modifier.height(48.dp))

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/SyncScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/SyncScreen.kt
@@ -1,5 +1,6 @@
 package org.commcare.app.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -47,6 +48,20 @@ fun SyncScreen(
         )
 
         Spacer(modifier = Modifier.height(16.dp))
+
+        // Offline banner
+        if (syncViewModel.isOffline) {
+            Text(
+                text = "Offline — No network connection",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+        }
 
         // Sync status
         when (val state = syncViewModel.syncState) {

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/FormQueueViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/FormQueueViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import org.commcare.app.platform.currentEpochSeconds
 import org.commcare.app.storage.CommCareDatabase
 import org.commcare.core.interfaces.HttpRequest
 import org.commcare.core.interfaces.PlatformHttpClient
@@ -185,7 +186,49 @@ class FormQueueViewModel(
     private var nextId = 1
     private fun generateId(): String = "form-${nextId++}"
 
-    private fun currentTimestamp(): String = "now"
+    /**
+     * Returns the current time as an ISO 8601 UTC string (e.g. "2026-03-21T14:30:00Z").
+     * Uses the platform-specific [currentEpochSeconds] expect/actual.
+     */
+    private fun currentTimestamp(): String {
+        val epochSeconds = currentEpochSeconds()
+        // Manual ISO 8601 formatting without kotlinx-datetime dependency
+        val s = epochSeconds % 60
+        val totalMinutes = epochSeconds / 60
+        val m = totalMinutes % 60
+        val totalHours = totalMinutes / 60
+        val h = totalHours % 24
+        var totalDays = totalHours / 24
+
+        // Convert days since epoch (1970-01-01) to year/month/day
+        var year = 1970
+        while (true) {
+            val daysInYear = if (isLeapYear(year)) 366L else 365L
+            if (totalDays < daysInYear) break
+            totalDays -= daysInYear
+            year++
+        }
+        val monthDays = if (isLeapYear(year))
+            intArrayOf(31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+        else
+            intArrayOf(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+        var month = 1
+        for (md in monthDays) {
+            if (totalDays < md) break
+            totalDays -= md
+            month++
+        }
+        val day = totalDays + 1
+
+        return "${year.pad4()}-${month.pad2()}-${day.toLong().pad2()}T${h.pad2()}:${m.pad2()}:${s.pad2()}Z"
+    }
+
+    private fun isLeapYear(year: Int): Boolean =
+        (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+
+    private fun Int.pad4(): String = toString().padStart(4, '0')
+    private fun Int.pad2(): String = toString().padStart(2, '0')
+    private fun Long.pad2(): String = toString().padStart(2, '0')
 }
 
 data class QueuedForm(

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/MessagingViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/MessagingViewModel.kt
@@ -25,11 +25,24 @@ import org.commcare.app.network.ConnectMarketplaceApi
  * - 30-second polling when a thread is open (startPolling/stopPolling)
  * - Unsent message retry: failed sends are queued and retried via retrySending()
  * - Consent flow with loading state and error reporting
+ *
+ * TODO: Add end-to-end message encryption using AES-256-GCM.
+ *   Requires server-side key exchange API (not yet available). When the HQ
+ *   endpoint for per-thread symmetric key negotiation is ready, encrypt
+ *   outgoing message content before sending and decrypt incoming messages
+ *   after receipt. The [isEncryptionEnabled] flag should be flipped to true
+ *   once the implementation is in place.
  */
 class MessagingViewModel(
     private val api: ConnectMarketplaceApi,
     private val tokenManager: ConnectIdTokenManager
 ) {
+    /**
+     * Whether end-to-end encryption is active for messages.
+     * Currently false — encryption is deferred until the server-side
+     * key exchange API is available.
+     */
+    val isEncryptionEnabled: Boolean = false
     var threads by mutableStateOf<List<MessageThread>>(emptyList())
         private set
     var currentThreadMessages by mutableStateOf<List<Message>>(emptyList())

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/SyncViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/SyncViewModel.kt
@@ -32,6 +32,8 @@ class SyncViewModel(
         private set
     var lastSyncToken by mutableStateOf<String?>(null)
         private set
+    var isOffline by mutableStateOf(false)
+        private set
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
@@ -57,6 +59,14 @@ class SyncViewModel(
 
         scope.launch {
             try {
+                // Pre-check: verify network connectivity with a lightweight HEAD request
+                if (!checkConnectivity()) {
+                    isOffline = true
+                    syncState = SyncState.Error("No network connection. Please check your internet and try again.")
+                    return@launch
+                }
+                isOffline = false
+
                 // Phase 1: Submit queued forms first (send before receive)
                 if (formQueue != null && formQueue.pendingCount > 0) {
                     syncState = SyncState.Syncing(0.1f, "Submitting ${formQueue.pendingCount} forms...")
@@ -133,8 +143,30 @@ class SyncViewModel(
         }
     }
 
+    /**
+     * Lightweight connectivity check: sends a HEAD request to the server.
+     * Returns true if the server is reachable, false otherwise.
+     */
+    private fun checkConnectivity(): Boolean {
+        return try {
+            val pingUrl = "${serverUrl.trimEnd('/')}/serverup.txt"
+            val response = httpClient.execute(
+                HttpRequest(
+                    url = pingUrl,
+                    method = "GET",
+                    headers = mapOf("Authorization" to authHeader)
+                )
+            )
+            // Any response (even 4xx) means the network is up
+            response.code > 0
+        } catch (_: Exception) {
+            false
+        }
+    }
+
     fun resetState() {
         syncState = SyncState.Idle
+        isOffline = false
     }
 }
 

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/UpdateViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/UpdateViewModel.kt
@@ -5,8 +5,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.commcare.app.engine.AppInstaller
 import org.commcare.app.storage.SqlDelightUserSandbox
@@ -33,8 +35,11 @@ class UpdateViewModel(
         private set
     var updateMessage by mutableStateOf<String?>(null)
         private set
+    var hasNewUpdate by mutableStateOf(false)
+        private set
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var periodicCheckJob: Job? = null
 
     fun cancel() { scope.cancel() }
 
@@ -87,6 +92,7 @@ class UpdateViewModel(
 
                 if (serverVersion != null && installedVersion != null && serverVersion > installedVersion) {
                     availableVersion = serverVersion.toString()
+                    hasNewUpdate = true
                     updateState = UpdateState.Available
                     updateMessage = "Version $serverVersion available (installed: $installedVersion)"
                 } else {
@@ -134,8 +140,52 @@ class UpdateViewModel(
         }
     }
 
+    /**
+     * Schedule a daily background check for app updates.
+     * Runs an infinite coroutine loop with a 24-hour delay between checks.
+     * Safe to call multiple times — cancels any existing periodic job first.
+     */
+    fun schedulePeriodicCheck() {
+        periodicCheckJob?.cancel()
+        periodicCheckJob = scope.launch {
+            while (true) {
+                delay(24 * 60 * 60 * 1000L) // 24 hours
+                try {
+                    checkForUpdatesQuietly()
+                } catch (_: Exception) {
+                    // Background check failures are non-fatal; retry next cycle
+                }
+            }
+        }
+    }
+
+    /**
+     * Silent update check that only sets [hasNewUpdate] without changing [updateState].
+     * Used by the periodic background checker so it doesn't interrupt the UI.
+     */
+    private fun checkForUpdatesQuietly() {
+        if (profileUrl.isBlank()) return
+        try {
+            val httpClient = createHttpClient()
+            val response = httpClient.execute(
+                HttpRequest(url = profileUrl, method = "GET")
+            )
+            if (response.code !in 200..299) return
+            val body = response.body?.decodeToString() ?: return
+            val serverVersion = extractVersionFromProfile(body)
+            val installedVersion = currentVersion?.toIntOrNull()
+            if (serverVersion != null && installedVersion != null && serverVersion > installedVersion) {
+                hasNewUpdate = true
+                availableVersion = serverVersion.toString()
+            }
+        } catch (_: Exception) {
+            // Swallow — background check is best-effort
+        }
+    }
+
     fun dismissUpdate() {
         updateState = UpdateState.Idle
+        hasNewUpdate = false
         updateMessage = null
         updateProgress = 0f
     }


### PR DESCRIPTION
## Summary
- **FormQueueViewModel**: replaced hardcoded `"now"` timestamp with real ISO 8601 UTC strings using the existing `currentEpochSeconds()` platform function
- **SyncViewModel**: added offline detection via lightweight server connectivity check before sync; shows "Offline" banner in both HomeLanding and SyncScreen when offline
- **UpdateViewModel**: added `schedulePeriodicCheck()` for daily background update checks with `hasNewUpdate` observable state; HomeScreen shows update-available banner
- **MessagingViewModel**: added `isEncryptionEnabled = false` flag and TODO documenting the future AES-256-GCM encryption plan (deferred until server-side key exchange API is available)

Closes #341

## Test plan
- [x] `compileKotlinJvm` passes with no new errors
- [x] `jvmTest` passes (all existing tests green)
- [ ] Manual: verify ISO 8601 timestamp appears in SQLDelight `created_at` column after form enqueue
- [ ] Manual: disconnect network and tap Sync — verify "Offline" banner appears
- [ ] Manual: verify update-available banner appears on home screen when server has newer version

🤖 Generated with [Claude Code](https://claude.com/claude-code)