### PR TITLE
feat: select appearance variants + DateTime widget (Phase 7 Wave 2)

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/ui/FormEntryScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/FormEntryScreen.kt
@@ -363,8 +363,10 @@ private fun QuestionWidget(
                 }
                 appearance.contains("quick") -> {
                     SelectOneQuick(question, enabled) { choice ->
-                        viewModel.answerQuestionString(index, choice)
-                        viewModel.nextQuestion()
+                        val accepted = viewModel.answerQuestionString(index, choice)
+                        if (accepted) {
+                            viewModel.nextQuestion()
+                        }
                     }
                 }
                 appearance.contains("combobox") -> {
@@ -762,7 +764,7 @@ private fun SelectOneCombobox(
     enabled: Boolean,
     onSelect: (String) -> Unit
 ) {
-    var text by remember { mutableStateOf(question.answer) }
+    var text by remember(question.answer) { mutableStateOf(question.answer) }
     var expanded by remember { mutableStateOf(false) }
     val isFuzzy = appearance.contains("fuzzy")
     val isMultiword = appearance.contains("multiword")

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/FormEntryViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/FormEntryViewModel.kt
@@ -104,7 +104,11 @@ class FormEntryViewModel(
         updateQuestions()
     }
 
-    fun answerQuestion(index: Int, answer: IAnswerData?) {
+    /**
+     * Answer a question. Returns true if the answer was accepted (ANSWER_OK),
+     * false if it violated a constraint or was otherwise rejected.
+     */
+    fun answerQuestion(index: Int, answer: IAnswerData?): Boolean {
         try {
             val result = formSession.answerAtIndex(index, answer)
             when (result) {
@@ -113,6 +117,7 @@ class FormEntryViewModel(
                     clearConstraint(index)
                     // Refresh questions — relevancy may have changed (skip logic)
                     updateQuestions()
+                    return true
                 }
                 FormEntryController.ANSWER_CONSTRAINT_VIOLATED -> {
                     val prompts = formSession.getPrompts()
@@ -130,17 +135,22 @@ class FormEntryViewModel(
         } catch (e: Exception) {
             errorMessage = "Error answering question: ${e.message}"
         }
+        return false
     }
 
-    fun answerQuestionString(index: Int, value: String) {
+    /**
+     * Answer a question with a string value. Returns true if accepted.
+     */
+    fun answerQuestionString(index: Int, value: String): Boolean {
         val prompts = formSession.getPrompts()
         if (index < prompts.size) {
             val prompt = prompts[index]
             val data = FormEntrySession.createAnswerData(
                 value, prompt.getControlType(), prompt.getDataType()
             )
-            answerQuestion(index, data)
+            return answerQuestion(index, data)
         }
+        return false
     }
 
     /**
@@ -443,6 +453,7 @@ class FormEntryViewModel(
                     Constants.DATATYPE_DECIMAL -> QuestionType.DECIMAL
                     Constants.DATATYPE_DATE -> QuestionType.DATE
                     Constants.DATATYPE_TIME -> QuestionType.TIME
+                    Constants.DATATYPE_DATE_TIME -> QuestionType.DATETIME
                     Constants.DATATYPE_GEOPOINT -> QuestionType.GEOPOINT
                     else -> QuestionType.TEXT
                 }


### PR DESCRIPTION
## Summary

- Add 7 select appearance variants: minimal, compact, quick, combobox, label, list-nolabel, collapsible groups
- Add DATETIME combined widget (date + time side by side)
- Appearance-driven rendering branches on `question.appearance` string
- Default behavior unchanged when no appearance specified

Closes #351

## Test plan

- [x] `compileCommonMainKotlinMetadata` passes
- [x] `./gradlew :app:jvmTest` passes (all existing tests)
- [ ] Manual verification of each appearance variant with test forms
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)