### PR TITLE
perf: crypto, restore, and case list benchmarks (Phase 8 Tasks 7-8)

### DIFF
--- a/app/src/jvmTest/kotlin/org/commcare/app/perf/CaseListBenchmark.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/perf/CaseListBenchmark.kt
@@ -1,0 +1,207 @@
+package org.commcare.app.perf
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import org.commcare.app.storage.CommCareDatabase
+import org.commcare.app.storage.SqlDelightUserSandbox
+import org.commcare.cases.model.Case
+import org.commcare.core.parse.ParseUtils
+import org.javarosa.core.io.createByteArrayInputStream
+import kotlin.system.measureTimeMillis
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Performance benchmarks for case list loading from storage.
+ *
+ * Populates a sandbox with cases via restore XML, then measures the time to
+ * iterate all cases, read individual records, and query by meta-data index.
+ * This reflects the critical path when a user opens a case list screen.
+ *
+ * Each test prints a BENCHMARK line for CI log parsing and asserts a generous
+ * upper bound so the test only fails on severe regressions.
+ */
+class CaseListBenchmark {
+
+    private fun createSandbox(): SqlDelightUserSandbox {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        CommCareDatabase.Schema.create(driver)
+        val db = CommCareDatabase(driver)
+        return SqlDelightUserSandbox(db)
+    }
+
+    /**
+     * Generate restore XML with [caseCount] cases of the given [caseType].
+     */
+    private fun generateRestoreXml(caseCount: Int, caseType: String = "patient"): String {
+        val sb = StringBuilder(caseCount * 400)
+        sb.append("""<?xml version="1.0"?>""")
+        sb.append("""<OpenRosaResponse xmlns="http://openrosa.org/http/response">""")
+        sb.append("""<message nature="ota_restore_success">Success</message>""")
+        sb.append("""<Sync xmlns="http://commcarehq.org/sync">""")
+        sb.append("""<restore_id>bench-sync-token</restore_id>""")
+        sb.append("""</Sync>""")
+
+        for (i in 1..caseCount) {
+            sb.append("""<case case_id="case-$i" date_modified="2026-03-24T12:00:00.000000Z" """)
+            sb.append("""xmlns="http://commcarehq.org/case/transaction/v2">""")
+            sb.append("""<create>""")
+            sb.append("""<case_type>$caseType</case_type>""")
+            sb.append("""<case_name>Record $i</case_name>""")
+            sb.append("""<owner_id>user-bench</owner_id>""")
+            sb.append("""</create>""")
+            sb.append("""<update>""")
+            sb.append("""<first_name>First $i</first_name>""")
+            sb.append("""<last_name>Last $i</last_name>""")
+            sb.append("""<age>${20 + (i % 60)}</age>""")
+            sb.append("""</update>""")
+            sb.append("""</case>""")
+        }
+
+        sb.append("""</OpenRosaResponse>""")
+        return sb.toString()
+    }
+
+    /**
+     * Populate a sandbox with [count] cases via restore parsing.
+     */
+    private fun populateSandbox(sandbox: SqlDelightUserSandbox, count: Int, caseType: String = "patient") {
+        val xml = generateRestoreXml(count, caseType)
+        ParseUtils.parseIntoSandbox(
+            createByteArrayInputStream(xml.encodeToByteArray()),
+            sandbox,
+            false
+        )
+    }
+
+    @Test
+    fun benchmarkCaseListLoad100() {
+        val sandbox = createSandbox()
+        populateSandbox(sandbox, 100)
+        val storage = sandbox.getCaseStorage()
+        assertEquals(100, storage.getNumRecords())
+
+        // Measure full iteration (simulates case list screen load)
+        val ms = measureTimeMillis {
+            repeat(10) {
+                val iter = storage.iterate()
+                var count = 0
+                while (iter.hasMore()) {
+                    val c = iter.nextRecord()
+                    // Access properties like a case list would
+                    c.getName()
+                    c.getTypeId()
+                    count++
+                }
+                assertEquals(100, count)
+            }
+        }
+        println("BENCHMARK: 10x iterate 100 cases in ${ms}ms (${ms / 10.0}ms/iteration)")
+        assertTrue(ms < 5000, "10x iterating 100 cases should complete within 5s, took ${ms}ms")
+    }
+
+    @Test
+    fun benchmarkCaseListLoad500() {
+        val sandbox = createSandbox()
+        populateSandbox(sandbox, 500)
+        val storage = sandbox.getCaseStorage()
+        assertEquals(500, storage.getNumRecords())
+
+        val ms = measureTimeMillis {
+            repeat(10) {
+                val iter = storage.iterate()
+                var count = 0
+                while (iter.hasMore()) {
+                    val c = iter.nextRecord()
+                    c.getName()
+                    c.getTypeId()
+                    count++
+                }
+                assertEquals(500, count)
+            }
+        }
+        println("BENCHMARK: 10x iterate 500 cases in ${ms}ms (${ms / 10.0}ms/iteration)")
+        assertTrue(ms < 10000, "10x iterating 500 cases should complete within 10s, took ${ms}ms")
+    }
+
+    @Test
+    fun benchmarkCaseMetaIndexLookup() {
+        val sandbox = createSandbox()
+        // Create mixed-type cases: 200 patient + 100 household
+        populateSandbox(sandbox, 200, "patient")
+        // Add household cases via direct storage since restore would overwrite sync token
+        val storage = sandbox.getCaseStorage()
+        for (i in 1..100) {
+            val c = Case("household-$i", "household")
+            c.setName("Household $i")
+            c.setCaseId("hh-case-$i")
+            storage.add(c)
+        }
+        assertEquals(300, storage.getNumRecords())
+
+        // Measure index lookup by case-type (used for filtering case lists)
+        val ms = measureTimeMillis {
+            repeat(1000) {
+                val patientIds = storage.getIDsForValue("case-type", "patient")
+                assertEquals(200, patientIds.size)
+            }
+        }
+        println("BENCHMARK: 1000x meta-index lookup (case-type) in ${ms}ms (${ms / 1000.0}ms/op)")
+        assertTrue(ms < 5000, "1000 index lookups should complete within 5s, took ${ms}ms")
+    }
+
+    @Test
+    fun benchmarkBulkRead() {
+        val sandbox = createSandbox()
+        populateSandbox(sandbox, 200)
+        val storage = sandbox.getCaseStorage()
+        assertEquals(200, storage.getNumRecords())
+
+        // Get all IDs
+        val allIds = storage.getIDsForValue("case-type", "patient")
+        val idSet = LinkedHashSet(allIds)
+
+        // Measure bulk read (used when rendering case list with all data)
+        val ms = measureTimeMillis {
+            repeat(50) {
+                val recordMap = HashMap<Int, Case>()
+                storage.bulkRead(idSet, recordMap)
+                assertEquals(200, recordMap.size)
+            }
+        }
+        println("BENCHMARK: 50x bulkRead 200 cases in ${ms}ms (${ms / 50.0}ms/op)")
+        assertTrue(ms < 5000, "50x bulk reading 200 cases should complete within 5s, took ${ms}ms")
+    }
+
+    @Test
+    fun benchmarkCasePropertyAccess() {
+        val sandbox = createSandbox()
+        populateSandbox(sandbox, 100)
+        val storage = sandbox.getCaseStorage()
+
+        // Read all cases into a list
+        val cases = mutableListOf<Case>()
+        val iter = storage.iterate()
+        while (iter.hasMore()) {
+            cases.add(iter.nextRecord())
+        }
+        assertEquals(100, cases.size)
+
+        // Measure property access (simulates rendering case detail fields)
+        val ms = measureTimeMillis {
+            repeat(100) {
+                for (c in cases) {
+                    c.getName()
+                    c.getTypeId()
+                    c.getCaseId()
+                    c.isClosed()
+                    c.getProperty("first_name")
+                    c.getProperty("last_name")
+                    c.getProperty("age")
+                }
+            }
+        }
+        println("BENCHMARK: 100x access 7 properties on 100 cases in ${ms}ms")
+        assertTrue(ms < 5000, "100x property access on 100 cases should complete within 5s, took ${ms}ms")
+    }
+}

--- a/app/src/jvmTest/kotlin/org/commcare/app/perf/CryptoBenchmark.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/perf/CryptoBenchmark.kt
@@ -1,0 +1,110 @@
+package org.commcare.app.perf
+
+import org.commcare.core.interfaces.PlatformCrypto
+import kotlin.system.measureTimeMillis
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Performance benchmarks for platform cryptography operations.
+ *
+ * These tests establish baseline timing for AES-256-GCM encryption/decryption,
+ * PBKDF2 key derivation, and SHA-256 hashing — the operations used for user
+ * key records, encrypted storage, and password verification in CommCare.
+ *
+ * Each test prints a BENCHMARK line for CI log parsing and asserts a generous
+ * upper bound so the test only fails on severe regressions.
+ */
+class CryptoBenchmark {
+
+    @Test
+    fun benchmarkAesEncrypt1KB() {
+        val key = PlatformCrypto.generateAesKey(256)
+        val data = ByteArray(1024) { it.toByte() }
+
+        // Warm up JIT
+        repeat(10) { PlatformCrypto.aesEncrypt(data, key) }
+
+        val ms = measureTimeMillis {
+            repeat(1000) { PlatformCrypto.aesEncrypt(data, key) }
+        }
+        println("BENCHMARK: 1000x AES-256-GCM encrypt 1KB in ${ms}ms (${ms / 1000.0}ms/op)")
+        assertTrue(ms < 30000, "1000 AES encryptions should complete within 30s, took ${ms}ms")
+    }
+
+    @Test
+    fun benchmarkAesDecrypt1KB() {
+        val key = PlatformCrypto.generateAesKey(256)
+        val data = ByteArray(1024) { it.toByte() }
+        val encrypted = PlatformCrypto.aesEncrypt(data, key)
+
+        // Warm up JIT
+        repeat(10) { PlatformCrypto.aesDecrypt(encrypted, key) }
+
+        val ms = measureTimeMillis {
+            repeat(1000) { PlatformCrypto.aesDecrypt(encrypted, key) }
+        }
+        println("BENCHMARK: 1000x AES-256-GCM decrypt 1KB in ${ms}ms (${ms / 1000.0}ms/op)")
+        assertTrue(ms < 30000, "1000 AES decryptions should complete within 30s, took ${ms}ms")
+    }
+
+    @Test
+    fun benchmarkAesRoundTrip10KB() {
+        val key = PlatformCrypto.generateAesKey(256)
+        val data = ByteArray(10_240) { it.toByte() }
+
+        // Warm up
+        repeat(5) {
+            val enc = PlatformCrypto.aesEncrypt(data, key)
+            PlatformCrypto.aesDecrypt(enc, key)
+        }
+
+        val ms = measureTimeMillis {
+            repeat(500) {
+                val enc = PlatformCrypto.aesEncrypt(data, key)
+                PlatformCrypto.aesDecrypt(enc, key)
+            }
+        }
+        println("BENCHMARK: 500x AES-256-GCM roundtrip 10KB in ${ms}ms (${ms / 500.0}ms/op)")
+        assertTrue(ms < 30000, "500 AES roundtrips of 10KB should complete within 30s, took ${ms}ms")
+    }
+
+    @Test
+    fun benchmarkPbkdf2_100k() {
+        val salt = "user@domain.com".encodeToByteArray()
+
+        val ms = measureTimeMillis {
+            PlatformCrypto.pbkdf2("testpassword", salt, 100_000, 32)
+        }
+        println("BENCHMARK: PBKDF2 100K iterations in ${ms}ms")
+        assertTrue(ms < 10000, "PBKDF2 100K iterations should complete within 10s, took ${ms}ms")
+    }
+
+    @Test
+    fun benchmarkSha256() {
+        val data = ByteArray(10_000) { it.toByte() }
+
+        // Warm up
+        repeat(100) { PlatformCrypto.sha256(data) }
+
+        val ms = measureTimeMillis {
+            repeat(10_000) { PlatformCrypto.sha256(data) }
+        }
+        println("BENCHMARK: 10000x SHA-256 of 10KB in ${ms}ms (${ms / 10000.0}ms/op)")
+        assertTrue(ms < 30000, "10000 SHA-256 hashes should complete within 30s, took ${ms}ms")
+    }
+
+    @Test
+    fun benchmarkMd5() {
+        val data = ByteArray(10_000) { it.toByte() }
+
+        // Warm up
+        repeat(100) { PlatformCrypto.md5(data) }
+
+        val ms = measureTimeMillis {
+            repeat(10_000) { PlatformCrypto.md5(data) }
+        }
+        println("BENCHMARK: 10000x MD5 of 10KB in ${ms}ms (${ms / 10000.0}ms/op)")
+        assertTrue(ms < 30000, "10000 MD5 hashes should complete within 30s, took ${ms}ms")
+    }
+}

--- a/app/src/jvmTest/kotlin/org/commcare/app/perf/RestoreBenchmark.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/perf/RestoreBenchmark.kt
@@ -1,0 +1,135 @@
+package org.commcare.app.perf
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import org.commcare.app.storage.CommCareDatabase
+import org.commcare.app.storage.SqlDelightUserSandbox
+import org.commcare.core.parse.ParseUtils
+import org.javarosa.core.io.createByteArrayInputStream
+import kotlin.system.measureTimeMillis
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Performance benchmarks for OTA restore XML parsing.
+ *
+ * Generates synthetic restore payloads with varying case counts and measures
+ * end-to-end parse time through [ParseUtils.parseIntoSandbox]. This exercises
+ * the full XML pull-parser -> CaseXmlParser -> InMemoryStorage pipeline, which
+ * is the critical path during user login and sync.
+ *
+ * Each test prints a BENCHMARK line for CI log parsing and asserts a generous
+ * upper bound so the test only fails on severe regressions.
+ */
+class RestoreBenchmark {
+
+    private fun createSandbox(): SqlDelightUserSandbox {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        CommCareDatabase.Schema.create(driver)
+        val db = CommCareDatabase(driver)
+        return SqlDelightUserSandbox(db)
+    }
+
+    /**
+     * Generate a valid CommCare OTA restore XML payload with [caseCount] cases.
+     * Each case has a create block (case_type, case_name, owner_id) and an
+     * update block with 3 properties, matching the v2 case transaction format.
+     */
+    private fun generateRestoreXml(caseCount: Int): String {
+        val sb = StringBuilder(caseCount * 400) // rough estimate per case
+        sb.append("""<?xml version="1.0"?>""")
+        sb.append("""<OpenRosaResponse xmlns="http://openrosa.org/http/response">""")
+        sb.append("""<message nature="ota_restore_success">Success</message>""")
+        sb.append("""<Sync xmlns="http://commcarehq.org/sync">""")
+        sb.append("""<restore_id>bench-sync-token</restore_id>""")
+        sb.append("""</Sync>""")
+
+        for (i in 1..caseCount) {
+            sb.append("""<case case_id="case-$i" date_modified="2026-03-24T12:00:00.000000Z" """)
+            sb.append("""xmlns="http://commcarehq.org/case/transaction/v2">""")
+            sb.append("""<create>""")
+            sb.append("""<case_type>patient</case_type>""")
+            sb.append("""<case_name>Patient $i</case_name>""")
+            sb.append("""<owner_id>user-bench</owner_id>""")
+            sb.append("""</create>""")
+            sb.append("""<update>""")
+            sb.append("""<first_name>Patient</first_name>""")
+            sb.append("""<last_name>Number $i</last_name>""")
+            sb.append("""<age>${20 + (i % 60)}</age>""")
+            sb.append("""</update>""")
+            sb.append("""</case>""")
+        }
+
+        sb.append("""</OpenRosaResponse>""")
+        return sb.toString()
+    }
+
+    @Test
+    fun benchmarkRestore100Cases() {
+        val sandbox = createSandbox()
+        val xml = generateRestoreXml(100)
+
+        val ms = measureTimeMillis {
+            ParseUtils.parseIntoSandbox(
+                createByteArrayInputStream(xml.encodeToByteArray()),
+                sandbox,
+                false
+            )
+        }
+
+        val caseCount = sandbox.getCaseStorage().getNumRecords()
+        println("BENCHMARK: 100 cases restore parsed in ${ms}ms ($caseCount cases stored)")
+        assertEquals(100, caseCount, "All 100 cases should be stored")
+        assertTrue(ms < 10000, "100-case restore should parse within 10s, took ${ms}ms")
+    }
+
+    @Test
+    fun benchmarkRestore500Cases() {
+        val sandbox = createSandbox()
+        val xml = generateRestoreXml(500)
+
+        val ms = measureTimeMillis {
+            ParseUtils.parseIntoSandbox(
+                createByteArrayInputStream(xml.encodeToByteArray()),
+                sandbox,
+                false
+            )
+        }
+
+        val caseCount = sandbox.getCaseStorage().getNumRecords()
+        println("BENCHMARK: 500 cases restore parsed in ${ms}ms ($caseCount cases stored)")
+        assertEquals(500, caseCount, "All 500 cases should be stored")
+        assertTrue(ms < 30000, "500-case restore should parse within 30s, took ${ms}ms")
+    }
+
+    @Test
+    fun benchmarkRestore500CasesBulk() {
+        val sandbox = createSandbox()
+        val xml = generateRestoreXml(500)
+
+        val ms = measureTimeMillis {
+            ParseUtils.parseIntoSandbox(
+                createByteArrayInputStream(xml.encodeToByteArray()),
+                sandbox,
+                false,
+                bulkProcessingEnabled = true
+            )
+        }
+
+        val caseCount = sandbox.getCaseStorage().getNumRecords()
+        println("BENCHMARK: 500 cases restore (bulk) parsed in ${ms}ms ($caseCount cases stored)")
+        assertEquals(500, caseCount, "All 500 cases should be stored in bulk mode")
+        assertTrue(ms < 30000, "500-case bulk restore should parse within 30s, took ${ms}ms")
+    }
+
+    @Test
+    fun benchmarkRestoreXmlGeneration() {
+        // Verify XML generation itself is fast and not a bottleneck in other benchmarks
+        val ms = measureTimeMillis {
+            val xml = generateRestoreXml(1000)
+            assertTrue(xml.length > 100_000, "1000-case XML should be substantial")
+        }
+        println("BENCHMARK: 1000-case XML generation in ${ms}ms")
+        assertTrue(ms < 5000, "XML generation for 1000 cases should be fast, took ${ms}ms")
+    }
+}


### PR DESCRIPTION
## Summary

Performance benchmark suite: AES, PBKDF2, SHA-256, restore parsing, case list loading.
Prints timing to stdout, asserts generous upper bounds for regression detection.

Closes #377

## Test plan

- [x] `./gradlew :app:jvmTest --tests "*.perf.*"` — all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)