### PR TITLE
chore: App Store metadata + encryption compliance (Phase 8 Tasks 5b+6)

### DIFF
--- a/app/iosApp/iosApp/Info.plist
+++ b/app/iosApp/iosApp/Info.plist
@@ -42,6 +42,8 @@
 	<string>CommCare needs photo library access to attach images</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>CommCare needs location access to capture GPS coordinates for forms</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<true/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/app/iosApp/metadata/en-US/description.txt
+++ b/app/iosApp/metadata/en-US/description.txt
@@ -1,0 +1,21 @@
+CommCare is a mobile data collection and case management platform used by frontline workers in global health, agriculture, and social services.
+
+Built by Dimagi, CommCare enables organizations to create custom mobile applications without coding. Frontline workers use CommCare to:
+
+- Collect data using customizable forms with validation, skip logic, and multimedia support
+- Manage cases over time — track patients, households, or any entity across multiple visits
+- Work offline and sync automatically when connectivity is available
+- Access decision support and checklists during field visits
+- View reports and dashboards on collected data
+
+CommCare is used by over 500 organizations in 80+ countries, supporting millions of frontline workers. Applications are built in CommCare HQ (www.commcarehq.org) and deployed to mobile devices.
+
+This app requires a CommCare HQ account to function. Contact your organization administrator or visit www.dimagi.com to learn more.
+
+Key features:
+- Offline-first: collect data without internet, sync when connected
+- Multimedia: capture photos, audio, video, signatures, GPS coordinates, and barcodes
+- Case management: track and follow up on cases over time
+- Multiple languages: forms support any language including RTL scripts
+- Secure: AES-256 encryption for data at rest, PIN and biometric login
+- Connect marketplace: access opportunities and earn through Connect ID

--- a/app/iosApp/metadata/en-US/keywords.txt
+++ b/app/iosApp/metadata/en-US/keywords.txt
@@ -1,0 +1,1 @@
+commcare,data collection,case management,mobile health,mhealth,frontline,community health,survey,forms,dimagi,offline,field work

--- a/app/iosApp/metadata/en-US/privacy_url.txt
+++ b/app/iosApp/metadata/en-US/privacy_url.txt
@@ -1,0 +1,1 @@
+https://www.dimagi.com/terms/

--- a/app/iosApp/metadata/en-US/subtitle.txt
+++ b/app/iosApp/metadata/en-US/subtitle.txt
@@ -1,0 +1,1 @@
+Mobile Data Collection & Case Management

--- a/app/iosApp/metadata/en-US/support_url.txt
+++ b/app/iosApp/metadata/en-US/support_url.txt
@@ -1,0 +1,1 @@
+https://www.dimagi.com/commcare/


### PR DESCRIPTION
## Summary

- App Store metadata files (description, keywords, subtitle, privacy URL, support URL)
- Info.plist: ITSAppUsesNonExemptEncryption = YES for AES-256 encryption compliance

## Test plan

- [x] `compileCommonMainKotlinMetadata` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)