### PR TITLE
fix: encryption compliance + iosArm64 PBKDF2 build

### DIFF
--- a/app/iosApp/iosApp/Info.plist
+++ b/app/iosApp/iosApp/Info.plist
@@ -43,7 +43,7 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>CommCare needs location access to capture GPS coordinates for forms</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<true/>
+	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/commcare-core/src/iosNativeCrypto/kotlin/org/commcare/core/interfaces/PlatformCrypto.kt
+++ b/commcare-core/src/iosNativeCrypto/kotlin/org/commcare/core/interfaces/PlatformCrypto.kt
@@ -176,20 +176,18 @@ actual object PlatformCrypto {
 
     actual fun pbkdf2(password: String, salt: ByteArray, iterations: Int, keyLengthBytes: Int): ByteArray {
         val derivedKey = ByteArray(keyLengthBytes)
-        val passwordBytes = password.encodeToByteArray()
+        val passwordLen = password.encodeToByteArray().size.toUInt()
 
-        passwordBytes.usePinned { pinnedPassword ->
-            salt.usePinned { pinnedSalt ->
-                derivedKey.usePinned { pinnedKey ->
-                    val status = cc_pbkdf2_sha256(
-                        pinnedPassword.addressOf(0).reinterpret(),
-                        passwordBytes.size.toUInt(),
-                        pinnedSalt.addressOf(0), salt.size.toUInt(),
-                        iterations.toUInt(),
-                        pinnedKey.addressOf(0), keyLengthBytes.toUInt()
-                    )
-                    check(status == 0) { "PBKDF2 failed with status $status" }
-                }
+        salt.usePinned { pinnedSalt ->
+            derivedKey.usePinned { pinnedKey ->
+                val status = cc_pbkdf2_sha256(
+                    password,
+                    passwordLen,
+                    pinnedSalt.addressOf(0), salt.size.toUInt(),
+                    iterations.toUInt(),
+                    pinnedKey.addressOf(0), keyLengthBytes.toUInt()
+                )
+                check(status == 0) { "PBKDF2 failed with status $status" }
             }
         }
 


### PR DESCRIPTION
## Summary

- ITSAppUsesNonExemptEncryption set to NO (exempt for device-local encryption)
- iosArm64 PBKDF2 fix: K/N maps `const char*` to `String?` on device target

Verified: full archive + App Store Connect upload succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)