### PR TITLE
fix(#406): MSelect state restored from engine answer in updateQuestions

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/FormEntryViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/FormEntryViewModel.kt
@@ -459,11 +459,24 @@ class FormEntryViewModel(
         questions = try {
             formSession.getPrompts().mapIndexed { index, prompt ->
                 val questionId = prompt.getIndex().toString()
-                val engineValue = prompt.getAnswerValue()?.getDisplayText() ?: ""
+                val answerValue = prompt.getAnswerValue()
+                val engineValue = answerValue?.getDisplayText() ?: ""
                 // Draft always wins over engine value — that's the whole point
                 // of the draft layer (#394). Drafts are cleared on successful
                 // commit and on navigation.
                 val displayValue = draftTexts[index] ?: engineValue
+                // For select-multi, extract the selected values from the
+                // engine's SelectMultiData so the checkbox UI can reflect the
+                // current selection. Without this, every refresh (triggered
+                // by toggleMultiSelectChoice → answerQuestion → updateQuestions)
+                // would reset selectedChoices to empty and the UI would never
+                // show a checked box even though the engine has accepted the
+                // answer.
+                val selectedChoices: Set<String> = if (answerValue is SelectMultiData) {
+                    answerValue.getValue().map { it.getValue() }.toSet()
+                } else {
+                    emptySet()
+                }
                 QuestionState(
                     questionId = questionId,
                     questionText = prompt.getQuestionText() ?: prompt.getLongText() ?: "",
@@ -476,6 +489,7 @@ class FormEntryViewModel(
                         it.labelInnerText ?: it.value ?: ""
                     } ?: emptyList(),
                     appearance = prompt.getAppearanceHint(),
+                    selectedChoices = selectedChoices,
                     audioUri = try { prompt.getAudioText() } catch (_: Exception) { null },
                     imageUri = try { prompt.getImageText() } catch (_: Exception) { null }
                 )

--- a/app/src/jvmTest/kotlin/org/commcare/app/viewmodel/MultiSelectStateTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/viewmodel/MultiSelectStateTest.kt
@@ -1,0 +1,136 @@
+package org.commcare.app.viewmodel
+
+import org.commcare.app.engine.FormEntrySession
+import org.javarosa.xform.util.XFormUtils
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for multi-select question state management in
+ * [FormEntryViewModel].
+ *
+ * Historical context: `updateQuestions()` used to rebuild the questions list
+ * from the engine's prompts without carrying the currently-selected values
+ * into `QuestionState.selectedChoices`. Every call to
+ * `toggleMultiSelectChoice` triggers an `answerQuestion` → `updateQuestions`
+ * cycle, so each new tap would immediately reset `selectedChoices` back to
+ * `emptySet()` even though the engine had happily accepted the answer. The
+ * visible symptom (caught during Phase 9 Wave 5 scouting of the Visit form
+ * on iOS): tapping a checkbox briefly highlighted the row but the checkbox
+ * never rendered as checked.
+ *
+ * The fix populates `selectedChoices` from the engine's `SelectMultiData`
+ * answer inside `updateQuestions()`, so the UI always reflects whatever the
+ * engine has accepted. These tests guard that behavior.
+ */
+class MultiSelectStateTest {
+
+    /**
+     * Load the test_multi_select.xml form, navigate to the symptoms
+     * (select-multi) question, and verify that the test fixture is what
+     * we expect before exercising toggle behavior.
+     */
+    private fun setupViewModelAtSymptomsQuestion(): FormEntryViewModel {
+        val stream = this::class.java.getResourceAsStream("/test_multi_select.xml")
+        assertNotNull(stream, "test_multi_select.xml fixture missing")
+        val formDef = XFormUtils.getFormFromInputStream(stream)
+        assertNotNull(formDef)
+
+        val session = FormEntrySession(formDef)
+        val vm = FormEntryViewModel(session)
+        vm.loadForm()
+
+        // Question 0 = favorite_color (select-one), Question 1 = symptoms
+        // (select-multi). Navigate past the first to reach the multi-select.
+        assertEquals(QuestionType.SELECT_ONE, vm.questions[0].questionType)
+        vm.nextQuestion()
+
+        // We should now be on the select-multi question.
+        assertTrue(vm.questions.isNotEmpty(), "no questions after nextQuestion")
+        assertEquals(
+            QuestionType.SELECT_MULTI,
+            vm.questions[0].questionType,
+            "expected select-multi as second question"
+        )
+        return vm
+    }
+
+    @Test
+    fun selectedChoicesPersistAfterSingleToggle() {
+        val vm = setupViewModelAtSymptomsQuestion()
+
+        vm.toggleMultiSelectChoice(0, "fever")
+
+        // After a single toggle, the ViewModel should reflect the selection.
+        // Before the fix, `updateQuestions()` ran inside `answerQuestion`
+        // (triggered by the toggle) and wiped `selectedChoices` back to empty.
+        assertEquals(
+            setOf("fever"),
+            vm.questions[0].selectedChoices,
+            "selectedChoices should contain 'fever' after first toggle; " +
+                "if empty, updateQuestions is dropping engine state"
+        )
+    }
+
+    @Test
+    fun selectedChoicesAccumulateAcrossMultipleToggles() {
+        val vm = setupViewModelAtSymptomsQuestion()
+
+        vm.toggleMultiSelectChoice(0, "fever")
+        vm.toggleMultiSelectChoice(0, "cough")
+        vm.toggleMultiSelectChoice(0, "headache")
+
+        // All three selections should be present. Before the fix, each
+        // subsequent toggle would start from an empty set because the
+        // previous answer had been wiped by updateQuestions, so the final
+        // state would only contain "headache".
+        assertEquals(
+            setOf("fever", "cough", "headache"),
+            vm.questions[0].selectedChoices,
+            "all three toggled choices should persist across successive calls"
+        )
+    }
+
+    @Test
+    fun togglingSelectedChoiceRemovesItFromState() {
+        val vm = setupViewModelAtSymptomsQuestion()
+
+        vm.toggleMultiSelectChoice(0, "fever")
+        vm.toggleMultiSelectChoice(0, "cough")
+        // Un-toggle fever — should leave only cough.
+        vm.toggleMultiSelectChoice(0, "fever")
+
+        assertEquals(
+            setOf("cough"),
+            vm.questions[0].selectedChoices,
+            "un-toggling should remove a choice without affecting siblings"
+        )
+    }
+
+    @Test
+    fun selectedChoicesSurviveNavigationAwayAndBack() {
+        val vm = setupViewModelAtSymptomsQuestion()
+
+        vm.toggleMultiSelectChoice(0, "fever")
+        vm.toggleMultiSelectChoice(0, "cough")
+
+        // Navigate forward to the third question, then back to the
+        // select-multi. The engine retains the answer across navigation, so
+        // the UI state should reflect it when we return.
+        vm.nextQuestion()
+        vm.previousQuestion()
+
+        assertEquals(
+            QuestionType.SELECT_MULTI,
+            vm.questions[0].questionType,
+            "should have navigated back to the select-multi question"
+        )
+        assertEquals(
+            setOf("fever", "cough"),
+            vm.questions[0].selectedChoices,
+            "selectedChoices should survive forward+back navigation"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fifth bug in the Phase 9 Wave 5a pattern. Tapping a checkbox on a multi-select question on iOS briefly highlighted the row but the box never rendered as checked, and the form couldn't advance past the required MSelect. Caught while scouting the Visit form's "family planning type" page.

Root cause is in `commonMain` (not iOS-specific): `FormEntryViewModel.updateQuestions()` rebuilds the questions list from the engine prompts but never populates `QuestionState.selectedChoices` from the engine answer — it falls back to the default `emptySet()`. Every `toggleMultiSelectChoice` call triggers an `answerQuestion → updateQuestions` cycle, so each tap immediately wiped the selection the user had just made.

## Fix

Read `prompt.getAnswerValue()` inside `updateQuestions()` and extract values when it's a `SelectMultiData`. Engine is the source of truth — the ViewModel had an accidental dependence on `toggleMultiSelectChoice` being the only code path that populated `selectedChoices`, which is wrong.

```kotlin
val selectedChoices: Set<String> = if (answerValue is SelectMultiData) {
    answerValue.getValue().map { it.getValue() }.toSet()
} else {
    emptySet()
}
```

## Test Coverage Gap (Again)

**Zero** tests exercised `FormEntryViewModel.toggleMultiSelectChoice`. Engine-level oracle tests in `ComprehensiveOracleTest` and `GoldenFileGenerator` exercised `SelectMultiData` at the engine layer but never touched the ViewModel path that drives the UI.

`RepeatGroupTest.kt` and `FormNavigationTest.kt` in the same package look like ViewModel tests but are placeholder tests asserting constants and defaults. The file explicitly acknowledges "cannot construct ViewModel without FormEntrySession, so test state defaults" — i.e. the author knew they weren't testing the real thing and moved on. That's the AI-port pattern the user flagged earlier in this session.

New `MultiSelectStateTest.kt` adds 4 real regression tests:

- `selectedChoicesPersistAfterSingleToggle` — minimal repro
- `selectedChoicesAccumulateAcrossMultipleToggles` — three consecutive toggles all persist
- `togglingSelectedChoiceRemovesItFromState` — un-toggle works and doesn't affect siblings
- `selectedChoicesSurviveNavigationAwayAndBack` — forward+back navigation survives engine round-trip

**All 4 fail without the fix** (verified by reverting the fix, running the tests, watching them fail, then restoring). **All 4 pass with the fix.**

## Systematic Pattern

Fifth low-level bug caught by Phase 9 E2E expansion, all in the same class:

1. #391 — `LoginViewModel` domain fallback (PR #398)
2. #399 — `CaseListViewModel` filtering (PR #400)
3. #401 — iOS `loadClasspathResource` stub (PR #402)
4. #403 — iOS XML parser whitespace/comment coalescing (PR #404)
5. **This PR** — `FormEntryViewModel.updateQuestions` dropping MSelect state

All five were AI-ported code that passed the ported test suite. All five were invisible until real E2E testing hit them. The ViewModel layer in particular has a big test coverage hole — oracle tests cover the engine, Maestro flows cover the screens, and nothing covers the ViewModel that glues them together. Learning doc follows in a separate doc PR per CLAUDE.md rules.

Closes #406.

## Test plan

- [x] `:app:jvmTest --tests "org.commcare.app.viewmodel.MultiSelectStateTest"` — 4/4 passing with fix, 4/4 failing without
- [x] `:app:compileKotlinJvm` — clean
- [ ] CI: `CommCare Core Tests` + `iOS Build & Test` green
- [ ] Manual: Phase 9 Wave 5a scout can tap two MSelect checkboxes on the Visit form and advance past the "family planning type" page