### PR TITLE
fix(#410): call configureApp before state transition on kill-relaunch

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/App.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/App.kt
@@ -123,10 +123,20 @@ fun App(db: CommCareDatabase) {
 
             // If apps exist in DB but LoginViewModel is still LoggedOut, bridge the gap:
             // load the seated app and transition to NeedsLogin so the app switcher gets data.
+            // Crucially, call configureApp BEFORE the state transition so the login
+            // VM has the app's domain populated by the time the login screen renders.
+            // Without this, a fast tap on Log In races against the LaunchedEffect in
+            // the NeedsLogin branch, and resolveDomain() falls back to "demo" because
+            // currentApp is still null. See #410.
             if (hasApps.value && appState is AppState.LoggedOut) {
                 val seatedApp = appRepository.getSeatedApp()
                 if (seatedApp != null) {
                     val allApps = appRepository.getAllApps()
+                    loginViewModel.configureApp(
+                        serverUrl = "https://www.commcarehq.org",
+                        appId = seatedApp.id,
+                        app = seatedApp
+                    )
                     loginViewModel.setReadyState(AppState.NeedsLogin(seatedApp, allApps))
                 }
             }


### PR DESCRIPTION
## Summary

After kill-relaunch, short-form username login (e.g. `haltest`) returned "Invalid username or password" even though the same credentials worked on fresh install. The fix is a one-line addition to the `LoggedOut → NeedsLogin` bridge in `App.kt`.

## Root Cause

The bridge loaded the seated app from the repository and called `setReadyState(NeedsLogin)`, but deferred `configureApp()` to a `LaunchedEffect` in the `NeedsLogin` Compose branch. `LaunchedEffect` runs asynchronously — a fast tap on Log In (or Maestro's automated tap) races it, and `resolveDomain()` finds `currentApp` still null, falling back to `"demo"`.

## Fix

Call `loginViewModel.configureApp(...)` synchronously in the bridge, before `setReadyState`, so the domain is populated by the time the login screen renders. The `LaunchedEffect` in the `NeedsLogin` branch still fires and calls `configureApp` redundantly, which is harmless (idempotent setter).

```kotlin
if (hasApps.value && appState is AppState.LoggedOut) {
    val seatedApp = appRepository.getSeatedApp()
    if (seatedApp != null) {
        val allApps = appRepository.getAllApps()
        loginViewModel.configureApp(              // NEW — populate before transition
            serverUrl = "https://www.commcarehq.org",
            appId = seatedApp.id,
            app = seatedApp
        )
        loginViewModel.setReadyState(AppState.NeedsLogin(seatedApp, allApps))
    }
}
```

## Verification

On-device (iOS simulator):

1. Fresh install → install Bonsaaso via profile URL → login with `haltest` → home screen (success)
2. `xcrun simctl terminate` → `xcrun simctl launch` → login with `haltest` → **home screen (success)**

Before the fix, step 2 returned "Invalid username or password". Full-form `haltest@jonstest.commcarehq.org` worked as a workaround because `resolveDomain()` extracts the domain from the `@` suffix without needing `currentApp`.

Closes #410.

## Test plan

- [x] On-device: kill-relaunch re-login with short-form username succeeds
- [x] On-device: fresh install login still works (no regression)
- [x] `:app:compileKotlinJvm` — clean
- [ ] CI: `CommCare Core Tests` + `iOS Build & Test` green