### PR TITLE
fix(#416): move LoggedOut→NeedsLogin bridge to LaunchedEffect

### DIFF
--- a/.maestro/flows/app-switch-to-bonsaaso.yaml
+++ b/.maestro/flows/app-switch-to-bonsaaso.yaml
@@ -1,0 +1,58 @@
+# Wave 6: switch from Small App back to Bonsaaso via the login dropdown.
+# Precondition: at the NeedsLogin screen with Small App seated.
+
+appId: org.marshellis.commcare.ios
+
+---
+
+- extendedWaitUntil:
+    visible:
+      text: ".*Small App.*"
+    timeout: 10000
+
+# Tap the app switcher dropdown ("Small App ▼")
+- tapOn:
+    text: ".*Small App.*▼"
+- waitForAnimationToEnd: {timeout: 3000}
+
+- takeScreenshot: /tmp/phase9-wave6-app-switcher-dropdown
+
+# Tap Bonsaaso in the dropdown
+- tapOn:
+    text: ".*Bonsaaso.*"
+- waitForAnimationToEnd: {timeout: 3000}
+
+- takeScreenshot: /tmp/phase9-wave6-switched-to-bonsaaso
+
+# Login with Bonsaaso — should land on Bonsaaso home
+- tapOn:
+    id: "username_field"
+- inputText: ${COMMCARE_MOBILE_USERNAME}
+- tapOn:
+    point: "50%,10%"
+- waitForAnimationToEnd: {timeout: 1000}
+- tapOn:
+    id: "password_field"
+- inputText: ${COMMCARE_MOBILE_PASSWORD}
+- tapOn:
+    point: "50%,10%"
+- waitForAnimationToEnd: {timeout: 1000}
+- tapOn:
+    id: "login_button"
+
+- extendedWaitUntil:
+    visible:
+      id: "start_button"
+    timeout: 30000
+
+- takeScreenshot: /tmp/phase9-wave6-home-bonsaaso-after-switch
+
+# Verify Bonsaaso modules are visible (not Small App's)
+- tapOn:
+    id: "start_button"
+- waitForAnimationToEnd: {timeout: 3000}
+
+- assertVisible:
+    text: ".*Household List.*"
+
+- takeScreenshot: /tmp/phase9-wave6-bonsaaso-modules

--- a/.maestro/flows/multi-app-switch.yaml
+++ b/.maestro/flows/multi-app-switch.yaml
@@ -1,0 +1,104 @@
+# Phase 9 Wave 6: install a second app + switch between apps.
+#
+# Precondition: Bonsaaso installed + logged in at home screen.
+#
+# Flow:
+#   1. Kill-relaunch to get to login screen (with App Manager visible)
+#   2. Tap App Manager
+#   3. Tap "Install New App"
+#   4. Enter Small App profile URL
+#   5. Install Small App
+#   6. Return to login — Small App should now be active
+#   7. Login → verify Small App's modules are visible
+#   8. Kill-relaunch → login → switch back to Bonsaaso
+#   9. Login → verify Bonsaaso's modules are visible
+
+appId: org.marshellis.commcare.ios
+
+---
+
+# Wait for the login screen to render in NeedsLogin mode (with app header +
+# App Manager). The state bridges from LoggedOut → NeedsLogin during first
+# composition, so the App Manager button may not be immediately visible.
+- extendedWaitUntil:
+    visible:
+      text: ".*App Manager.*"
+    timeout: 15000
+
+- takeScreenshot: /tmp/phase9-wave6-login-with-app-manager
+
+- tapOn:
+    text: ".*App Manager.*"
+- waitForAnimationToEnd: {timeout: 5000}
+
+- takeScreenshot: /tmp/phase9-wave6-app-manager-bonsaaso
+
+# Verify Bonsaaso is listed
+- assertVisible:
+    text: ".*Bonsaaso.*"
+
+# Tap "Install New App" to go to SetupFlow
+- tapOn:
+    text: ".*Install New App.*"
+- waitForAnimationToEnd: {timeout: 5000}
+
+- takeScreenshot: /tmp/phase9-wave6-setup-for-second-app
+
+# Enter Small App profile URL
+- tapOn:
+    id: "enter_code_button"
+- waitForAnimationToEnd: {timeout: 3000}
+
+- tapOn:
+    id: "profile_url_field"
+- inputText: ${SECOND_APP_PROFILE_URL}
+
+# Dismiss keyboard
+- tapOn:
+    point: "50%,10%"
+- waitForAnimationToEnd: {timeout: 1000}
+
+- tapOn:
+    id: "submit_button"
+- waitForAnimationToEnd: {timeout: 10000}
+
+# Install button should appear
+- extendedWaitUntil:
+    visible:
+      id: "install_button"
+    timeout: 30000
+
+- tapOn:
+    id: "install_button"
+
+# Wait for install to complete — should land on login screen
+- extendedWaitUntil:
+    visible:
+      id: "username_field"
+    timeout: 60000
+
+- takeScreenshot: /tmp/phase9-wave6-post-second-install
+
+# Login with same credentials
+- tapOn:
+    id: "username_field"
+- inputText: ${COMMCARE_MOBILE_USERNAME}
+- tapOn:
+    point: "50%,10%"
+- waitForAnimationToEnd: {timeout: 1000}
+- tapOn:
+    id: "password_field"
+- inputText: ${COMMCARE_MOBILE_PASSWORD}
+- tapOn:
+    point: "50%,10%"
+- waitForAnimationToEnd: {timeout: 1000}
+- tapOn:
+    id: "login_button"
+
+# Should land on home screen with the SECOND app's content
+- extendedWaitUntil:
+    visible:
+      id: "start_button"
+    timeout: 30000
+
+- takeScreenshot: /tmp/phase9-wave6-home-second-app

--- a/.maestro/scripts/run-wave6.sh
+++ b/.maestro/scripts/run-wave6.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Phase 9 Wave 6: multi-app management.
+#
+# Installs Bonsaaso, logs in, then installs Small App as a second app
+# via App Manager, and verifies both apps work and can be switched
+# between via the login dropdown.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+if [ ! -f .env.e2e.local ]; then
+  echo "ERROR: .env.e2e.local not found" >&2
+  exit 1
+fi
+
+set -a
+# shellcheck disable=SC1091
+source .env.e2e.local
+set +a
+
+: "${COMMCARE_APP_PROFILE_URL:?must be set in .env.e2e.local}"
+: "${COMMCARE_MOBILE_USERNAME:?must be set in .env.e2e.local}"
+: "${COMMCARE_MOBILE_PASSWORD:?must be set in .env.e2e.local}"
+
+export JAVA_HOME="${JAVA_HOME:-/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home}"
+export MAESTRO_DRIVER_STARTUP_TIMEOUT="${MAESTRO_DRIVER_STARTUP_TIMEOUT:-180000}"
+MAESTRO="${MAESTRO:-$HOME/.maestro/bin/maestro}"
+APP_PATH="$ROOT/app/iosApp/build/Build/Products/Debug-iphonesimulator/CommCare.app"
+BUNDLE_ID="org.marshellis.commcare.ios"
+SECOND_APP_URL="https://www.commcarehq.org/a/jonstest/apps/download/12ab84e1f722c951c32147f57a91ebb2/profile.ccpr"
+
+echo "=== Phase 9 Wave 6: multi-app management ==="
+echo ""
+
+# Kill stale Maestro driver
+pkill -f "maestro-driver-iosUITests-Runner" 2>/dev/null || true
+pkill -f "xcodebuild test-without-building.*maestro" 2>/dev/null || true
+sleep 1
+
+# Fresh install
+xcrun simctl terminate booted "$BUNDLE_ID" 2>/dev/null || true
+xcrun simctl uninstall booted "$BUNDLE_ID" 2>/dev/null || true
+if [ ! -d "$APP_PATH" ]; then
+  echo "ERROR: $APP_PATH not found. Build with xcodebuild first." >&2
+  exit 1
+fi
+xcrun simctl install booted "$APP_PATH"
+xcrun simctl launch booted "$BUNDLE_ID" >/dev/null
+sleep 2
+
+echo "--- Step 1: Install Bonsaaso + login ---"
+"$MAESTRO" test \
+  -e "COMMCARE_APP_PROFILE_URL=$COMMCARE_APP_PROFILE_URL" \
+  .maestro/flows/install-via-url.yaml \
+  --no-ansi
+
+"$MAESTRO" test \
+  -e "COMMCARE_MOBILE_USERNAME=$COMMCARE_MOBILE_USERNAME" \
+  -e "COMMCARE_MOBILE_PASSWORD=$COMMCARE_MOBILE_PASSWORD" \
+  .maestro/flows/login-to-home.yaml \
+  --no-ansi
+
+echo ""
+echo "--- Step 2: Kill-relaunch + install Small App via App Manager ---"
+xcrun simctl terminate booted "$BUNDLE_ID"
+sleep 2
+xcrun simctl launch booted "$BUNDLE_ID" >/dev/null
+sleep 5
+
+"$MAESTRO" test \
+  -e "SECOND_APP_PROFILE_URL=$SECOND_APP_URL" \
+  -e "COMMCARE_MOBILE_USERNAME=$COMMCARE_MOBILE_USERNAME" \
+  -e "COMMCARE_MOBILE_PASSWORD=$COMMCARE_MOBILE_PASSWORD" \
+  .maestro/flows/multi-app-switch.yaml \
+  --no-ansi
+
+echo ""
+echo "--- Step 3: Kill-relaunch + switch back to Bonsaaso ---"
+xcrun simctl terminate booted "$BUNDLE_ID"
+sleep 2
+xcrun simctl launch booted "$BUNDLE_ID" >/dev/null
+sleep 5
+
+"$MAESTRO" test \
+  -e "COMMCARE_MOBILE_USERNAME=$COMMCARE_MOBILE_USERNAME" \
+  -e "COMMCARE_MOBILE_PASSWORD=$COMMCARE_MOBILE_PASSWORD" \
+  .maestro/flows/app-switch-to-bonsaaso.yaml \
+  --no-ansi
+
+echo ""
+echo "=== Wave 6 complete ==="
+echo "Screenshots:"
+ls -1 /tmp/phase9-wave6-*.png 2>/dev/null || echo "  (none found)"

--- a/app/src/commonMain/kotlin/org/commcare/app/App.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/App.kt
@@ -123,21 +123,21 @@ fun App(db: CommCareDatabase) {
 
             // If apps exist in DB but LoginViewModel is still LoggedOut, bridge the gap:
             // load the seated app and transition to NeedsLogin so the app switcher gets data.
-            // Crucially, call configureApp BEFORE the state transition so the login
-            // VM has the app's domain populated by the time the login screen renders.
-            // Without this, a fast tap on Log In races against the LaunchedEffect in
-            // the NeedsLogin branch, and resolveDomain() falls back to "demo" because
-            // currentApp is still null. See #410.
-            if (hasApps.value && appState is AppState.LoggedOut) {
-                val seatedApp = appRepository.getSeatedApp()
-                if (seatedApp != null) {
-                    val allApps = appRepository.getAllApps()
-                    loginViewModel.configureApp(
-                        serverUrl = "https://www.commcarehq.org",
-                        appId = seatedApp.id,
-                        app = seatedApp
-                    )
-                    loginViewModel.setReadyState(AppState.NeedsLogin(seatedApp, allApps))
+            // This must run as a LaunchedEffect (not inline during composition) because
+            // state mutations during composition don't reliably trigger recomposition
+            // on Compose Multiplatform iOS — see #416.
+            LaunchedEffect(hasApps.value, appState) {
+                if (hasApps.value && appState is AppState.LoggedOut) {
+                    val seatedApp = appRepository.getSeatedApp()
+                    if (seatedApp != null) {
+                        val allApps = appRepository.getAllApps()
+                        loginViewModel.configureApp(
+                            serverUrl = "https://www.commcarehq.org",
+                            appId = seatedApp.id,
+                            app = seatedApp
+                        )
+                        loginViewModel.setReadyState(AppState.NeedsLogin(seatedApp, allApps))
+                    }
                 }
             }
 
@@ -186,6 +186,11 @@ fun App(db: CommCareDatabase) {
                                 onBack = { showAppManager = false },
                                 onInstallNew = {
                                     showAppManager = false
+                                    // Reset both hasApps AND appState so the setup flow
+                                    // renders. Without resetting appState, the line-120
+                                    // override (NeedsLogin → hasApps=true) immediately
+                                    // overrides hasApps=false on the next composition.
+                                    loginViewModel.setReadyState(AppState.LoggedOut)
                                     hasApps.value = false
                                 }
                             )


### PR DESCRIPTION
## Summary

Two bugs fixed + Wave 6 multi-app E2E flow.

### Bug 1: LoggedOut→NeedsLogin bridge (original #416)

On kill-relaunch, the login screen stayed in `LoggedOut` mode despite the installed app being in the DB. The bridge that transitions `LoggedOut → NeedsLogin` was running inline during Compose composition, but **mutating `mutableStateOf` during composition doesn't reliably trigger recomposition on CMP iOS**. Moved to `LaunchedEffect`.

### Bug 2: "Install New App" state override (found during W6)

"Install New App" in App Manager sets `hasApps.value = false`, but line 120 immediately overrides it back to `true` because `appState` is still `NeedsLogin`. Fixed by also resetting `appState` to `LoggedOut` in the `onInstallNew` handler.

### Wave 6: multi-app management

Three Maestro flows exercising the full multi-app lifecycle:

1. **multi-app-switch.yaml**: From NeedsLogin login screen → App Manager → Install New App → enter Small App profile URL → install → login → Small App home screen
2. **app-switch-to-bonsaaso.yaml**: From NeedsLogin with Small App → tap app dropdown → select Bonsaaso → login → Bonsaaso home → Start → verify Household List module visible
3. **run-wave6.sh**: Orchestrator chaining fresh install + login + kill-relaunch + second app install + kill-relaunch + switch back

All verified on iOS simulator. First successful multi-app install + switch on iOS.

Also found cosmetic bug #418: module list renders `${0}` badge count template literally.

Closes #416.

## Test plan

- [x] Kill-relaunch shows NeedsLogin login screen
- [x] App Manager accessible from login screen
- [x] "Install New App" routes to Setup Flow
- [x] Small App installs via profile URL
- [x] Login after second install lands on Small App home
- [x] App dropdown shows both apps
- [x] Switch to Bonsaaso → login → Bonsaaso modules visible (not Small App's)
- [x] `:app:compileKotlinJvm` — clean
- [ ] CI green