### PR TITLE
fix(phase9-w7): Connect ID nav drawer wiring + hasConnectAccess

### DIFF
--- a/.maestro/flows/marketplace-scout.yaml
+++ b/.maestro/flows/marketplace-scout.yaml
@@ -1,0 +1,25 @@
+# Wave 7: scout the Connect marketplace from the nav drawer.
+# Precondition: app installed, logged in, Connect ID signed in.
+
+appId: org.marshellis.commcare.ios
+
+---
+
+- extendedWaitUntil:
+    visible:
+      id: "start_button"
+    timeout: 15000
+
+# Open nav drawer
+- tapOn:
+    id: "drawer_menu"
+- waitForAnimationToEnd: {timeout: 3000}
+
+# Tap Opportunities
+- tapOn:
+    text: "Opportunities"
+- waitForAnimationToEnd: {timeout: 10000}
+
+- takeScreenshot: /tmp/phase9-wave7-opportunities-list
+
+# Tap Messaging (back first, then nav drawer again)

--- a/.maestro/flows/nav-drawer-scout.yaml
+++ b/.maestro/flows/nav-drawer-scout.yaml
@@ -1,0 +1,18 @@
+# Scout the navigation drawer from the home screen.
+# Precondition: app installed, logged in, at home screen.
+
+appId: org.marshellis.commcare.ios
+
+---
+
+- extendedWaitUntil:
+    visible:
+      id: "start_button"
+    timeout: 15000
+
+# Tap the hamburger menu
+- tapOn:
+    id: "drawer_menu"
+- waitForAnimationToEnd: {timeout: 3000}
+
+- takeScreenshot: /tmp/phase9-wave7-nav-drawer

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
@@ -39,6 +39,7 @@ import org.javarosa.core.services.storage.IStorageUtilityIndexed
 import org.commcare.app.state.AppState
 import org.commcare.app.storage.AppRecordRepository
 import org.commcare.app.storage.CommCareDatabase
+import org.commcare.app.storage.ConnectIdRepository
 import org.commcare.app.viewmodel.CaseItem
 import org.commcare.app.viewmodel.CaseListViewModel
 import org.commcare.app.viewmodel.CaseSearchViewModel
@@ -116,7 +117,8 @@ fun HomeScreen(
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
     val appRepository = remember { AppRecordRepository(db) }
-    val drawerViewModel = remember { DrawerViewModel(appRepository) }
+    val connectIdRepo = remember { ConnectIdRepository(db) }
+    val drawerViewModel = remember { DrawerViewModel(appRepository, connectIdRepo) }
 
     LaunchedEffect(Unit) { drawerViewModel.refresh() }
 

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/ConnectIdViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/ConnectIdViewModel.kt
@@ -168,7 +168,7 @@ class ConnectIdViewModel(
                                     name = fullName,
                                     phone = "${countryCode}${phoneNumber}",
                                     photoPath = null,
-                                    hasConnectAccess = false,
+                                    hasConnectAccess = true,
                                     securityMethod = securityMethod
                                 )
                                 repository.saveUser(user)


### PR DESCRIPTION
## Summary

Two bugs that prevented the marketplace from appearing in the nav drawer.

### Bug 1: `hasConnectAccess = false` on registration and recovery

`ConnectIdViewModel.submitBackupCode()` hardcoded `hasConnectAccess = false` when saving the user record after both registration and recovery. After completing device seating, the user should have marketplace access. Changed to `true`.

### Bug 2: `ConnectIdRepository` not wired into `DrawerViewModel`

`HomeScreen` created `DrawerViewModel(appRepository)` without passing `ConnectIdRepository`. The drawer's `refresh()` read `getUser()` from a null repository and defaulted `hasConnectAccess` to false regardless of the DB state.

### Result

Nav drawer now shows: Opportunities, Messaging, "Sign out of Personal ID" after Connect ID recovery + app install + login.

Tapping Opportunities shows "Not signed in to ConnectID" — this is the existing #389 OAuth token refresh issue, not addressed here.

## Test plan

- [x] Recovery → install Bonsaaso → login → nav drawer shows Opportunities + Messaging
- [x] `:app:compileKotlinJvm` — clean
- [ ] CI green