### PR TITLE
feat(phase9-w8): sync flow + visit-submit timing

### DIFF
--- a/.maestro/flows/visit-submit.yaml
+++ b/.maestro/flows/visit-submit.yaml
@@ -60,19 +60,27 @@ appId: org.marshellis.commcare.ios
 - waitForAnimationToEnd: {timeout: 3000}
 
 # p05: "family planning type" (MSelect) → cd + iud
+# MSelect taps trigger Compose recomposition which can make the Next
+# button briefly invisible on CMP iOS. Generous waits required.
 - tapOn: "^cd$"
-- waitForAnimationToEnd: {timeout: 1000}
+- waitForAnimationToEnd: {timeout: 2000}
 - tapOn: "^iud$"
+- waitForAnimationToEnd: {timeout: 2000}
+- extendedWaitUntil:
+    visible:
+      id: "form_next_button"
+    timeout: 5000
 - tapOn:
     id: "form_next_button"
-- waitForAnimationToEnd: {timeout: 3000}
+- waitForAnimationToEnd: {timeout: 5000}
 
 # p06: "family planning type" (MSelect, 2nd) → ij
 - extendedWaitUntil:
     visible:
       text: "^ij$"
-    timeout: 5000
+    timeout: 10000
 - tapOn: "^ij$"
+- waitForAnimationToEnd: {timeout: 2000}
 - tapOn:
     id: "form_next_button"
 - waitForAnimationToEnd: {timeout: 3000}

--- a/.maestro/flows/wave8-sync.yaml
+++ b/.maestro/flows/wave8-sync.yaml
@@ -1,0 +1,48 @@
+# Phase 9 Wave 8: sync from home screen.
+#
+# Precondition: app installed, logged in, at home screen.
+# Tests incremental sync (no new changes should be fast).
+
+appId: org.marshellis.commcare.ios
+
+---
+
+- extendedWaitUntil:
+    visible:
+      id: "start_button"
+    timeout: 15000
+
+# Navigate to Sync screen
+- tapOn:
+    id: "sync_button"
+- waitForAnimationToEnd: {timeout: 5000}
+
+- takeScreenshot: /tmp/phase9-wave8-sync-before
+
+# Tap Sync Now
+- tapOn:
+    text: "Sync Now"
+
+# Wait for sync to complete
+- extendedWaitUntil:
+    visible:
+      text: ".*Sync complete.*"
+    timeout: 60000
+
+- takeScreenshot: /tmp/phase9-wave8-sync-after
+
+# Verify sync completed successfully
+- assertVisible: "Sync complete"
+
+# Verify no unsent forms
+- assertVisible: "No unsent forms"
+
+# Go back
+- tapOn:
+    text: "Back"
+- waitForAnimationToEnd: {timeout: 3000}
+
+- assertVisible:
+    id: "start_button"
+
+- takeScreenshot: /tmp/phase9-wave8-home-after-sync


### PR DESCRIPTION
## Summary

Wave 8: incremental sync (no changes) works end-to-end. Also improved MSelect timing in visit-submit.yaml.

### Sync (no bugs)

`wave8-sync.yaml`: home → Sync button → Sync Now → "Sync complete" → "No unsent forms" → Back → home. Clean pass.

### Visit-submit timing

Added `extendedWaitUntil` and longer `waitForAnimationToEnd` after MSelect checkbox taps. CMP iOS recomposition after checkbox toggles briefly makes the Next button invisible to Maestro. The flow is still flaky (~50% pass rate) but improved from consistent failure.

## Test plan

- [x] `wave8-sync.yaml` passes on fresh install + login
- [x] `:app:compileKotlinJvm` — clean (no source changes)
- [ ] CI green