### PR TITLE
feat(phase9-w9): diagnostics + settings screens

### DIFF
--- a/.maestro/flows/wave9-diagnostics.yaml
+++ b/.maestro/flows/wave9-diagnostics.yaml
@@ -1,0 +1,38 @@
+# Phase 9 Wave 9: diagnostics screen.
+#
+# Precondition: app installed, logged in, at home screen.
+
+appId: org.marshellis.commcare.ios
+
+---
+
+- extendedWaitUntil:
+    visible:
+      id: "start_button"
+    timeout: 15000
+
+# Tap Diagnostics
+- tapOn:
+    text: "Diagnostics"
+- waitForAnimationToEnd: {timeout: 5000}
+
+- takeScreenshot: /tmp/phase9-wave9-diagnostics-before
+
+# Run diagnostics
+- tapOn:
+    text: "Run Diagnostics"
+- waitForAnimationToEnd: {timeout: 15000}
+
+- takeScreenshot: /tmp/phase9-wave9-diagnostics-after
+
+# Go back
+- tapOn:
+    text: "<"
+- waitForAnimationToEnd: {timeout: 3000}
+
+# Now test Settings
+- tapOn:
+    text: "Settings"
+- waitForAnimationToEnd: {timeout: 5000}
+
+- takeScreenshot: /tmp/phase9-wave9-settings


### PR DESCRIPTION
## Summary

Wave 9: diagnostics and settings screens verified on iOS.

- **Diagnostics**: Run Diagnostics → "Server Reachability: PASS". Works.
- **Settings**: Server URL, Auto-sync, Fuzzy search, Auto-update, Check for Updates — all rendered and interactive.

No bugs found. PIN/biometric deferred (need iOS lockscreen). Language switch deferred (Bonsaaso is English-only).

## Test plan

- [x] Diagnostics runs and shows server reachability PASS
- [x] Settings screen renders all options
- [ ] CI green (Maestro-only, no app changes)