### PR TITLE
fix(#424): parse messaging channels + use channel ID for consent

### DIFF
--- a/app/src/commonMain/kotlin/org/commcare/app/network/ConnectMarketplaceApi.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/network/ConnectMarketplaceApi.kt
@@ -269,16 +269,11 @@ class ConnectMarketplaceApi(
      * POST /messaging/update_consent/
      * Authorization: Bearer <access_token>
      */
-    fun updateConsent(accessToken: String): Result<Unit> {
-        // TODO(#389): The update_consent endpoint requires "channel" and
-        // "consent" fields, but the channel comes from an assigned
-        // opportunity. Without opportunities, there's no channel to
-        // consent to. The empty body triggers a 400 from the server.
-        // Android CommCare may use a different consent flow or endpoint.
+    fun updateConsent(accessToken: String, channelId: String): Result<Unit> {
         return executeAuthenticatedPost(
             "$messagingBaseUrl/messaging/update_consent/",
             accessToken,
-            body = """{"consent": true}"""
+            body = """{"channel": "${escapeJson(channelId)}", "consent": true}"""
         )
     }
 
@@ -299,7 +294,21 @@ class ConnectMarketplaceApi(
      * GET /messaging/retrieve_messages/
      * Authorization: Bearer <access_token>
      */
-    fun getMessages(accessToken: String): Result<List<MessageThread>> {
+    /**
+     * Response from /messaging/retrieve_messages/ containing available
+     * channels and message threads.
+     */
+    data class MessagingResponse(
+        val channels: List<MessagingChannel>,
+        val threads: List<MessageThread>
+    )
+
+    data class MessagingChannel(
+        val id: String,
+        val name: String
+    )
+
+    fun getMessages(accessToken: String): Result<MessagingResponse> {
         return try {
             val response = httpClient.execute(
                 HttpRequest(
@@ -319,17 +328,32 @@ class ConnectMarketplaceApi(
             val json = response.body?.decodeToString()
                 ?: return Result.failure(ConnectMarketplaceException("Empty response"))
 
-            val objects = splitJsonArray(json)
-            val threads = objects.map { obj ->
-                MessageThread(
-                    id = extractJsonString(obj, "id") ?: "",
-                    participantName = extractJsonString(obj, "participant_name") ?: "",
-                    lastMessage = extractJsonString(obj, "last_message") ?: "",
-                    lastMessageDate = extractJsonString(obj, "last_message_date") ?: "",
-                    unreadCount = extractJsonInt(obj, "unread_count") ?: 0
-                )
-            }
-            Result.success(threads)
+            // Response is {"channels": [...], "messages": [...]}
+            val channelsRaw = extractJsonArrayRaw(json, "channels")
+            val messagesRaw = extractJsonArrayRaw(json, "messages")
+
+            val channels = if (channelsRaw != null) {
+                splitJsonArray(channelsRaw).map { obj ->
+                    MessagingChannel(
+                        id = extractJsonString(obj, "id") ?: "",
+                        name = extractJsonString(obj, "name") ?: ""
+                    )
+                }
+            } else emptyList()
+
+            val threads = if (messagesRaw != null) {
+                splitJsonArray(messagesRaw).map { obj ->
+                    MessageThread(
+                        id = extractJsonString(obj, "id") ?: "",
+                        participantName = extractJsonString(obj, "participant_name") ?: "",
+                        lastMessage = extractJsonString(obj, "last_message") ?: "",
+                        lastMessageDate = extractJsonString(obj, "last_message_date") ?: "",
+                        unreadCount = extractJsonInt(obj, "unread_count") ?: 0
+                    )
+                }
+            } else emptyList()
+
+            Result.success(MessagingResponse(channels, threads))
         } catch (e: Exception) {
             Result.failure(ConnectMarketplaceException("Get messages request failed: ${e.message}", e))
         }
@@ -941,6 +965,29 @@ class ConnectMarketplaceApi(
             if (closeQuote >= json.length) return null
 
             return json.substring(openQuote + 1, closeQuote)
+        }
+        return null
+    }
+
+    /**
+     * Extract a raw JSON array (as a String) for a given key.
+     * Returns the "[...]" substring including brackets, or null if not found.
+     */
+    private fun extractJsonArrayRaw(json: String, key: String): String? {
+        val searchKey = "\"$key\""
+        val keyIdx = json.indexOf(searchKey)
+        if (keyIdx == -1) return null
+        val colonIdx = json.indexOf(':', keyIdx + searchKey.length)
+        if (colonIdx == -1) return null
+        var start = colonIdx + 1
+        while (start < json.length && json[start].isWhitespace()) start++
+        if (start >= json.length || json[start] != '[') return null
+        var depth = 0
+        for (i in start until json.length) {
+            when (json[i]) {
+                '[' -> depth++
+                ']' -> { depth--; if (depth == 0) return json.substring(start, i + 1) }
+            }
         }
         return null
     }

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/MessagingViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/MessagingViewModel.kt
@@ -58,6 +58,9 @@ class MessagingViewModel(
         private set
     var hasConsented by mutableStateOf(false)
         private set
+    /** Available messaging channels from the server (empty before consent). */
+    var availableChannels by mutableStateOf<List<ConnectMarketplaceApi.MessagingChannel>>(emptyList())
+        private set
     var messageText by mutableStateOf("")
     var unreadCount by mutableStateOf(0)
         private set
@@ -93,11 +96,16 @@ class MessagingViewModel(
                 }
                 val result = api.getMessages(token)
                 result.fold(
-                    onSuccess = { list ->
+                    onSuccess = { response ->
                         platformSynchronized(threadsLock) {
-                            threads = list
+                            threads = response.threads
                         }
-                        unreadCount = list.sumOf { it.unreadCount }
+                        availableChannels = response.channels
+                        unreadCount = response.threads.sumOf { it.unreadCount }
+                        // If threads exist, user has already consented
+                        if (response.threads.isNotEmpty()) {
+                            hasConsented = true
+                        }
                     },
                     onFailure = { errorMessage = "Failed to load messages: ${it.message}" }
                 )
@@ -245,18 +253,29 @@ class MessagingViewModel(
                     isConsentLoading = false
                     return@launch
                 }
-                val result = api.updateConsent(token)
-                result.fold(
-                    onSuccess = {
-                        hasConsented = true
-                        isConsentLoading = false
-                        loadThreads()
-                    },
-                    onFailure = {
-                        errorMessage = "Failed to enable messaging: ${it.message}"
-                        isConsentLoading = false
+                // Consent to each available channel. If no channels are
+                // available, the server hasn't configured messaging for
+                // the user's opportunities yet.
+                if (availableChannels.isEmpty()) {
+                    errorMessage = "No messaging channels available. Your opportunities may not have messaging enabled."
+                    isConsentLoading = false
+                    return@launch
+                }
+                var allSucceeded = true
+                for (channel in availableChannels) {
+                    val result = api.updateConsent(token, channel.id)
+                    result.onFailure {
+                        allSucceeded = false
+                        errorMessage = "Failed to enable messaging for ${channel.name}: ${it.message}"
                     }
-                )
+                }
+                if (allSucceeded) {
+                    hasConsented = true
+                    isConsentLoading = false
+                    loadThreads()
+                } else {
+                    isConsentLoading = false
+                }
             } catch (e: Exception) {
                 errorMessage = "Consent error: ${e::class.simpleName}: ${e.message}"
                 isConsentLoading = false

--- a/app/src/jvmTest/kotlin/org/commcare/app/integration/ConnectMessagingIntegrationTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/integration/ConnectMessagingIntegrationTest.kt
@@ -42,7 +42,7 @@ class ConnectMessagingIntegrationTest {
     @Test
     fun testUpdateConsentSucceeds() {
         val token = ConnectTestConfig.connectAccessToken
-        val result = api.updateConsent(token)
+        val result = api.updateConsent(token, "test-channel")
         assertTrue(
             result.isSuccess,
             "updateConsent should succeed: ${result.exceptionOrNull()}"

--- a/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectApiRequestTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectApiRequestTest.kt
@@ -174,7 +174,7 @@ class ConnectApiRequestTest {
         val client = RecordingHttpClient()
         val api = ConnectMarketplaceApi(client)
 
-        api.updateConsent("consent-tok")
+        api.updateConsent("consent-tok", "channel-xyz")
 
         val req = client.lastRequest
         assertNotNull(req)
@@ -287,29 +287,39 @@ class ConnectApiRequestTest {
 
     @Test
     fun testMessageThreadParsing() {
-        val json = """[
-            {
-                "id": "thread-001",
-                "participant_name": "Alice",
-                "last_message": "See you tomorrow",
-                "last_message_date": "2026-03-24T10:30:00Z",
-                "unread_count": 3
-            },
-            {
-                "id": "thread-002",
-                "participant_name": "Bob",
-                "last_message": "Thanks!",
-                "last_message_date": "2026-03-23T08:15:00Z",
-                "unread_count": 0
-            }
-        ]"""
+        val json = """{
+            "channels": [
+                {"id": "chan-1", "name": "General"}
+            ],
+            "messages": [
+                {
+                    "id": "thread-001",
+                    "participant_name": "Alice",
+                    "last_message": "See you tomorrow",
+                    "last_message_date": "2026-03-24T10:30:00Z",
+                    "unread_count": 3
+                },
+                {
+                    "id": "thread-002",
+                    "participant_name": "Bob",
+                    "last_message": "Thanks!",
+                    "last_message_date": "2026-03-23T08:15:00Z",
+                    "unread_count": 0
+                }
+            ]
+        }"""
 
         val client = RecordingHttpClient(defaultBody = json)
         val api = ConnectMarketplaceApi(client)
 
         val result = api.getMessages("tok")
         assertTrue(result.isSuccess)
-        val threads = result.getOrThrow()
+        val response = result.getOrThrow()
+        assertEquals(1, response.channels.size)
+        assertEquals("chan-1", response.channels[0].id)
+        assertEquals("General", response.channels[0].name)
+
+        val threads = response.threads
         assertEquals(2, threads.size)
 
         assertEquals("thread-001", threads[0].id)

--- a/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectMarketplaceApiJsonTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectMarketplaceApiJsonTest.kt
@@ -403,33 +403,38 @@ class ConnectMarketplaceApiJsonTest {
     // =====================================================================
 
     @Test
-    fun testGetMessages_parsesThreads() {
-        val json = """[
+    fun testGetMessages_parsesThreadsAndChannels() {
+        val json = """{"channels": [
+            {"id": "ch1", "name": "Demo Channel"}
+        ], "messages": [
             {"id": "t1", "participant_name": "Alice", "last_message": "Hello", "last_message_date": "2026-03-10", "unread_count": 2},
             {"id": "t2", "participant_name": "Bob", "last_message": "Hi there", "last_message_date": "2026-03-09", "unread_count": 0}
-        ]"""
+        ]}"""
         val client = MockHttpClient(responseBody = json)
         val api = ConnectMarketplaceApi(client)
 
         val result = api.getMessages("access-token")
         assertTrue(result.isSuccess)
-        val threads = result.getOrThrow()
-        assertEquals(2, threads.size)
-        assertEquals("t1", threads[0].id)
-        assertEquals("Alice", threads[0].participantName)
-        assertEquals(2, threads[0].unreadCount)
-        assertEquals("Bob", threads[1].participantName)
-        assertEquals(0, threads[1].unreadCount)
+        val response = result.getOrThrow()
+        assertEquals(1, response.channels.size)
+        assertEquals("ch1", response.channels[0].id)
+        assertEquals(2, response.threads.size)
+        assertEquals("t1", response.threads[0].id)
+        assertEquals("Alice", response.threads[0].participantName)
+        assertEquals(2, response.threads[0].unreadCount)
+        assertEquals("Bob", response.threads[1].participantName)
+        assertEquals(0, response.threads[1].unreadCount)
     }
 
     @Test
-    fun testGetMessages_emptyList() {
-        val client = MockHttpClient(responseBody = "[]")
+    fun testGetMessages_emptyResponse() {
+        val client = MockHttpClient(responseBody = """{"channels": [], "messages": []}""")
         val api = ConnectMarketplaceApi(client)
 
         val result = api.getMessages("access-token")
         assertTrue(result.isSuccess)
-        assertEquals(0, result.getOrThrow().size)
+        assertEquals(0, result.getOrThrow().threads.size)
+        assertEquals(0, result.getOrThrow().channels.size)
     }
 
     // =====================================================================


### PR DESCRIPTION
## Summary

Three bugs in the messaging consent flow:

1. **Response parser wrong**: `getMessages()` treated the `{"channels": [...], "messages": [...]}` response as a flat JSON array, silently returning empty lists. Fixed to parse both `channels` and `messages` arrays from the top-level object.

2. **Consent body missing channel**: `updateConsent()` sent `{}` or `{"consent": true}` but the server requires `{"channel": "<id>", "consent": true}`. Fixed to accept a `channelId` parameter.

3. **No channel availability check**: When no channels exist (server hasn't configured messaging for the user's opportunities), the old code sent an empty body and got a 400. Fixed to show "No messaging channels available" instead.

## Result

With demo opportunities on connect.dimagi.com: "No messaging channels available. Your opportunities may not have messaging enabled." — correct behavior since the demo opps don't have messaging configured server-side.

When messaging channels ARE configured, the consent flow will send the proper `{"channel": "<id>", "consent": true}` for each channel.

Closes #424.

## Test plan

- [x] Messaging screen shows clear error when no channels available
- [x] No more 400/500 crashes on consent tap
- [x] `:app:compileKotlinJvm` clean
- [ ] CI green
- [ ] With messaging-enabled opportunity: consent → thread list → send message (needs server config)