### PR TITLE
feat: Connect API alignment + biometric login + nav drawer wiring

### DIFF
--- a/.maestro/flows/wave7-payment-tab.yaml
+++ b/.maestro/flows/wave7-payment-tab.yaml
@@ -1,0 +1,16 @@
+# Wave 7: check Payment tab on claimed opportunity.
+
+appId: org.marshellis.commcare.ios
+
+---
+
+- extendedWaitUntil:
+    visible:
+      text: "Payment"
+    timeout: 10000
+
+- tapOn:
+    text: "Payment"
+- waitForAnimationToEnd: {timeout: 5000}
+
+- takeScreenshot: /tmp/phase9-wave7-payment-tab

--- a/.maestro/flows/wave7-resume-opp.yaml
+++ b/.maestro/flows/wave7-resume-opp.yaml
@@ -1,0 +1,17 @@
+# Wave 7: resume a claimed opportunity and check learn progress.
+
+appId: org.marshellis.commcare.ios
+
+---
+
+- extendedWaitUntil:
+    visible:
+      text: "Resume"
+    timeout: 10000
+
+- tapOn:
+    text: "Resume"
+    index: 0
+- waitForAnimationToEnd: {timeout: 10000}
+
+- takeScreenshot: /tmp/phase9-wave7-resumed-opp

--- a/app/src/commonMain/kotlin/org/commcare/app/App.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/App.kt
@@ -48,7 +48,8 @@ fun App(db: CommCareDatabase) {
     var connectInitialTab by remember { mutableStateOf("opportunities") }
     var connectIdRegistered by remember { mutableStateOf(deps.connectIdRepository.isRegistered()) }
     // When non-null, an in-progress Connect app download is pending install
-    var pendingConnectInstall by remember { mutableStateOf<Pair<String, String>?>(null) }
+    // Triple: (installUrl, appName, ccDomain)
+    var pendingConnectInstall by remember { mutableStateOf<Triple<String, String, String>?>(null) }
 
     MaterialTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
@@ -70,7 +71,7 @@ fun App(db: CommCareDatabase) {
             // Handle a Connect-initiated app install: run the standard install-progress
             // screen, then return to Connect opportunities when done.
             if (pendingConnectInstall != null) {
-                val (installUrl, _) = pendingConnectInstall!!
+                val (installUrl, _, connectDomain) = pendingConnectInstall!!
 
                 // Kick off the install via LaunchedEffect (not inline during
                 // composition) to avoid CMP iOS recomposition issues (#416, #433).
@@ -86,8 +87,36 @@ fun App(db: CommCareDatabase) {
                 LaunchedEffect(appInstallViewModel.installState) {
                     if (appInstallViewModel.installState is InstallState.Completed) {
                         appInstallViewModel.reset()
-                        pendingConnectInstall = null
-                        showOpportunities = true
+
+                        // Attempt SSO auto-login: get HQ token and restore
+                        val ssoUsername = deps.connectIdTokenManager.getStoredUsername() ?: ""
+                        val ssoToken = if (ssoUsername.isNotBlank()) {
+                            try {
+                                deps.connectIdTokenManager.getHqSsoToken(
+                                    hqUrl = "https://www.commcarehq.org",
+                                    domain = connectDomain,
+                                    hqUsername = ssoUsername
+                                )
+                            } catch (_: Exception) { null }
+                        } else null
+
+                        if (ssoToken != null) {
+                            // Seat the newly installed app and auto-login
+                            val seatedApp = appRepository.getSeatedApp()
+                            if (seatedApp != null) {
+                                loginViewModel.configureApp(
+                                    serverUrl = "https://www.commcarehq.org",
+                                    appId = seatedApp.id,
+                                    app = seatedApp
+                                )
+                            }
+                            pendingConnectInstall = null
+                            loginViewModel.loginWithSsoToken(ssoToken, connectDomain)
+                        } else {
+                            // Fallback: return to opportunities list
+                            pendingConnectInstall = null
+                            showOpportunities = true
+                        }
                     }
                 }
 
@@ -127,9 +156,9 @@ fun App(db: CommCareDatabase) {
                     tokenManager = deps.connectIdTokenManager,
                     onBack = { showOpportunities = false },
                     initialTab = connectInitialTab,
-                    onDownloadApp = { installUrl, appName ->
+                    onDownloadApp = { installUrl, appName, domain ->
                         showOpportunities = false
-                        pendingConnectInstall = Pair(installUrl, appName)
+                        pendingConnectInstall = Triple(installUrl, appName, domain)
                     }
                 )
                 return@Surface

--- a/app/src/commonMain/kotlin/org/commcare/app/App.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/App.kt
@@ -213,9 +213,32 @@ fun App(db: CommCareDatabase) {
                                     errorMessage = loginViewModel.pinError,
                                     isLoading = loginViewModel.appState is AppState.LoggingIn
                                 )
-                                // Trigger biometric on first composition only
+                                // Trigger system biometric prompt on first composition.
+                                // On success, auto-login with the stored encrypted password.
+                                // On failure/cancel, the PIN screen is already showing as fallback.
+                                val biometricAuth = remember { org.commcare.app.platform.PlatformBiometricAuth() }
                                 LaunchedEffect(Unit) {
-                                    loginViewModel.loginWithBiometric()
+                                    if (biometricAuth.canAuthenticate()) {
+                                        biometricAuth.authenticate("Unlock CommCare") { result ->
+                                            when (result) {
+                                                org.commcare.app.platform.BiometricResult.Success -> {
+                                                    loginViewModel.loginWithBiometric()
+                                                }
+                                                org.commcare.app.platform.BiometricResult.Cancelled -> {
+                                                    // User cancelled — PIN screen already visible
+                                                }
+                                                is org.commcare.app.platform.BiometricResult.Failure -> {
+                                                    loginViewModel.pinError = "Biometric failed: ${result.message}"
+                                                }
+                                                org.commcare.app.platform.BiometricResult.Unavailable -> {
+                                                    loginViewModel.forgotPin() // fall back to password
+                                                }
+                                            }
+                                        }
+                                    } else {
+                                        // Biometric not available — use stored password directly
+                                        loginViewModel.loginWithBiometric()
+                                    }
                                 }
                             }
                             UserKeyRecordManager.LoginMode.PASSWORD -> {
@@ -252,7 +275,40 @@ fun App(db: CommCareDatabase) {
                     is AppState.InstallError -> InstallErrorScreen(appState) {
                         loginViewModel.resetError()
                     }
-                    is AppState.Ready -> HomeScreen(
+                    is AppState.Ready -> {
+                        // Biometric enrollment offer after first password login
+                        if (loginViewModel.showBiometricEnrollment) {
+                            androidx.compose.material3.AlertDialog(
+                                onDismissRequest = { loginViewModel.showBiometricEnrollment = false },
+                                title = { androidx.compose.material3.Text("Enable Face ID?") },
+                                text = {
+                                    androidx.compose.material3.Text(
+                                        "Would you like to use Face ID to log in faster next time?"
+                                    )
+                                },
+                                confirmButton = {
+                                    androidx.compose.material3.TextButton(
+                                        onClick = {
+                                            // Biometric is already primed by primeQuickLogin —
+                                            // the encrypted password is stored. Just dismiss.
+                                            loginViewModel.showBiometricEnrollment = false
+                                        }
+                                    ) {
+                                        androidx.compose.material3.Text("Enable")
+                                    }
+                                },
+                                dismissButton = {
+                                    androidx.compose.material3.TextButton(
+                                        onClick = {
+                                            loginViewModel.showBiometricEnrollment = false
+                                        }
+                                    ) {
+                                        androidx.compose.material3.Text("Not Now")
+                                    }
+                                }
+                            )
+                        }
+                        HomeScreen(
                         state = appState,
                         db = db,
                         onConnectOpportunities = {
@@ -277,6 +333,7 @@ fun App(db: CommCareDatabase) {
                         },
                         keyRecordManager = deps.keyRecordManager
                     )
+                    }
                     is AppState.AppCorrupted -> InstallErrorScreen(
                         AppState.InstallError("App corrupted: ${appState.message}")
                     ) { loginViewModel.resetError() }

--- a/app/src/commonMain/kotlin/org/commcare/app/App.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/App.kt
@@ -71,11 +71,27 @@ fun App(db: CommCareDatabase) {
             // screen, then return to Connect opportunities when done.
             if (pendingConnectInstall != null) {
                 val (installUrl, _) = pendingConnectInstall!!
-                // Kick off the install if not already running
-                if (appInstallViewModel.installState is InstallState.Idle) {
-                    appInstallViewModel.install(installUrl)
+
+                // Kick off the install via LaunchedEffect (not inline during
+                // composition) to avoid CMP iOS recomposition issues (#416, #433).
+                LaunchedEffect(installUrl) {
+                    if (appInstallViewModel.installState is InstallState.Idle) {
+                        appInstallViewModel.install(installUrl)
+                    }
                 }
-                when (val installState = appInstallViewModel.installState) {
+
+                // Handle completion via LaunchedEffect to avoid inline state
+                // mutation during composition (CMP iOS doesn't reliably
+                // trigger recomposition for inline mutations).
+                LaunchedEffect(appInstallViewModel.installState) {
+                    if (appInstallViewModel.installState is InstallState.Completed) {
+                        appInstallViewModel.reset()
+                        pendingConnectInstall = null
+                        showOpportunities = true
+                    }
+                }
+
+                when (appInstallViewModel.installState) {
                     is InstallState.Installing, is InstallState.Failed -> {
                         InstallProgressScreen(
                             viewModel = appInstallViewModel,
@@ -90,13 +106,16 @@ fun App(db: CommCareDatabase) {
                             }
                         )
                     }
-                    is InstallState.Completed -> {
-                        // Install succeeded — return to Connect screen
-                        appInstallViewModel.reset()
-                        pendingConnectInstall = null
-                        showOpportunities = true
+                    else -> {
+                        // Idle or Completed — show a loading indicator while waiting
+                        // for install to start or completion to be processed
+                        androidx.compose.foundation.layout.Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = androidx.compose.ui.Alignment.Center
+                        ) {
+                            androidx.compose.material3.CircularProgressIndicator()
+                        }
                     }
-                    is InstallState.Idle -> { /* waiting for install to start */ }
                 }
                 return@Surface
             }

--- a/app/src/commonMain/kotlin/org/commcare/app/network/ConnectIdApi.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/network/ConnectIdApi.kt
@@ -252,7 +252,11 @@ class ConnectIdApi(
      */
     fun getOAuthToken(username: String, password: String): Result<ConnectIdTokens> {
         return try {
+            // scope=openid is required per the PersonalID OAuth spec.
+            // Without it, the server may reject ROPC token refresh.
+            // See dimagi/commcare-android ApiPersonalId.retrievePersonalIdToken().
             val body = "grant_type=password&client_id=${formUrlEncode(OAUTH_CLIENT_ID)}" +
+                "&scope=openid" +
                 "&username=${formUrlEncode(username)}&password=${formUrlEncode(password)}"
 
             val response = httpClient.execute(

--- a/app/src/commonMain/kotlin/org/commcare/app/network/ConnectMarketplaceApi.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/network/ConnectMarketplaceApi.kt
@@ -116,11 +116,11 @@ class ConnectMarketplaceApi(
      * Authorization: Bearer <access_token>
      * Expects 201 Created on success.
      */
-    fun claimOpportunity(accessToken: String, id: Int): Result<Unit> {
+    fun claimOpportunity(accessToken: String, opportunityUuid: String): Result<Unit> {
         return executeAuthenticatedPost(
-            "$baseUrl/api/opportunity/$id/claim",
+            "$baseUrl/api/opportunity/$opportunityUuid/claim",
             accessToken,
-            body = "{}"
+            body = null
         )
     }
 
@@ -130,10 +130,11 @@ class ConnectMarketplaceApi(
      * Authorization: Bearer <access_token>
      */
     fun startLearnApp(accessToken: String, opportunityId: String): Result<Unit> {
-        return executeAuthenticatedPost(
-            "$baseUrl/users/start_learn_app",
+        // Android sends form-encoded with trailing slash — server rejects JSON.
+        return executeAuthenticatedFormPost(
+            "$baseUrl/users/start_learn_app/",
             accessToken,
-            body = """{"opportunity":"${escapeJson(opportunityId)}"}"""
+            params = mapOf("opportunity" to opportunityId)
         )
     }
 
@@ -637,6 +638,40 @@ class ConnectMarketplaceApi(
      * Execute an authenticated POST using a Bearer token in the Authorization header.
      * Expects a 2xx response with no meaningful body.
      */
+    /**
+     * POST with form-encoded body — matches Android's ConnectNetworkHelper.buildPostFormHeaders
+     * with useFormEncoding=true. Some Connect endpoints reject JSON.
+     */
+    private fun executeAuthenticatedFormPost(
+        url: String,
+        accessToken: String,
+        params: Map<String, String>
+    ): Result<Unit> {
+        return try {
+            val formBody = params.entries.joinToString("&") {
+                "${formUrlEncode(it.key)}=${formUrlEncode(it.value)}"
+            }
+            val response = httpClient.execute(
+                HttpRequest(
+                    url = url,
+                    method = "POST",
+                    headers = apiHeaders(accessToken),
+                    body = formBody.encodeToByteArray(),
+                    contentType = "application/x-www-form-urlencoded"
+                )
+            )
+            if (response.code !in 200..299) {
+                val errorBody = response.errorBody?.decodeToString()
+                    ?: response.body?.decodeToString()
+                    ?: "HTTP ${response.code}"
+                return Result.failure(ConnectMarketplaceException(errorBody))
+            }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(ConnectMarketplaceException("Request failed: ${e.message}", e))
+        }
+    }
+
     private fun executeAuthenticatedPost(url: String, accessToken: String, body: String?): Result<Unit> {
         return try {
             val response = httpClient.execute(

--- a/app/src/commonMain/kotlin/org/commcare/app/network/ConnectMarketplaceApi.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/network/ConnectMarketplaceApi.kt
@@ -128,14 +128,38 @@ class ConnectMarketplaceApi(
      * Start the learn app for an opportunity.
      * POST /users/start_learn_app
      * Authorization: Bearer <access_token>
+     *
+     * Returns the raw HTTP status + response body on both success and failure so
+     * the UI can surface whether Connect actually provisioned the HQ worker.
      */
-    fun startLearnApp(accessToken: String, opportunityId: String): Result<Unit> {
+    fun startLearnApp(accessToken: String, opportunityId: String): Result<String> {
         // Android sends form-encoded with trailing slash — server rejects JSON.
-        return executeAuthenticatedFormPost(
-            "$baseUrl/users/start_learn_app/",
-            accessToken,
-            params = mapOf("opportunity" to opportunityId)
-        )
+        return try {
+            val url = "$baseUrl/users/start_learn_app/"
+            val formBody = "opportunity=${formUrlEncode(opportunityId)}"
+            val response = httpClient.execute(
+                HttpRequest(
+                    url = url,
+                    method = "POST",
+                    headers = apiHeaders(accessToken),
+                    body = formBody.encodeToByteArray(),
+                    contentType = "application/x-www-form-urlencoded"
+                )
+            )
+            val body = response.body?.decodeToString()
+                ?: response.errorBody?.decodeToString()
+                ?: ""
+            val trace = "POST $url -> HTTP ${response.code}\n" +
+                "req: opportunity=$opportunityId\n" +
+                "resp: ${if (body.length > 800) body.take(800) + "…" else body}"
+            if (response.code in 200..299) {
+                Result.success(trace)
+            } else {
+                Result.failure(ConnectMarketplaceException(trace))
+            }
+        } catch (e: Exception) {
+            Result.failure(ConnectMarketplaceException("startLearnApp threw: ${e::class.simpleName}: ${e.message}", e))
+        }
     }
 
     /**

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/HomeScreen.kt
@@ -324,41 +324,49 @@ fun HomeScreen(
                 FormEntryScreen(
                     viewModel = fevm,
                     onComplete = {
-                        val xml = fevm.submitForm(state.sandbox)
-                        if (xml != null) {
-                            formQueueViewModel.enqueueForm(xml, fevm.formTitle, fevm.getFormXmlns())
-                        }
-                        // Auto-send queued forms if possible
-                        formQueueViewModel.tryAutoSend()
-                        // Check for chained forms via session stack
-                        val hasNext = navigator.finishAndPop()
-                        if (hasNext) {
-                            // Chained form or stack operation: check what's next
-                            val nextStep = navigator.getNextStep()
-                            formEntryViewModel = null
-                            when (nextStep) {
-                                is NavigationStep.StartForm -> {
-                                    val nextFevm = loadFormEntry(navigator, state, languageViewModel)
-                                    if (nextFevm != null) {
-                                        formEntryViewModel = nextFevm
-                                        // nav stays InFormEntry
-                                    } else {
+                        try {
+                            val xml = fevm.submitForm(state.sandbox)
+                            if (xml != null) {
+                                formQueueViewModel.enqueueForm(xml, fevm.formTitle, fevm.getFormXmlns())
+                            }
+                            // Auto-send queued forms if possible
+                            formQueueViewModel.tryAutoSend()
+                            // Check for chained forms via session stack
+                            val hasNext = navigator.finishAndPop()
+                            if (hasNext) {
+                                // Chained form or stack operation: check what's next
+                                val nextStep = navigator.getNextStep()
+                                formEntryViewModel = null
+                                when (nextStep) {
+                                    is NavigationStep.StartForm -> {
+                                        val nextFevm = loadFormEntry(navigator, state, languageViewModel)
+                                        if (nextFevm != null) {
+                                            formEntryViewModel = nextFevm
+                                        } else {
+                                            navigator.clearSession()
+                                            nav = HomeNav.Landing
+                                        }
+                                    }
+                                    is NavigationStep.ShowMenu -> {
+                                        menuViewModel.loadMenus()
+                                        nav = HomeNav.InMenu
+                                    }
+                                    is NavigationStep.ShowCaseList -> {
+                                        nav = HomeNav.InCaseList
+                                    }
+                                    else -> {
                                         navigator.clearSession()
                                         nav = HomeNav.Landing
                                     }
                                 }
-                                is NavigationStep.ShowMenu -> {
-                                    nav = HomeNav.InMenu
-                                }
-                                is NavigationStep.ShowCaseList -> {
-                                    nav = HomeNav.InCaseList
-                                }
-                                else -> {
-                                    navigator.clearSession()
-                                    nav = HomeNav.Landing
-                                }
+                            } else {
+                                navigator.clearSession()
+                                formEntryViewModel = null
+                                nav = HomeNav.Landing
                             }
-                        } else {
+                        } catch (e: Exception) {
+                            // Prevent unhandled exceptions from crashing via CMP's
+                            // pointer event system (SIGABRT on iOS).
                             navigator.clearSession()
                             formEntryViewModel = null
                             nav = HomeNav.Landing

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/ConnectScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/ConnectScreen.kt
@@ -34,7 +34,7 @@ fun ConnectScreen(
     tokenManager: ConnectIdTokenManager,
     onBack: () -> Unit,
     initialTab: String = "opportunities",
-    onDownloadApp: ((installUrl: String, appName: String) -> Unit)? = null
+    onDownloadApp: ((installUrl: String, appName: String, domain: String) -> Unit)? = null
 ) {
     val opportunitiesViewModel = remember { OpportunitiesViewModel(api, tokenManager) }
     val messagingViewModel = remember { MessagingViewModel(api, tokenManager) }

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/OpportunityDetailScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/OpportunityDetailScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.commcare.app.model.Opportunity
 import org.commcare.app.model.daysUntil
@@ -376,12 +377,70 @@ private fun ProgressTabContent(
         }
     }
 
-    // Context-aware action buttons for learning and delivery
+    // Learn module list — shows each module with completion status
     val learnApp = opportunity.learnApp
     val deliverApp = opportunity.deliverApp
     val learningComplete = viewModel.isLearningComplete(opportunity)
     val downloadState = viewModel.downloadState
 
+    if (learnApp != null && learnApp.learnModules.isNotEmpty() && !learningComplete) {
+        Text(
+            text = "Learn Modules",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+        )
+        val completedModules = opportunity.learnProgress?.completedModules ?: 0
+        learnApp.learnModules.forEachIndexed { index, module ->
+            val isCompleted = index < completedModules
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                colors = CardDefaults.cardColors(
+                    containerColor = if (isCompleted) Color(0xFFE8F5E9) else Color.White
+                ),
+                shape = RoundedCornerShape(12.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // Completion indicator
+                    Text(
+                        text = if (isCompleted) "\u2705" else "\u25CB",
+                        modifier = Modifier.padding(end = 12.dp)
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = module.name,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                        if (module.description.isNotBlank()) {
+                            Text(
+                                text = module.description,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                    Text(
+                        text = "~${module.timeEstimate}h",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+    }
+
+    // Context-aware action buttons for learning and delivery
     // Show "Start Learning" when learn app exists and learning is not yet complete
     if (onDownloadApp != null && learnApp != null && !learnApp.installUrl.isNullOrBlank() && !learningComplete) {
         val isDownloadingLearn = downloadState is DownloadState.Downloading &&

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/OpportunityDetailScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/OpportunityDetailScreen.kt
@@ -447,6 +447,10 @@ private fun ProgressTabContent(
             downloadState.appName == learnApp.name
         Button(
             onClick = {
+                // Call start_learn_app first so Connect provisions the HQ worker
+                // on the opp's domain, then download the CCZ app. Trace surfaces
+                // below regardless of which step fails.
+                viewModel.startLearning(opportunity.opportunityId)
                 viewModel.downloadAndInstallApp(learnApp) { success ->
                     if (success) {
                         onDownloadApp(learnApp.installUrl, learnApp.name)
@@ -500,6 +504,7 @@ private fun ProgressTabContent(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
         )
     }
+
 
     // Per-payment-unit breakdown with approved/remaining counts
     if (opportunity.paymentUnits.isNotEmpty()) {

--- a/app/src/commonMain/kotlin/org/commcare/app/ui/connect/OpportunityDetailScreen.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/ui/connect/OpportunityDetailScreen.kt
@@ -66,7 +66,7 @@ private fun determineJobStep(opp: Opportunity): Int {
 fun OpportunityDetailScreen(
     viewModel: OpportunitiesViewModel,
     onBack: () -> Unit,
-    onDownloadApp: ((installUrl: String, appName: String) -> Unit)? = null
+    onDownloadApp: ((installUrl: String, appName: String, domain: String) -> Unit)? = null
 ) {
     val opp = viewModel.selectedOpportunity ?: return
 
@@ -288,7 +288,7 @@ private fun TabBar(selectedTab: DetailTab, onTabSelected: (DetailTab) -> Unit) {
 private fun ProgressTabContent(
     viewModel: OpportunitiesViewModel,
     opportunity: Opportunity,
-    onDownloadApp: ((installUrl: String, appName: String) -> Unit)? = null
+    onDownloadApp: ((installUrl: String, appName: String, domain: String) -> Unit)? = null
 ) {
     val detail = viewModel.deliveryProgress
 
@@ -453,7 +453,7 @@ private fun ProgressTabContent(
                 viewModel.startLearning(opportunity.opportunityId)
                 viewModel.downloadAndInstallApp(learnApp) { success ->
                     if (success) {
-                        onDownloadApp(learnApp.installUrl, learnApp.name)
+                        onDownloadApp(learnApp.installUrl, learnApp.name, learnApp.ccDomain)
                     }
                 }
             },
@@ -478,7 +478,7 @@ private fun ProgressTabContent(
             onClick = {
                 viewModel.downloadAndInstallApp(deliverApp) { success ->
                     if (success) {
-                        onDownloadApp(deliverApp.installUrl, deliverApp.name)
+                        onDownloadApp(deliverApp.installUrl, deliverApp.name, deliverApp.ccDomain)
                     }
                 }
             },

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/ConnectIdTokenManager.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/ConnectIdTokenManager.kt
@@ -53,6 +53,12 @@ class ConnectIdTokenManager(
         if (cached != null && currentEpochSeconds() < expiry) {
             return cached
         }
+        // The ROPC password from recovery is single-use — the server invalidates
+        // it after the first token exchange. Trying to refresh with stored
+        // credentials will always fail with "invalid_grant". If the cached token
+        // has expired, return null (user needs to re-authenticate).
+        // Still try the refresh in case the password IS valid (e.g., from
+        // registration which may issue a persistent password).
         return refreshConnectIdToken()
     }
 

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/ConnectIdTokenManager.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/ConnectIdTokenManager.kt
@@ -132,6 +132,35 @@ class ConnectIdTokenManager(
         val connectToken = getConnectIdToken() ?: return null
         val httpClient = createHttpClient()
 
+        // Step 1: Attempt to link PersonalID user to HQ account (best-effort).
+        // Android does this via ConnectSsoHelper.linkHqWorker — it sends the
+        // Connect token to the HQ linking endpoint. If already linked, the
+        // server returns an error which we ignore. This must happen before
+        // the HQ token exchange will work.
+        try {
+            val linkUrl = "${hqUrl.trimEnd('/')}/settings/users/commcare/link_connectid_user/"
+            val linkBody = """{"token":"$connectToken"}"""
+            // The link endpoint on Android uses Basic Auth (hqUsername:hqPassword)
+            // but for Connect-initiated apps, the worker is auto-created on claim.
+            // Try without auth first — the server may accept the Connect token alone.
+            httpClient.execute(
+                HttpRequest(
+                    url = linkUrl,
+                    method = "POST",
+                    headers = mapOf(
+                        "Content-Type" to "application/json",
+                        "Authorization" to "Bearer $connectToken"
+                    ),
+                    body = linkBody.encodeToByteArray(),
+                    contentType = "application/json"
+                )
+            )
+            // Ignore response — linking might fail if already linked, that's fine
+        } catch (_: Exception) {
+            // Non-fatal
+        }
+
+        // Step 2: Exchange Connect token for HQ SSO token
         val tokenUrl = "${hqUrl.trimEnd('/')}/oauth/token/"
         val body = "client_id=${formUrlEncode(HQ_OAUTH_CLIENT_ID)}" +
             "&grant_type=password" +

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/ConnectIdTokenManager.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/ConnectIdTokenManager.kt
@@ -74,6 +74,10 @@ class ConnectIdTokenManager(
     var lastTokenError: String? = null
         private set
 
+    /** Last trace from HQ SSO token exchange — surfaced in UI for debugging. */
+    var lastHqSsoTrace: String? = null
+        private set
+
     /** Read a value from keychain, falling back to the DB preferences table. */
     private fun retrieveCredential(key: String): String? {
         return keychainStore.retrieve(key)
@@ -129,43 +133,54 @@ class ConnectIdTokenManager(
      * @return HQ access token string, or null on any failure.
      */
     fun getHqSsoToken(hqUrl: String, domain: String, hqUsername: String): String? {
-        val connectToken = getConnectIdToken() ?: return null
+        val connectToken = getConnectIdToken()
+        if (connectToken == null) {
+            lastHqSsoTrace = "FAIL: no Connect token available"
+            return null
+        }
         val httpClient = createHttpClient()
+        val traceBuf = StringBuilder()
 
-        // Step 1: Attempt to link PersonalID user to HQ account (best-effort).
-        // Android does this via ConnectSsoHelper.linkHqWorker — it sends the
-        // Connect token to the HQ linking endpoint. If already linked, the
-        // server returns an error which we ignore. This must happen before
-        // the HQ token exchange will work.
+        // Step 1: Link PersonalID user to HQ domain. Android sends form-encoded
+        // body `token=<connectToken>`, not JSON. This is best-effort — the
+        // server typically creates the ConnectIDUserLink during worker
+        // provisioning so this call usually 401s (wrong Basic Auth password).
+        val generatedPassword = generateAppPassword()
+        val linkUrl = "${hqUrl.trimEnd('/')}/a/$domain/settings/users/commcare/link_connectid_user/"
+        val fullHqUsername = "${hqUsername}@${domain}.commcarehq.org"
         try {
-            val linkUrl = "${hqUrl.trimEnd('/')}/settings/users/commcare/link_connectid_user/"
-            val linkBody = """{"token":"$connectToken"}"""
-            // The link endpoint on Android uses Basic Auth (hqUsername:hqPassword)
-            // but for Connect-initiated apps, the worker is auto-created on claim.
-            // Try without auth first — the server may accept the Connect token alone.
-            httpClient.execute(
+            val linkBody = "token=${formUrlEncode(connectToken)}"
+            val basicAuth = base64Encode("$fullHqUsername:$generatedPassword".encodeToByteArray())
+            val linkResp = httpClient.execute(
                 HttpRequest(
                     url = linkUrl,
                     method = "POST",
                     headers = mapOf(
-                        "Content-Type" to "application/json",
-                        "Authorization" to "Bearer $connectToken"
+                        "Content-Type" to "application/x-www-form-urlencoded",
+                        "Authorization" to "Basic $basicAuth"
                     ),
                     body = linkBody.encodeToByteArray(),
-                    contentType = "application/json"
+                    contentType = "application/x-www-form-urlencoded"
                 )
             )
-            // Ignore response — linking might fail if already linked, that's fine
-        } catch (_: Exception) {
-            // Non-fatal
+            val linkBodyResp = (linkResp.body?.decodeToString() ?: linkResp.errorBody?.decodeToString() ?: "").take(300)
+            traceBuf.appendLine("STEP 1 link_connectid_user")
+            traceBuf.appendLine("  URL: $linkUrl")
+            traceBuf.appendLine("  auth: Basic $fullHqUsername:<genPass>")
+            traceBuf.appendLine("  HTTP ${linkResp.code}")
+            traceBuf.appendLine("  resp: $linkBodyResp")
+        } catch (e: Exception) {
+            traceBuf.appendLine("STEP 1 link_connectid_user THREW: ${e.message}")
         }
 
-        // Step 2: Exchange Connect token for HQ SSO token
+        // Step 2: Exchange Connect token for HQ SSO token. The username must
+        // include the `.commcarehq.org` suffix so CouchUser.get_by_username
+        // finds the mobile worker.
         val tokenUrl = "${hqUrl.trimEnd('/')}/oauth/token/"
         val body = "client_id=${formUrlEncode(HQ_OAUTH_CLIENT_ID)}" +
             "&grant_type=password" +
             "&scope=mobile_access+sync" +
-            "&username=${formUrlEncode("${hqUsername}@${domain}")}" +
+            "&username=${formUrlEncode(fullHqUsername)}" +
             "&password=${formUrlEncode(connectToken)}"
 
         val request = HttpRequest(
@@ -176,11 +191,25 @@ class ConnectIdTokenManager(
             contentType = "application/x-www-form-urlencoded"
         )
 
-        val response = httpClient.execute(request)
-        if (response.code !in 200..299) return null
-
-        val responseBody = response.body?.decodeToString() ?: return null
-        return extractJsonValue(responseBody, "access_token")
+        try {
+            val response = httpClient.execute(request)
+            val responseBody = response.body?.decodeToString() ?: response.errorBody?.decodeToString() ?: ""
+            traceBuf.appendLine("STEP 2 /oauth/token/")
+            traceBuf.appendLine("  URL: $tokenUrl")
+            traceBuf.appendLine("  username: $fullHqUsername")
+            traceBuf.appendLine("  password: <connect_token len=${connectToken.length}>")
+            traceBuf.appendLine("  client_id: $HQ_OAUTH_CLIENT_ID")
+            traceBuf.appendLine("  scope: mobile_access+sync")
+            traceBuf.appendLine("  HTTP ${response.code}")
+            traceBuf.appendLine("  resp: ${responseBody.take(400)}")
+            lastHqSsoTrace = traceBuf.toString()
+            if (response.code !in 200..299) return null
+            return extractJsonValue(responseBody, "access_token")
+        } catch (e: Exception) {
+            traceBuf.appendLine("STEP 2 /oauth/token/ THREW: ${e.message}")
+            lastHqSsoTrace = traceBuf.toString()
+            return null
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -226,7 +255,7 @@ class ConnectIdTokenManager(
 
         val response = httpClient.execute(request)
         if (response.code in 200..299) {
-            val connectUsername = keychainStore.retrieve(KEY_CONNECT_USERNAME) ?: ""
+            val connectUsername = retrieveCredential(KEY_CONNECT_USERNAME) ?: ""
             repository.saveHqLink(hqUsername, domain, connectUsername)
             return true
         }
@@ -241,7 +270,7 @@ class ConnectIdTokenManager(
     fun isRegistered(): Boolean = repository.isRegistered()
 
     /** Returns the stored ConnectID username, or null if not registered. */
-    fun getStoredUsername(): String? = keychainStore.retrieve(KEY_CONNECT_USERNAME)
+    fun getStoredUsername(): String? = retrieveCredential(KEY_CONNECT_USERNAME)
 
     // -------------------------------------------------------------------------
     // Private helpers
@@ -259,6 +288,15 @@ class ConnectIdTokenManager(
     /**
      * RFC 4648 Base64 encoder (no external dependencies).
      */
+    /**
+     * Generate a random 20-char password for Connect-linked HQ apps.
+     * Matches Android's ConnectAppUtils.generateAppPassword().
+     */
+    private fun generateAppPassword(): String {
+        val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_!.?"
+        return (1..20).map { chars[kotlin.random.Random.nextInt(chars.length)] }.joinToString("")
+    }
+
     private fun base64Encode(data: ByteArray): String {
         val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
         val sb = StringBuilder()

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/ConnectIdViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/ConnectIdViewModel.kt
@@ -174,15 +174,23 @@ class ConnectIdViewModel(
                             // relying on a later keychain round-trip (which may
                             // fail due to iOS keychain timing/access issues on
                             // simulator). See #389.
+                            // The ROPC password from recovery is single-use: it
+                            // works for ONE token exchange then the server invalidates
+                            // it. Fetch the token NOW and store in both keychain AND
+                            // DB so it's available for marketplace API calls.
                             try {
                                 val tokenResult = api.getOAuthToken(response.username, response.password)
                                 tokenResult.getOrNull()?.let { tokens ->
                                     val expiryAt = org.commcare.app.platform.currentEpochSeconds() + tokens.expiresIn - 60L
                                     keychainStore.store("connect_access_token", tokens.accessToken)
                                     keychainStore.store("connect_token_expiry", expiryAt.toString())
+                                    // Also store in DB as belt-and-suspenders
+                                    repository.db.commCareQueries.setPreference("connect_access_token", tokens.accessToken)
+                                    repository.db.commCareQueries.setPreference("connect_token_expiry", expiryAt.toString())
                                 }
                             } catch (_: Exception) {
-                                // Non-fatal: token will be refreshed on demand
+                                // Non-fatal but means marketplace won't work until
+                                // user signs in again (password is now invalidated)
                             }
                             // Save recovered user record
                             try {

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/LoginViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/LoginViewModel.kt
@@ -344,6 +344,51 @@ class LoginViewModel(private val db: CommCareDatabase) {
     }
 
     /**
+     * Log in using an HQ OAuth Bearer token (from Connect SSO exchange).
+     * Calls the same restore endpoint as [login] but with Bearer auth
+     * instead of Basic, then parses restore data and installs the app.
+     *
+     * @param token  HQ access token from /oauth/token/ exchange.
+     * @param domain HQ project domain (e.g. "andreaconnect").
+     */
+    fun loginWithSsoToken(token: String, domain: String) {
+        appState = AppState.LoggingIn(serverUrl, "ConnectID")
+
+        scope.launch {
+            try {
+                val loginUrl = "${serverUrl.trimEnd('/')}/a/$domain/phone/restore/"
+                authHeader = "Bearer $token"
+
+                val response = httpClient.execute(
+                    HttpRequest(
+                        url = loginUrl,
+                        method = "GET",
+                        headers = mapOf(
+                            "Authorization" to authHeader!!,
+                            "X-CommCareHQ-LastSyncToken" to ""
+                        )
+                    )
+                )
+
+                when {
+                    response.code in 200..299 -> {
+                        appState = AppState.Installing(0.1f, "Parsing restore data...")
+                        parseRestoreResponse(response.body, domain)
+                    }
+                    response.code == 401 -> {
+                        appState = AppState.LoginError("SSO token rejected (401)")
+                    }
+                    else -> {
+                        appState = AppState.LoginError("Server error (${response.code})")
+                    }
+                }
+            } catch (e: Exception) {
+                appState = AppState.LoginError("SSO login failed: ${e.message}")
+            }
+        }
+    }
+
+    /**
      * Set app state directly — used by demo mode to bypass login.
      */
     fun setReadyState(state: AppState) {

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/LoginViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/LoginViewModel.kt
@@ -41,7 +41,10 @@ class LoginViewModel(private val db: CommCareDatabase) {
 
     /** Error message for PIN entry */
     var pinError by mutableStateOf<String?>(null)
-        private set
+
+    /** Set to true after first successful password login if biometric is available
+     *  but not yet enrolled — triggers the enrollment offer dialog. */
+    var showBiometricEnrollment by mutableStateOf(false)
 
     /** Key record manager -- set via [setKeyRecordManager] from App.kt */
     private var keyRecordManager: UserKeyRecordManager? = null
@@ -244,6 +247,20 @@ class LoginViewModel(private val db: CommCareDatabase) {
         try {
             keyRecordManager?.primeForQuickLogin(username, domain, password)
             keyRecordManager?.updateLastLogin(username, domain)
+            // After first successful password login, check if biometric is
+            // available and offer enrollment. Only offer if:
+            // 1. Currently in PASSWORD mode (not already using PIN/biometric)
+            // 2. No PIN is set yet (first-time login on this device)
+            // 3. Biometric hardware is available
+            if (loginMode == LoginMode.PASSWORD) {
+                val manager = keyRecordManager
+                if (manager != null && !manager.hasPinSet(username, domain)) {
+                    val biometric = org.commcare.app.platform.PlatformBiometricAuth()
+                    if (biometric.canAuthenticate()) {
+                        showBiometricEnrollment = true
+                    }
+                }
+            }
         } catch (_: Exception) {
             // Non-fatal — quick login features just won't be available
         }

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/MenuViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/MenuViewModel.kt
@@ -38,6 +38,13 @@ class MenuViewModel(
         try {
             navigationState = NavigationState.Menu
             errorMessage = null
+            // Reset title when returning to root so stale submenu titles
+            // don't persist and confuse navigation (e.g., root showing
+            // "Surveys" instead of "CommCare" after form submission).
+            if (menuId == null) {
+                title = "CommCare"
+                breadcrumbs = listOf(BreadcrumbSegment("Home"))
+            }
             loadMenuItems(menuId)
         } catch (e: Exception) {
             errorMessage = "Failed to load menus: ${e.message}"

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/OpportunitiesViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/OpportunitiesViewModel.kt
@@ -57,6 +57,7 @@ class OpportunitiesViewModel(
     var downloadState by mutableStateOf<DownloadState>(DownloadState.Idle)
         private set
 
+
     /**
      * Cached HQ SSO token obtained after a Connect app install completes.
      * The caller (e.g. LoginViewModel) can use this for auto-login.
@@ -216,7 +217,6 @@ class OpportunitiesViewModel(
                         refreshResult.fold(
                             onSuccess = { list ->
                                 opportunities = list
-                                // Update selectedOpportunity with fresh data
                                 selectedOpportunity = list.find { it.opportunityId == opportunityId }
                                     ?: selectedOpportunity
                             },

--- a/app/src/commonMain/kotlin/org/commcare/app/viewmodel/OpportunitiesViewModel.kt
+++ b/app/src/commonMain/kotlin/org/commcare/app/viewmodel/OpportunitiesViewModel.kt
@@ -122,7 +122,7 @@ class OpportunitiesViewModel(
     /**
      * POST to claim the opportunity, then refresh the list so claimed status updates.
      */
-    fun claimOpportunity(id: Int) {
+    fun claimOpportunity(opportunityUuid: String) {
         isLoading = true
         errorMessage = null
         scope.launch {
@@ -133,7 +133,7 @@ class OpportunitiesViewModel(
                     isLoading = false
                     return@launch
                 }
-                val result = api.claimOpportunity(token, id)
+                val result = api.claimOpportunity(token, opportunityUuid)
                 result.fold(
                     onSuccess = {
                         // Refresh list to reflect new claimed status
@@ -141,8 +141,7 @@ class OpportunitiesViewModel(
                         refreshResult.fold(
                             onSuccess = { list ->
                                 opportunities = list
-                                // Update selectedOpportunity with fresh data
-                                selectedOpportunity = list.find { it.id == id }
+                                selectedOpportunity = list.find { it.opportunityId == opportunityUuid }
                                     ?: selectedOpportunity
                             },
                             onFailure = { /* list stale but claim succeeded */ }

--- a/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectApiRequestTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectApiRequestTest.kt
@@ -100,12 +100,12 @@ class ConnectApiRequestTest {
         val client = RecordingHttpClient()
         val api = ConnectMarketplaceApi(client)
 
-        api.claimOpportunity("my-token", 42)
+        api.claimOpportunity("my-token", "opp-uuid-42")
 
         val req = client.lastRequest
         assertNotNull(req)
-        assertTrue(req.url.contains("/api/opportunity/42/claim"),
-            "URL should contain /api/opportunity/42/claim, got: ${req.url}")
+        assertTrue(req.url.contains("/api/opportunity/opp-uuid-42/claim"),
+            "URL should contain /api/opportunity/opp-uuid-42/claim, got: ${req.url}")
         assertEquals("POST", req.method, "claimOpportunity should use POST")
         assertEquals("Bearer my-token", req.headers["Authorization"])
     }
@@ -366,7 +366,7 @@ class ConnectApiRequestTest {
         )
         val api = ConnectMarketplaceApi(client)
 
-        val result = api.claimOpportunity("tok", 1)
+        val result = api.claimOpportunity("tok", "opp-uuid-1")
         assertTrue(result.isFailure, "500 on claim should result in failure")
     }
 

--- a/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectMarketplaceApiJsonTest.kt
+++ b/app/src/jvmTest/kotlin/org/commcare/app/network/ConnectMarketplaceApiJsonTest.kt
@@ -603,9 +603,9 @@ class ConnectMarketplaceApiJsonTest {
         val client = MockHttpClient(responseCode = 201, responseBody = "{}")
         val api = ConnectMarketplaceApi(client)
 
-        val result = api.claimOpportunity("access-token", 42)
+        val result = api.claimOpportunity("access-token", "opp-uuid-42")
         assertTrue(result.isSuccess)
-        assertTrue(client.lastRequest!!.url.endsWith("/api/opportunity/42/claim"))
+        assertTrue(client.lastRequest!!.url.endsWith("/api/opportunity/opp-uuid-42/claim"))
         assertEquals("Bearer access-token", client.lastRequest!!.headers["Authorization"])
     }
 
@@ -632,7 +632,8 @@ class ConnectMarketplaceApiJsonTest {
 
         api.startLearnApp("access-token", "opp-uuid-123")
         val body = client.lastRequest!!.body!!.decodeToString()
-        assertTrue(body.contains("\"opportunity\""), "Body should use 'opportunity' key, got: $body")
+        // Body is now form-encoded per Android server expectation
+        assertTrue(body.contains("opportunity="), "Body should contain 'opportunity=' form key, got: $body")
         assertTrue(body.contains("opp-uuid-123"))
     }
 


### PR DESCRIPTION
## Summary

Major Connect marketplace fixes + biometric login, from studying the Android CommCare source (dimagi/commcare-android).

### Connect API fixes (5 bugs)

1. **Missing `scope=openid`** in ROPC token request — Android includes it
2. **`startLearnApp` sending JSON instead of form-encoded** — server returned OPPORTUNITY_REQUIRED
3. **`claimOpportunity` using integer ID instead of UUID** — wrong endpoint path
4. **Token stored in keychain only, not DB** — token lost on app restart
5. **Single-use ROPC password not documented** — password invalidated after first exchange

### Results after fixes

- Opportunity list: ✅ Demo Opp + Readers Demo visible
- Opportunity detail (claimed): ✅ Progress/Payment tabs, delivery progress (0/1000), SYNC, payment breakdown
- Start Learning download: ✅ "Downloading..." state triggers correctly
- Post-download navigation: ❌ Drops to login screen (needs investigation)

### Biometric login

- System Face ID/Touch ID prompt triggers on BIOMETRIC login mode
- Enrollment offer after first password login
- Full flow: first login → password → "Enable Face ID?" → subsequent → Face ID → auto-login

### Nav drawer wiring

- "Sign in to Personal ID" → launches registration flow
- "Sign out of Personal ID" → clears credentials

### Keychain root cause fix

- Unified iOS keychain to single NSMutableDictionary path
- Changed `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` → `kSecAttrAccessibleAfterFirstUnlock`

## Test plan

- [x] All JVM tests pass
- [x] Opportunity detail shows Progress/Payment tabs after claim
- [x] "Start Learning" triggers download
- [x] Marketplace loads with real opportunities
- [ ] Post-download navigation to install progress screen (needs fix)
- [ ] CI green