### PR TITLE
feat(e2e): add OTP fetch helper for +7426 test numbers

### DIFF
--- a/.maestro/scripts/otp.py
+++ b/.maestro/scripts/otp.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+OTP fetch helper for commcare-ios e2e tests.
+
+Fetches a one-time password from Dimagi's connect-id service for test
+phone numbers (must start with +7426 — the connect-id test prefix that
+suppresses real SMS delivery).
+
+Two modes:
+  1. OAuth2 client credentials (preferred, for CI):
+       Set CONNECTID_E2E_CLIENT_ID and CONNECTID_E2E_CLIENT_SECRET.
+       Calls POST /o/token/ then GET /users/generate_manual_otp.
+
+  2. Session cookie (local dev fallback):
+       Set CONNECTID_SESSION_COOKIE to a valid sessionid cookie value
+       from a Dimagi SSO login. Calls GET /users/connect_user_otp/?phone=.
+
+Usage:
+  # CLI
+  python .maestro/scripts/otp.py +74260000042
+
+  # As a module
+  from otp import get_test_otp
+  code = get_test_otp("+74260000042")
+
+  # With explicit OAuth2 credentials
+  code = get_test_otp("+74260000042",
+                       client_id="...", client_secret="...")
+
+Environment variables (all optional if passed as arguments):
+  CONNECTID_E2E_CLIENT_ID       OAuth2 client ID
+  CONNECTID_E2E_CLIENT_SECRET   OAuth2 client secret
+  CONNECTID_SESSION_COOKIE      Fallback: sessionid cookie value
+  CONNECTID_E2E_BASE_URL        Override base URL
+                                (default: https://connectid.dimagi.com)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+TEST_PREFIX = "+7426"
+DEFAULT_BASE_URL = "https://connectid.dimagi.com"
+
+
+def get_test_otp(
+    phone_number: str,
+    *,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    session_cookie: str | None = None,
+    base_url: str | None = None,
+) -> str:
+    """Fetch the current OTP for a +7426 test phone number.
+
+    Raises ValueError for non-test numbers and RuntimeError on API errors.
+    """
+    if not phone_number.startswith(TEST_PREFIX):
+        raise ValueError(
+            f"Only {TEST_PREFIX} test numbers supported "
+            f"— refusing to fetch OTP for real phone: {phone_number}"
+        )
+
+    base = (base_url or os.environ.get("CONNECTID_E2E_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
+    cid = client_id or os.environ.get("CONNECTID_E2E_CLIENT_ID")
+    csec = client_secret or os.environ.get("CONNECTID_E2E_CLIENT_SECRET")
+    cookie = session_cookie or os.environ.get("CONNECTID_SESSION_COOKIE")
+
+    if cid and csec:
+        return _fetch_via_oauth(phone_number, base, cid, csec)
+    if cookie:
+        return _fetch_via_session(phone_number, base, cookie)
+
+    raise RuntimeError(
+        "No credentials provided. Set CONNECTID_E2E_CLIENT_ID + "
+        "CONNECTID_E2E_CLIENT_SECRET (OAuth2) or CONNECTID_SESSION_COOKIE "
+        "(session fallback)."
+    )
+
+
+def _fetch_via_oauth(phone: str, base: str, client_id: str, client_secret: str) -> str:
+    """OAuth2 client_credentials flow -> generate_manual_otp endpoint."""
+    token_url = f"{base}/o/token/"
+    token_data = urllib.parse.urlencode({
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }).encode()
+    token_req = urllib.request.Request(token_url, data=token_data, method="POST")
+    token_req.add_header("Content-Type", "application/x-www-form-urlencoded")
+
+    try:
+        with urllib.request.urlopen(token_req, timeout=15) as resp:
+            token_body = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"Token request failed (HTTP {e.code}): {e.read().decode()}")
+
+    access_token = token_body.get("access_token")
+    if not access_token:
+        raise RuntimeError(f"No access_token in response: {token_body}")
+
+    encoded_phone = urllib.parse.quote(phone, safe="")
+    otp_url = f"{base}/users/generate_manual_otp?phone_number={encoded_phone}"
+    otp_req = urllib.request.Request(otp_url)
+    otp_req.add_header("Authorization", f"Bearer {access_token}")
+
+    return _parse_otp_response(otp_req, phone)
+
+
+def _fetch_via_session(phone: str, base: str, session_cookie: str) -> str:
+    """Session cookie fallback -> connect_user_otp admin page."""
+    encoded_phone = urllib.parse.quote(phone, safe="")
+    url = f"{base}/users/connect_user_otp/?phone={encoded_phone}"
+    req = urllib.request.Request(url)
+    req.add_header("Cookie", f"sessionid={session_cookie}")
+
+    return _parse_otp_response(req, phone)
+
+
+def _parse_otp_response(req: urllib.request.Request, phone: str) -> str:
+    """Send request and extract a 6-digit OTP from the response."""
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = resp.read().decode()
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"OTP request failed (HTTP {e.code}): {e.read().decode()}")
+
+    # Try JSON first: {"otp": "123456"}
+    try:
+        data = json.loads(body)
+        if isinstance(data, dict) and "otp" in data:
+            otp = str(data["otp"])
+            if re.fullmatch(r"\d{6}", otp):
+                return otp
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    # Fallback: find first 6-digit number in the response body
+    match = re.search(r"\b(\d{6})\b", body)
+    if match:
+        return match.group(1)
+
+    raise RuntimeError(
+        f"Could not find a 6-digit OTP for {phone} in response "
+        f"(first 500 chars): {body[:500]}"
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: python {sys.argv[0]} <+7426...phone_number>", file=sys.stderr)
+        sys.exit(1)
+    try:
+        otp = get_test_otp(sys.argv[1])
+        print(otp)
+    except (ValueError, RuntimeError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/.maestro/scripts/test_otp.py
+++ b/.maestro/scripts/test_otp.py
@@ -1,0 +1,130 @@
+"""Tests for the OTP fetch helper."""
+
+from __future__ import annotations
+
+import json
+import re
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+from unittest.mock import patch
+
+import pytest
+
+from otp import get_test_otp
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (no network)
+# ---------------------------------------------------------------------------
+
+class TestPhoneGuard:
+    """Reject non-test phone numbers."""
+
+    def test_rejects_us_number(self):
+        with pytest.raises(ValueError, match=r"Only \+7426"):
+            get_test_otp("+12025550100")
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValueError, match=r"Only \+7426"):
+            get_test_otp("")
+
+    def test_rejects_similar_prefix(self):
+        with pytest.raises(ValueError, match=r"Only \+7426"):
+            get_test_otp("+7425000000")
+
+    def test_accepts_test_prefix(self):
+        """Valid prefix should pass the guard (will fail on missing creds)."""
+        with pytest.raises(RuntimeError, match="No credentials"):
+            get_test_otp("+74260000042")
+
+
+class TestResponseParsing:
+    """Verify OTP extraction from mocked HTTP responses."""
+
+    def _mock_urlopen(self, body: str, status: int = 200):
+        """Return a context-manager mock that yields body bytes."""
+        from unittest.mock import MagicMock
+        from io import BytesIO
+
+        resp = MagicMock()
+        resp.read.return_value = body.encode()
+        resp.status = status
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = lambda s, *a: None
+        return resp
+
+    @patch("otp.urllib.request.urlopen")
+    def test_json_otp_field(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen(
+            json.dumps({"otp": "482901"})
+        )
+        result = get_test_otp(
+            "+74260000042", session_cookie="fake-session"
+        )
+        assert result == "482901"
+
+    @patch("otp.urllib.request.urlopen")
+    def test_plain_text_6digit(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen("Your OTP is 193847.")
+        result = get_test_otp(
+            "+74260000042", session_cookie="fake-session"
+        )
+        assert result == "193847"
+
+    @patch("otp.urllib.request.urlopen")
+    def test_html_body_with_otp(self, mock_urlopen):
+        html = "<html><body><td>+74260000042</td><td>529301</td></body></html>"
+        mock_urlopen.return_value = self._mock_urlopen(html)
+        result = get_test_otp(
+            "+74260000042", session_cookie="fake-session"
+        )
+        assert result == "529301"
+
+    @patch("otp.urllib.request.urlopen")
+    def test_no_6digit_raises(self, mock_urlopen):
+        mock_urlopen.return_value = self._mock_urlopen("No codes here.")
+        with pytest.raises(RuntimeError, match="Could not find"):
+            get_test_otp("+74260000042", session_cookie="fake-session")
+
+
+class TestOAuthFlow:
+    """Verify the two-step OAuth2 client-credentials flow."""
+
+    def _mock_urlopen_side_effect(self, calls):
+        """Return different responses for successive urlopen calls."""
+        from unittest.mock import MagicMock
+        from io import BytesIO
+
+        results = []
+        for body in calls:
+            resp = MagicMock()
+            resp.read.return_value = body.encode()
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = lambda s, *a: None
+            results.append(resp)
+        return results
+
+    @patch("otp.urllib.request.urlopen")
+    def test_oauth_two_step(self, mock_urlopen):
+        mock_urlopen.side_effect = self._mock_urlopen_side_effect([
+            json.dumps({"access_token": "tok123"}),
+            json.dumps({"otp": "661234"}),
+        ])
+        result = get_test_otp(
+            "+74260000042",
+            client_id="cid",
+            client_secret="csec",
+        )
+        assert result == "661234"
+        assert mock_urlopen.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration test (real network — skip in CI)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+def test_real_otp_fetch():
+    """Fetch a real OTP from connect-id. Requires credentials in env."""
+    otp = get_test_otp("+74260000042")
+    assert re.fullmatch(r"\d{6}", otp), f"Expected 6-digit OTP, got: {otp}"


### PR DESCRIPTION
## Summary
- Adds `.maestro/scripts/otp.py` — fetches OTPs for +7426 test numbers from connect-id, enabling autonomous e2e loops.
- Supports OAuth2 client_credentials (preferred, for CI) and session-cookie fallback (for local dev).
- Hard-rejects any phone that doesn't start with `+7426`.
- 9 unit tests (mocked), 1 integration test gated behind `-m integration`.

## Why
From a recent iOS e2e session: Maestro flows kept stalling because Claude had no way to fetch OTPs; user manually copy-pasted codes from a browser for every run. User's ask: "create an approach where you can retrieve the otp directly with playwright so you can iterate on your own."

## Test plan
- [x] `pytest test_otp.py -m "not integration"` — 9/9 pass locally
- [ ] Manual: set `CONNECTID_E2E_CLIENT_ID` + `CONNECTID_E2E_CLIENT_SECRET`, run `python .maestro/scripts/otp.py +74260000042`, confirm a 6-digit OTP prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)